### PR TITLE
Require llms.txt for AI/LLM integration

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -149,3 +149,25 @@ See: [best-practices.md#pmtiles](best-practices.md#pmtiles)
 - Simpler to understand and debug
 
 **Consequences**: All links are relative. Tooling must normalize hrefs before saving.
+
+---
+
+### ADR-007: Require llms.txt for AI/LLM Integration
+
+**Date**: 2026-05-30
+**Status**: Accepted
+
+**Decision**: Every Portolan catalog and collection must include an `llms.txt` file linked via `rel: "llms"` in the STAC JSON.
+
+**Context**: AI agents and LLMs are increasingly used to discover, query, and analyze geospatial data. Machine-readable STAC metadata alone is not enough — agents need plain-language context about what a dataset contains, how to query it, what the fields mean, and what pitfalls to avoid. The [llms.txt](https://llmstxt.org/) standard provides a convention for LLM-friendly documentation.
+
+**Rationale**:
+- AI agents are a primary audience for cloud-native geodata catalogs
+- STAC metadata describes structure but not semantics — agents need both
+- Markdown is the most natural format for LLMs to consume
+- The llms.txt convention is simple, co-located with the data, and versioned alongside it
+- Early experience with portolan-nl shows this pattern works well in practice
+
+**Consequences**: All catalogs and collections must maintain an `llms.txt` file. Content recommendations are provided but expected to evolve rapidly as best practices emerge.
+
+See: [ai-integration.md](ai-integration.md)

--- a/ai-integration.md
+++ b/ai-integration.md
@@ -1,0 +1,59 @@
+# AI & LLM Integration
+
+This section covers practices for making Portolan catalogs discoverable and usable by AI agents and large language models. This is a rapidly evolving area — the recommendations here represent early patterns that have proven effective and will be refined as the community gains experience.
+
+## llms.txt
+
+[llms.txt](https://llmstxt.org/) is an emerging standard for providing LLM-friendly documentation alongside web resources. In Portolan, every catalog and collection includes an `llms.txt` file that gives AI agents the context they need to discover, understand, and query the data.
+
+### Requirements
+
+Every catalog and collection **MUST** include an `llms.txt` file in markdown format.
+
+The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
+
+```json
+{
+  "rel": "llms",
+  "href": "./llms.txt",
+  "type": "text/markdown",
+  "title": "Agent/LLM usage guide"
+}
+```
+
+- The `href` **MUST** use a relative path (consistent with `SELF_CONTAINED` catalog type)
+- The `type` **MUST** be `text/markdown`
+- `llms.txt` is a **link**, not an asset — it describes the data, it is not the data itself
+
+### Content Recommendations
+
+These recommendations are early and expected to evolve. They reflect patterns that have worked well in practice but are not exhaustive.
+
+#### Catalog-Level llms.txt
+
+A catalog-level `llms.txt` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
+
+- A summary of what the catalog contains and who publishes it
+- A list of all collections with brief descriptions (what each contains, feature count, key fields)
+- Data access patterns (base URLs, S3 paths, code examples)
+- Coordinate system conventions used across the catalog
+- License information
+- Pointers to collection-level `llms.txt` files for detailed documentation
+
+#### Collection-Level llms.txt
+
+A collection-level `llms.txt` provides everything an AI agent needs to work with a specific dataset. It **SHOULD** include:
+
+- **What the dataset is** — a plain-language description, including source, provider, and license
+- **How to access the data** — URLs and working code examples for loading the data (e.g., DuckDB SQL, Python)
+- **Schema documentation** — all field names, types, and meanings, ideally as a table
+- **Data quality notes** — sentinel values, privacy suppressions, known quirks, or caveats that would trip up a naive query
+- **Example queries** — practical, working examples showing common analysis patterns
+- **Related datasets** — cross-references to complementary collections, including join keys and how to combine them
+
+#### General Guidance
+
+- **SHOULD** be written for an AI agent audience — concise, structured, and practical
+- **SHOULD** favor concrete examples over abstract descriptions
+- **SHOULD** include working code that an agent can adapt, not just pseudocode
+- **SHOULD** call out non-obvious pitfalls (e.g., coordinate systems in meters vs. degrees, coded values, null conventions)

--- a/core.md
+++ b/core.md
@@ -12,9 +12,11 @@ project/
 │   ├── config.yaml
 │   └── state.json
 ├── catalog.json
+├── llms.txt
 ├── versions.json
 └── {collection_id}/
     ├── collection.json
+    ├── llms.txt
     ├── versions.json
     └── {item_id}/
         └── data.parquet
@@ -91,6 +93,13 @@ This is standard STAC practice for provenance and enables consumers to trace dat
 
 - **MUST** include a `README.md` at the catalog root
 - README content requirements: TBD (see [QUESTIONS.md](QUESTIONS.md))
+
+## AI & LLM Integration
+
+- **MUST** include an `llms.txt` file at both the catalog root and each collection directory
+- **MUST** link `llms.txt` in the STAC JSON `links` array with `rel: "llms"`
+
+See [ai-integration.md](ai-integration.md) for full requirements and content recommendations.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

- Adds `ai-integration.md` — a new spec page requiring every catalog and collection to include an `llms.txt` file linked via `rel: "llms"` in the STAC JSON, with content recommendations for what to include
- Updates the directory tree in `core.md` to show `llms.txt` at both catalog and collection levels, and adds a brief "AI & LLM Integration" section pointing to the new page
- Records ADR-007 in `DECISIONS.md` with rationale for requiring llms.txt

The page is framed broadly as "AI & LLM Integration" since llms.txt is the first mechanism but others may follow. Content recommendations are flagged as early and expected to evolve. Links to [llmstxt.org](https://llmstxt.org/) for the general standard.

Patterns extracted from [portolan-nl](https://github.com/cholmes/portolan-nl).

## Test plan
- [ ] Review `ai-integration.md` for completeness and tone
- [ ] Verify link JSON example matches portolan-nl usage
- [ ] Check RFC 2119 language consistency with existing spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)