### PR TITLE
docs: align spec with CLI implementation (ADR-0023)

### DIFF
--- a/core.md
+++ b/core.md
@@ -4,17 +4,20 @@ These requirements apply to all Portolan catalogs, regardless of data format.
 
 ## Catalog Structure
 
-A Portolan catalog lives in a `.portolan` directory at the project root. See [structure.md](structure.md) for the full directory layout.
+A Portolan catalog is a directory with STAC metadata at the project root and internal tooling state in `.portolan/`. See [structure.md](structure.md) for the full directory layout.
 
 ```
-.portolan/
+project/
+├── .portolan/
+│   ├── config.yaml
+│   └── state.json
 ├── catalog.json
-└── collections/
-    └── {collection_id}/
-        ├── collection.json
-        ├── versions.json
-        └── {item_id}/
-            └── data.parquet
+├── versions.json
+└── {collection_id}/
+    ├── collection.json
+    ├── versions.json
+    └── {item_id}/
+        └── data.parquet
 ```
 
 ## STAC Compliance

--- a/structure.md
+++ b/structure.md
@@ -1,35 +1,45 @@
 # Catalog Structure
 
-A Portolan catalog is a directory containing a `.portolan` folder with STAC metadata and cloud-native geospatial data.
+A Portolan catalog is a directory with STAC metadata and cloud-native geospatial data. Internal tooling state lives in `.portolan/`; all STAC-visible files live at the project root.
 
 ## Directory Layout
 
 ```
 project/
-└── .portolan/
-    ├── catalog.json
-    └── collections/
-        └── {collection_id}/
-            ├── collection.json
-            ├── versions.json
-            └── {item_id}/
-                └── {filename}.parquet
+├── .portolan/
+│   ├── config.yaml                    # Internal: catalog configuration
+│   └── state.json                     # Internal: local sync state
+├── catalog.json                       # STAC Catalog (root metadata)
+├── versions.json                      # Catalog-level versioning
+└── {collection_id}/
+    ├── collection.json                # STAC Collection metadata
+    ├── versions.json                  # Collection-level versioning
+    └── {item_id}/
+        └── {filename}.parquet         # Asset file
 ```
 
 ## Root Level
 
 | File | Required | Description |
 |------|----------|-------------|
+| `.portolan/` | **MUST** | Internal tooling directory (config, state) |
 | `catalog.json` | **MUST** | STAC Catalog (root metadata) |
-| `collections/` | — | Directory containing all collections (created on first dataset add) |
+| `versions.json` | **MUST** | Catalog-level version tracking |
 
 The `.portolan` directory **MUST** exist at the project root. Tools **SHOULD** create this directory via `portolan init`.
 
-Note: The `collections/` directory is created lazily when the first dataset is added, not during `portolan init`.
+### `.portolan/` Contents
+
+| File | Required | Description |
+|------|----------|-------------|
+| `config.yaml` | **MUST** | Catalog configuration (sentinel file) |
+| `state.json` | **SHOULD** | Local sync state |
+
+Only Portolan-internal tooling state lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
 
 ## Collection Level
 
-Each collection is a subdirectory of `collections/` named with the collection ID.
+Each collection is a top-level subdirectory of the project root, named with the collection ID.
 
 | File | Required | Description |
 |------|----------|-------------|
@@ -55,7 +65,7 @@ Each item is a subdirectory of the collection named with the item ID.
 | `thumbnail.png` | **SHOULD** | Preview image (any format: `.png`, `.jpg`, `.webp`) |
 | `style.json` | **MAY** | MapLibre-compatible styling |
 
-Item IDs **SHOULD** derive from the source filename stem (e.g., `census.shp` → item ID `census`).
+Item IDs are derived from the item directory name. By convention, item directories **SHOULD** be named after the primary data file's stem (e.g., source file `census.shp` goes into item directory `census/`).
 
 ## Flat Hierarchy
 
@@ -63,11 +73,11 @@ Portolan catalogs use a **flat hierarchy**: collections contain items directly, 
 
 ```
 # Correct (flat)
-.portolan/collections/census-2020/tracts/tracts.parquet
-.portolan/collections/census-2020/blocks/blocks.parquet
+census-2020/tracts/tracts.parquet
+census-2020/blocks/blocks.parquet
 
 # Incorrect (nested)
-.portolan/collections/census/2020/tracts/tracts.parquet
+census/2020/tracts/tracts.parquet
 ```
 
 This simplifies tooling and avoids ambiguity about where versioning boundaries lie.
@@ -96,14 +106,15 @@ A catalog with one vector dataset:
 ```
 project/
 ├── .portolan/
-│   ├── catalog.json
-│   └── collections/
-│       └── boundaries/
-│           ├── collection.json
-│           ├── versions.json
-│           └── districts/
-│               ├── districts.parquet
-│               ├── districts.pmtiles
-│               └── thumbnail.png
-└── README.md
+│   ├── config.yaml
+│   └── state.json
+├── catalog.json
+├── versions.json
+└── boundaries/
+    ├── collection.json
+    ├── versions.json
+    └── districts/
+        ├── districts.parquet
+        ├── districts.pmtiles
+        └── thumbnail.png
 ```

