### PR TITLE
docs: add visualization styles as STAC assets convention

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -46,9 +46,96 @@ PMTiles enable efficient web map rendering without server-side tile generation.
 ## Visualization
 
 - **SHOULD** include a thumbnail image generated from default styling
-- **SHOULD** provide default styling via `style.json`
-  - Compatible with MapLibre GL JS and deck.gl
-  - Enables immediate visualization without custom configuration
+- **SHOULD** provide visualization styles as standalone STAC assets (see [Visualization Styles](#visualization-styles))
+
+### Visualization Styles
+
+Collections with PMTiles assets **SHOULD** include one or more Mapbox GL v8 style files in a `styles/` subdirectory. Each style is a complete, self-contained JSON file that can be loaded directly by MapLibre GL JS.
+
+#### Style File Format
+
+```json
+{
+  "version": 8,
+  "name": "Buildings by Construction Year",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../data.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "buildings-fill",
+      "type": "fill",
+      "source": "data",
+      "source-layer": "buildings",
+      "paint": {
+        "fill-color": ["interpolate", ["linear"], ["get", "year"],
+          1900, "#8B4513", 1960, "#DAA520", 2020, "#FFFF00"
+        ],
+        "fill-opacity": 0.7
+      }
+    }
+  ]
+}
+```
+
+Key conventions:
+- `version`: Always `8` (Mapbox GL spec version)
+- `name`: Human-readable label (used in style pickers)
+- `sources.data.url`: Relative path from `styles/` to the PMTiles file (typically `../filename.pmtiles`)
+- `layers[].source`: Always `"data"` (matches the source key)
+
+#### STAC Registration
+
+Each style file is registered as a STAC asset on the collection:
+
+```json
+{
+  "portolan:styles": ["styles/default", "styles/by-age"],
+  "assets": {
+    "styles/default": {
+      "href": "./styles/default.json",
+      "type": "application/json",
+      "title": "Default",
+      "description": "Blue building footprints with semi-transparent fill.",
+      "roles": ["style"]
+    },
+    "styles/by-age": {
+      "href": "./styles/by-age.json",
+      "type": "application/json",
+      "title": "Buildings by Age",
+      "description": "Color ramp from brown (pre-1900) to yellow (post-2010).",
+      "roles": ["style"]
+    }
+  }
+}
+```
+
+- **Asset key**: `styles/{name}` (matches the filename stem)
+- **Type**: `application/json`
+- **Roles**: `["style"]`
+- **Title**: Short label for style pickers
+- **Description**: What the style shows and what the colors represent
+
+#### `portolan:styles` Manifest
+
+The `portolan:styles` property on the collection is a JSON array of asset keys in display order. The first entry is the default style.
+
+- If only one style exists, it is the default
+- Consumers **SHOULD** render the first style by default
+- Consumers with multiple styles **SHOULD** offer a style picker
+
+#### Best Practices
+
+1. **Create multiple styles for rich datasets.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each (e.g., buildings by age, by use, by height).
+
+2. **Vary default styles across a catalog.** Each collection should have a visually distinct default color so the catalog is not monotone. Use subject matter to inform color choices — water in blues, vegetation in greens, built environment in warm tones.
+
+3. **Use data-driven styling.** Leverage Mapbox GL expressions (`interpolate`, `match`, `case`, `step`) to reveal patterns. Include a description explaining what the colors represent.
+
+4. **Consider label layers.** For datasets with names (roads, monuments, admin areas), include a label layer or a dedicated "with labels" style variant.
 
 ## Documentation
 

--- a/extensions.md
+++ b/extensions.md
@@ -75,7 +75,7 @@ These are **derivatives**, not primary data. PMTiles **SHOULD** be generated fro
 | `catalog.json` | STAC Catalog (root) |
 | `collection.json` | STAC Collection |
 | `versions.json` | Portolan version manifest |
-| `style.json` | MapLibre/deck.gl style definition |
+| `styles/*.json` | Mapbox GL / MapLibre style definitions (see [Visualization Styles](#visualization-styles)) |
 
 These files have semantic meaning and are not imported as datasets.
 

--- a/formats/vector.md
+++ b/formats/vector.md
@@ -78,6 +78,7 @@ Each partition file also has a corresponding STAC item linked from the collectio
 
 ## Styling
 
-- **MAY** include `style.json` for default visualization
-  - Compatible with MapLibre GL JS and deck.gl
-  - See [best practices](../best-practices.md) for styling recommendations
+- **SHOULD** include visualization styles as standalone STAC assets when PMTiles are provided
+  - Complete Mapbox GL v8 JSON files stored in `{collection}/styles/`
+  - Registered in STAC with `portolan:styles` manifest and `["style"]` role
+  - See [best practices](../best-practices.md#visualization-styles) for format details and conventions

--- a/structure.md
+++ b/structure.md
@@ -65,6 +65,8 @@ When a collection contains a single data file (e.g., one GeoParquet file), the d
   {filename}.parquet
   {filename}.pmtiles          (recommended)
   thumbnail.png               (recommended)
+  styles/                     (recommended for PMTiles collections)
+    default.json
 ```
 
 ## Item Level
@@ -78,7 +80,6 @@ Each item is a subdirectory of the collection named with the item ID.
 | Primary data asset | **MUST** | One of: `.parquet` (vector), `.tif` (raster), `.copc.laz` (point cloud) |
 | `{item_id}.pmtiles` | **SHOULD** | Vector tile derivative for web display (vector only) |
 | `thumbnail.png` | **SHOULD** | Preview image (any format: `.png`, `.jpg`, `.webp`) |
-| `style.json` | **MAY** | MapLibre-compatible styling |
 
 Item IDs are derived from the item directory name. By convention, item directories **SHOULD** be named after the primary data file's stem (e.g., source file `census.shp` goes into item directory `census/`).
 


### PR DESCRIPTION
## Summary

- Replace the single `style.json` approach with a `styles/` directory containing multiple Mapbox GL v8 style files
- Add `portolan:styles` manifest convention on STAC collections (first entry = default)
- Style assets registered with `application/json` type and `["style"]` role
- Document style file format, STAC registration, and best practices

### Files changed
- **`best-practices.md`**: New "Visualization Styles" section with format spec, STAC registration, manifest convention, and best practices
- **`structure.md`**: Add `styles/` directory to collection layout examples
- **`extensions.md`**: Update metadata files table (`style.json` → `styles/*.json`)
- **`formats/vector.md`**: Update styling section to reference new convention

This aligns with [portolan-cli#420](https://github.com/portolan-sdi/portolan-cli/pull/420) which implements style generation, discovery, and STAC registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)