### PR TITLE
Add portolan:glob asset field for partitioned datasets

### DIFF
--- a/formats/vector.md
+++ b/formats/vector.md
@@ -50,9 +50,35 @@ GeoParquet files larger than approximately 2 GB **SHOULD** be spatially partitio
 When a dataset is partitioned:
 
 - Each partition file **MUST** be represented as a STAC item within the collection, with its spatial extent (bbox) reflecting the data in that partition.
-- The collection description **SHOULD** include the glob pattern that tools can use to access all partitions as a single dataset, since most users want a single URL they can pass to their analysis tools rather than enumerating STAC items. For example:
+- In addition to mentioning the glob pattern in the description, the collection **MUST** include a collection-level asset with a `portolan:glob` field providing the absolute glob URL that tools like DuckDB, GDAL, and PyArrow can use to read all partitions as a single dataset:
 
-  > Access all partitions: `s3://bucket/buildings/*.parquet`
+```json
+{
+  "type": "Collection",
+  "id": "buildings",
+  "assets": {
+    "data": {
+      "href": "./*.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "portolan:glob": "s3://bucket/buildings/*.parquet"
+    }
+  }
+}
+```
+
+This addresses a common usability gap: partitioned datasets described by STAC items are discoverable through metadata, but most users want a single URL they can pass to their analysis tools. The `portolan:glob` field makes this machine-readable rather than relying on consumers to parse the description.
+
+```sql
+-- DuckDB
+SELECT * FROM read_parquet('s3://bucket/buildings/*.parquet') WHERE ...;
+```
+
+```python
+# PyArrow
+import pyarrow.parquet as pq
+table = pq.read_table("s3://bucket/buildings/*.parquet")
+```
 
 ### Directory Layout for Partitioned Datasets
 


### PR DESCRIPTION
## Summary

Adds a machine-readable `portolan:glob` field on the collection-level data asset for partitioned datasets. This complements the human-readable glob pattern in the description (added in the base PR) with a structured field that tools can consume programmatically.

```json
"assets": {
  "data": {
    "href": "./*.parquet",
    "type": "application/vnd.apache.parquet",
    "roles": ["data"],
    "portolan:glob": "s3://bucket/buildings/*.parquet"
  }
}
```

## Context

Most users of partitioned GeoParquet datasets want a single URL they can pass to DuckDB, GDAL, or PyArrow rather than enumerating STAC items. The description approach from the base PR is human-friendly but not machine-readable. This PR adds a structured field that tools and catalogs can use directly.

Related: #11

## Test plan

- [ ] Review whether `portolan:glob` should be a custom STAC extension or just a Portolan convention
- [ ] Consider whether this should be proposed as a broader STAC extension beyond Portolan

🤖 Generated with [Claude Code](https://claude.com/claude-code)