--- a/versions.md
+++ b/versions.md
@@ -5,7 +5,7 @@ Each collection **MUST** include a `versions.json` file that tracks version hist
 ## Location
 
 ```
-.portolan/collections/{collection_id}/versions.json
+{collection_id}/versions.json
 ```
 
 Versioning is per-collection, not per-item. When any item in a collection changes, the collection version increments.
@@ -22,19 +22,19 @@ Versioning is per-collection, not per-item. When any item in a collection change
       "created": "2024-01-15T10:30:00Z",
       "breaking": false,
       "assets": {
-        "districts.parquet": {
+        "districts/districts.parquet": {
           "sha256": "abc123def456...",
           "size_bytes": 1048576,
-          "href": "districts.parquet"
+          "href": "boundaries/districts/districts.parquet"
         }
       },
-      "changes": ["districts.parquet"]
+      "changes": ["districts/districts.parquet"]
     }
   ]
 }
 ```
 
-Note: Asset keys and hrefs are filenames only (e.g., `districts.parquet`), not paths including the item directory. The item context is provided by the collection structure.
+Asset keys use item-scoped paths (`{item_id}/{filename}`). Asset hrefs are catalog-root-relative paths (`{collection_id}/{item_id}/{filename}`), enabling `push` and `pull` to resolve files directly via `catalog_root / href`.
 
 ## Fields
 
@@ -53,8 +53,8 @@ Note: Asset keys and hrefs are filenames only (e.g., `districts.parquet`), not p
 | `version` | string | **MUST** | Semantic version string (e.g., `"1.0.0"`) |
 | `created` | string | **MUST** | ISO 8601 timestamp in UTC (e.g., `"2024-01-15T10:30:00Z"`) |
 | `breaking` | boolean | **MUST** | `true` if this version has breaking changes |
-| `assets` | object | **MUST** | Map of relative paths to asset metadata |
-| `changes` | array | **MUST** | List of asset paths that changed in this version |
+| `assets` | object | **MUST** | Map of item-scoped asset keys to asset metadata |
+| `changes` | array | **MUST** | List of asset keys that changed in this version |
 
 ### Asset Entry
 
@@ -62,7 +62,7 @@ Note: Asset keys and hrefs are filenames only (e.g., `districts.parquet`), not p
 |-------|------|----------|-------------|
 | `sha256` | string | **MUST** | SHA-256 checksum of the file content |
 | `size_bytes` | integer | **MUST** | File size in bytes |
-| `href` | string | **MUST** | Relative path to the asset within the collection |
+| `href` | string | **MUST** | Catalog-root-relative path to the asset (e.g., `"boundaries/districts/districts.parquet"`) |
 
 ## Versioning Rules
 
@@ -108,31 +108,31 @@ The `versions.json` file serves as the sync manifest:
       "created": "2024-01-01T00:00:00Z",
       "breaking": false,
       "assets": {
-        "districts.parquet": {
+        "districts/districts.parquet": {
           "sha256": "abc123...",
           "size_bytes": 524288,
-          "href": "districts.parquet"
+          "href": "boundaries/districts/districts.parquet"
         }
       },
-      "changes": ["districts.parquet"]
+      "changes": ["districts/districts.parquet"]
     },
     {
       "version": "1.1.0",
       "created": "2024-06-15T12:00:00Z",
       "breaking": false,
       "assets": {
-        "districts.parquet": {
+        "districts/districts.parquet": {
           "sha256": "def456...",
           "size_bytes": 786432,
-          "href": "districts.parquet"
+          "href": "boundaries/districts/districts.parquet"
         },
-        "districts.pmtiles": {
+        "districts/districts.pmtiles": {
           "sha256": "ghi789...",
           "size_bytes": 262144,
-          "href": "districts.pmtiles"
+          "href": "boundaries/districts/districts.pmtiles"
         }
       },
-      "changes": ["districts.parquet", "districts.pmtiles"]
+      "changes": ["districts/districts.parquet", "districts/districts.pmtiles"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates `structure.md`, `versions.md`, and `core.md` to reflect the current CLI directory layout and `versions.json` format. The CLI evolved through ADR-0023 and others but the spec was never updated.

## Changes

- **`structure.md`**: Move layout from `.portolan/collections/` to root-level collections. Add `.portolan/` contents table. Clarify item ID derivation (directory name, not filename stem). Update all examples.
- **`versions.md`**: Change href format from filename-only to catalog-root-relative. Change asset keys from filename to item-scoped. Update all examples.
- **`core.md`**: Update directory layout example.

Closes #10 — see the issue for full analysis with code evidence and timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)