### PR TITLE
Require rel:via provenance link for extracted data

### DIFF
--- a/core.md
+++ b/core.md
@@ -72,6 +72,21 @@ This keeps the catalog portable if mirrored to a different bucket.
 ]
 ```
 
+## Source Provenance
+
+When data is extracted from an external source that is the canonical location for the data, the collection **MUST** include a `rel: "via"` link pointing to the original source URL:
+
+```json
+{
+  "rel": "via",
+  "href": "https://services-eu1.arcgis.com/example/FeatureServer",
+  "type": "text/html",
+  "title": "Source ArcGIS Feature Service"
+}
+```
+
+This is standard STAC practice for provenance and enables consumers to trace data back to its origin.
+
 ## Root Documentation
 
 - **MUST** include a `README.md` at the catalog root


### PR DESCRIPTION
## Summary

- Collections **MUST** include a `rel: "via"` link when data was extracted from an external source that is the canonical location for the data
- This is standard STAC practice for provenance and enables consumers to trace data back to its origin

## Context

When building a catalog from Rijkswaterstaat ArcGIS services, the generated collection.json had no link back to the original data source. The `source_url` in metadata.yaml was used for README generation but not reflected in the STAC links. We had to manually add `via` links pointing to each ArcGIS Feature Service URL.

## Test plan

- [ ] Review that the language is clear on when via links are required (extracted from canonical external source)
- [ ] Verify the example is representative

🤖 Generated with [Claude Code](https://claude.com/claude-code)