### PR TITLE
Add machine-readable JSON Schemas (Phase 1 of #23)

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,79 @@
+# Portolan Schemas
+
+Machine-readable validation schemas for Portolan catalogs. These schemas are the authoritative source of truth for validation logic shared between the CLI and registry.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `versions.schema.json` | Schema for `versions.json` manifest files |
+| `collection.schema.json` | Schema for STAC Collections with Portolan extensions |
+| `catalog.schema.json` | Schema for STAC Catalogs with Portolan extensions |
+| `rules.yaml` | Validation rules that cannot be expressed in JSON Schema |
+
+## Usage
+
+### Python (jsonschema)
+
+```python
+import json
+from pathlib import Path
+from jsonschema import validate, RefResolver
+
+schema_dir = Path("schema")
+
+# Load schema
+with open(schema_dir / "versions.schema.json") as f:
+    versions_schema = json.load(f)
+
+# Validate versions.json
+with open("my-collection/versions.json") as f:
+    versions_data = json.load(f)
+
+validate(instance=versions_data, schema=versions_schema)
+```
+
+### STAC Collection/Catalog Validation
+
+The collection and catalog schemas extend STAC's official schemas via `$ref`. For full validation, you need network access to fetch the STAC schemas, or use a resolver with local copies:
+
+```python
+from jsonschema import validate, RefResolver
+import requests
+
+# Fetch STAC schemas (or use local copies)
+resolver = RefResolver.from_schema(collection_schema)
+
+validate(instance=collection_data, schema=collection_schema, resolver=resolver)
+```
+
+### CLI Integration
+
+The Portolan CLI validates against these schemas in `tests/spec_compliance/`. See [portolan-cli](https://github.com/portolan-sdi/portolan-cli) for integration examples.
+
+## rules.yaml
+
+Some validation rules cannot be expressed in JSON Schema. These are documented in `rules.yaml` with:
+
+- **id**: Unique rule identifier (e.g., `RULE-0001`)
+- **level**: `error` or `warning`
+- **scope**: Where the rule applies
+- **validation**: Pseudo-code for implementation
+
+Example rules:
+- Asset hrefs must be absolute S3 URLs in published catalogs
+- Collection IDs should follow naming conventions
+- GeoParquet files must contain geo metadata
+
+## Schema Versioning
+
+Schemas follow the same versioning as the spec. The `spec_version` field in `versions.json` indicates which schema version applies.
+
+## Contributing
+
+When updating schemas:
+
+1. Update the JSON Schema files
+2. Update `rules.yaml` if needed
+3. Ensure CLI tests pass against new schemas (Phase 2)
+4. Update prose documentation to match (if schemas add new fields)

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -20,8 +20,8 @@
         },
         "stac_version": {
           "type": "string",
-          "pattern": "^1\\.",
-          "description": "STAC version MUST be 1.0.0 or later"
+          "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+          "description": "STAC version MUST be 1.x.x format (e.g., 1.0.0, 1.1.0)"
         },
         "id": {
           "type": "string",
@@ -75,9 +75,9 @@
           "then": {
             "properties": {
               "href": {
-                "description": "For structural links (root, self, parent, child), href SHOULD be a relative path for portability",
+                "description": "For structural links (root, self, parent, child), href MUST be a relative path for portability",
                 "not": {
-                  "pattern": "^https?://"
+                  "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://"
                 }
               }
             }

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/catalog.schema.json",
+  "title": "Portolan STAC Catalog",
+  "description": "Schema for Portolan-compliant STAC Catalogs. Extends the STAC Catalog schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
+  "allOf": [
+    {
+      "$ref": "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+    },
+    {
+      "$ref": "#/$defs/PortolanCatalogExtensions"
+    }
+  ],
+  "$defs": {
+    "PortolanCatalogExtensions": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Catalog"
+        },
+        "stac_version": {
+          "type": "string",
+          "pattern": "^1\\.",
+          "description": "STAC version MUST be 1.0.0 or later"
+        },
+        "id": {
+          "type": "string",
+          "description": "Catalog identifier. Defaults to 'portolan-catalog' if not specified.",
+          "default": "portolan-catalog"
+        },
+        "links": {
+          "type": "array",
+          "description": "Catalog links. MUST use relative paths (SELF_CONTAINED catalog type).",
+          "items": {
+            "$ref": "#/$defs/CatalogLink"
+          }
+        }
+      }
+    },
+    "CatalogLink": {
+      "type": "object",
+      "description": "STAC Link with Portolan requirements for SELF_CONTAINED catalogs",
+      "required": ["rel", "href"],
+      "properties": {
+        "rel": {
+          "type": "string",
+          "description": "Link relation type",
+          "examples": ["root", "self", "child", "parent", "item"]
+        },
+        "href": {
+          "type": "string",
+          "description": "Link target. SHOULD be relative path for portability (SELF_CONTAINED requirement).",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "Media type of the linked resource",
+          "examples": ["application/json", "application/geo+json"]
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "rel": {
+                "enum": ["root", "self", "parent", "child"]
+              }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "properties": {
+              "href": {
+                "description": "For structural links (root, self, parent, child), href SHOULD be a relative path for portability",
+                "not": {
+                  "pattern": "^https?://"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -20,15 +20,12 @@
         },
         "stac_version": {
           "type": "string",
-          "pattern": "^1\\.",
-          "description": "STAC version MUST be 1.0.0 or later"
+          "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+          "description": "STAC version MUST be 1.x.x format (e.g., 1.0.0, 1.1.0)"
         },
         "links": {
           "type": "array",
-          "description": "Collection links with Portolan requirements",
-          "contains": {
-            "$ref": "#/$defs/VersionHistoryLink"
-          },
+          "description": "Collection links with Portolan requirements. SHOULD include version-history link (see RULE-0070 in rules.yaml).",
           "items": {
             "$ref": "#/$defs/CollectionLink"
           }
@@ -92,6 +89,7 @@
           },
           "then": {
             "description": "PMTiles link per web-map-links STAC extension - MUST be present when PMTiles are provided",
+            "required": ["type"],
             "properties": {
               "type": {
                 "const": "application/vnd.pmtiles"

--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/collection.schema.json",
+  "title": "Portolan STAC Collection",
+  "description": "Schema for Portolan-compliant STAC Collections. Extends the STAC Collection schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
+  "allOf": [
+    {
+      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json"
+    },
+    {
+      "$ref": "#/$defs/PortolanCollectionExtensions"
+    }
+  ],
+  "$defs": {
+    "PortolanCollectionExtensions": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Collection"
+        },
+        "stac_version": {
+          "type": "string",
+          "pattern": "^1\\.",
+          "description": "STAC version MUST be 1.0.0 or later"
+        },
+        "links": {
+          "type": "array",
+          "description": "Collection links with Portolan requirements",
+          "contains": {
+            "$ref": "#/$defs/VersionHistoryLink"
+          },
+          "items": {
+            "$ref": "#/$defs/CollectionLink"
+          }
+        },
+        "assets": {
+          "type": "object",
+          "description": "Collection-level assets. Required for single-file collections.",
+          "additionalProperties": {
+            "$ref": "#/$defs/PortolanAsset"
+          }
+        },
+        "providers": {
+          "type": "array",
+          "description": "STAC-standard providers array (SHOULD be present)",
+          "items": {
+            "$ref": "#/$defs/Provider"
+          }
+        }
+      }
+    },
+    "CollectionLink": {
+      "type": "object",
+      "required": ["rel", "href"],
+      "properties": {
+        "rel": {
+          "type": "string",
+          "description": "Link relation type"
+        },
+        "href": {
+          "type": "string",
+          "description": "Link target. SHOULD be relative for root/self/child/parent relations."
+        },
+        "type": {
+          "type": "string",
+          "description": "Media type of the linked resource"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "via" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "Source provenance link - MUST be present when data is extracted from an external canonical source",
+            "required": ["rel", "href"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "pmtiles" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "PMTiles link per web-map-links STAC extension - MUST be present when PMTiles are provided",
+            "properties": {
+              "type": {
+                "const": "application/vnd.pmtiles"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "VersionHistoryLink": {
+      "type": "object",
+      "description": "Link to versions.json - SHOULD be present",
+      "properties": {
+        "rel": {
+          "const": "version-history"
+        },
+        "href": {
+          "type": "string",
+          "pattern": "(^|/)versions\\.json$"
+        },
+        "type": {
+          "const": "application/json"
+        }
+      },
+      "required": ["rel", "href"]
+    },
+    "PortolanAsset": {
+      "type": "object",
+      "description": "STAC Asset with Portolan requirements",
+      "required": ["href"],
+      "properties": {
+        "href": {
+          "type": "string",
+          "description": "Asset URL. In published catalogs, MUST be an absolute S3 URL. In local catalogs, may be relative.",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "Media type of the asset",
+          "examples": [
+            "application/vnd.apache.parquet",
+            "application/vnd.pmtiles",
+            "image/tiff; application=geotiff; profile=cloud-optimized",
+            "application/geo+json"
+          ]
+        },
+        "roles": {
+          "type": "array",
+          "description": "Asset roles",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["data"], ["visual"], ["thumbnail"]]
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the asset"
+        }
+      }
+    },
+    "Provider": {
+      "type": "object",
+      "description": "STAC Provider information",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Organization name"
+        },
+        "roles": {
+          "type": "array",
+          "description": "Provider roles",
+          "items": {
+            "type": "string",
+            "enum": ["licensor", "producer", "processor", "host"]
+          }
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Organization URL"
+        },
+        "description": {
+          "type": "string",
+          "description": "Provider description"
+        }
+      }
+    }
+  }
+}

--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -1,0 +1,263 @@
+# Portolan Validation Rules
+#
+# Rules that cannot be expressed in JSON Schema but are normative requirements.
+# These rules are intended for programmatic validation in the CLI and registry.
+#
+# Rule structure:
+#   id: Unique identifier (RULE-XXXX)
+#   level: error | warning
+#   scope: Where the rule applies (catalog, collection, item, asset, versions)
+#   description: Human-readable description
+#   rationale: Why this rule exists
+#   validation: How to validate (pseudo-code or description)
+#   references: Links to spec documentation
+
+rules:
+  # =============================================================================
+  # Asset URL Rules
+  # =============================================================================
+
+  - id: RULE-0001
+    level: error
+    scope: asset
+    description: Asset hrefs in published catalogs MUST be absolute S3 URLs
+    rationale: |
+      Portolan catalogs are designed for S3-compatible object storage.
+      Absolute URLs ensure assets can be fetched without ambiguity.
+    validation: |
+      For each asset.href in collection.json or item.json:
+        if catalog.is_published:
+          assert href.startswith("https://") and ".s3." in href
+    references:
+      - core.md#asset-urls
+
+  - id: RULE-0002
+    level: warning
+    scope: asset
+    description: Asset hrefs in local catalogs SHOULD be relative paths
+    rationale: |
+      Relative paths keep local catalogs portable before publishing.
+    validation: |
+      For each asset.href in collection.json or item.json:
+        if not catalog.is_published:
+          warn if href.startswith("https://")
+    references:
+      - core.md#asset-urls
+
+  # =============================================================================
+  # versions.json Path Rules
+  # =============================================================================
+
+  - id: RULE-0010
+    level: error
+    scope: versions
+    description: Asset keys in versions.json MUST be collection-relative
+    rationale: |
+      Asset keys are scoped relative to the collection directory.
+      The collection directory name MUST NOT appear in the asset key.
+    validation: |
+      For each asset_key in version.assets:
+        assert not asset_key.startswith(collection_id + "/")
+    references:
+      - versions.md#path-resolution
+    examples:
+      valid:
+        - "tunnels.parquet"  # Single-file collection
+        - "districts/districts.parquet"  # Item within collection
+      invalid:
+        - "tunnels/tunnels.parquet"  # Duplicates collection directory
+
+  - id: RULE-0011
+    level: error
+    scope: versions
+    description: Asset hrefs in versions.json MUST be catalog-root-relative
+    rationale: |
+      hrefs enable tools to resolve files via `catalog_root / href`.
+      They must include the collection directory.
+    validation: |
+      For each asset in version.assets:
+        assert asset.href.startswith(collection_id + "/")
+    references:
+      - versions.md#path-resolution
+    examples:
+      valid:
+        - "tunnels/tunnels.parquet"
+        - "boundaries/districts/districts.parquet"
+
+  # =============================================================================
+  # Collection ID Rules
+  # =============================================================================
+
+  - id: RULE-0020
+    level: warning
+    scope: collection
+    description: Collection IDs SHOULD follow naming conventions
+    rationale: |
+      Consistent naming improves discoverability and avoids filesystem issues.
+    validation: |
+      assert collection_id matches /^[a-z][a-z0-9_-]*$/
+    references:
+      - structure.md#collection-level
+    note: |
+      The CLI does not currently enforce these naming conventions.
+      Validation may be added in a future release.
+
+  # =============================================================================
+  # Content Inspection Rules
+  # =============================================================================
+
+  - id: RULE-0030
+    level: error
+    scope: asset
+    description: GeoParquet files MUST contain geo metadata
+    rationale: |
+      A .parquet file without GeoParquet metadata is just a Parquet file.
+      Content inspection ensures we don't import non-geospatial data.
+    validation: |
+      For each .parquet file:
+        metadata = read_parquet_metadata(file)
+        assert "geo" in metadata.schema.metadata
+    references:
+      - extensions.md#content-inspection
+
+  - id: RULE-0031
+    level: error
+    scope: asset
+    description: COG files MUST have internal tiling and overviews
+    rationale: |
+      Cloud-Optimized GeoTIFF requires internal structure for range-request access.
+    validation: |
+      For each .tif/.tiff file:
+        assert is_valid_cog(file)  # Use rio-cogeo or similar
+    references:
+      - extensions.md#content-inspection
+      - formats/raster.md
+
+  - id: RULE-0032
+    level: warning
+    scope: asset
+    description: Non-cloud-native formats SHOULD be converted
+    rationale: |
+      GeoJSON, Shapefile, GeoPackage work but cloud-native formats
+      (GeoParquet, COG) are preferred for performance.
+    validation: |
+      For each file with extension in [.geojson, .shp, .gpkg, .json]:
+        warn "Consider converting to GeoParquet"
+    references:
+      - extensions.md#non-cloud-native-format-handling
+
+  # =============================================================================
+  # Structural Rules
+  # =============================================================================
+
+  - id: RULE-0040
+    level: error
+    scope: catalog
+    description: Catalog MUST use SELF_CONTAINED type (relative links)
+    rationale: |
+      SELF_CONTAINED catalogs are portable across hosting locations.
+      No absolute filesystem paths should leak into metadata.
+    validation: |
+      For each link in catalog.json with rel in [root, self, parent, child]:
+        assert not link.href.startswith("/")
+        assert not link.href.startswith("file://")
+    references:
+      - structure.md#stac-conventions
+      - core.md#link-paths
+
+  - id: RULE-0041
+    level: error
+    scope: catalog
+    description: Catalog MUST have flat hierarchy (no nested sub-collections)
+    rationale: |
+      Flat hierarchy simplifies tooling and versioning boundaries.
+    validation: |
+      For each collection in catalog:
+        assert collection has no child collections
+        # Collections contain items directly
+    references:
+      - structure.md#flat-hierarchy
+
+  - id: RULE-0042
+    level: error
+    scope: collection
+    description: Single-file datasets MUST be collection-level assets
+    rationale: |
+      Item indirection adds no value for single-file datasets.
+    validation: |
+      If collection contains exactly one data file:
+        assert file is in collection.assets, not wrapped in item
+    references:
+      - structure.md#single-file-collections
+      - formats/vector.md#collection-level-assets
+
+  # =============================================================================
+  # Required Files Rules
+  # =============================================================================
+
+  - id: RULE-0050
+    level: error
+    scope: catalog
+    description: Catalog root MUST contain required files
+    rationale: |
+      Standard structure enables tooling interoperability.
+    validation: |
+      assert exists(catalog_root / ".portolan/config.yaml")
+      assert exists(catalog_root / "catalog.json")
+      assert exists(catalog_root / "versions.json")
+    references:
+      - structure.md#root-level
+
+  - id: RULE-0051
+    level: error
+    scope: collection
+    description: Each collection MUST contain required files
+    rationale: |
+      Collections need metadata and version tracking.
+    validation: |
+      For each collection directory:
+        assert exists(collection_dir / "collection.json")
+        assert exists(collection_dir / "versions.json")
+    references:
+      - structure.md#collection-level
+
+  - id: RULE-0052
+    level: warning
+    scope: catalog
+    description: Catalog root SHOULD contain README.md
+    rationale: |
+      Documentation helps users understand the catalog contents.
+    validation: |
+      warn if not exists(catalog_root / "README.md")
+    references:
+      - core.md#root-documentation
+
+  # =============================================================================
+  # PMTiles Rules
+  # =============================================================================
+
+  - id: RULE-0060
+    level: error
+    scope: collection
+    description: PMTiles MUST be collection-level assets when provided
+    rationale: |
+      Visualization derivatives should be discoverable at collection level
+      without navigating into items.
+    validation: |
+      If any .pmtiles file exists:
+        assert "pmtiles" in collection.assets or
+               any asset has role "visual" with .pmtiles href
+    references:
+      - formats/vector.md#recommended-formats
+
+  - id: RULE-0061
+    level: error
+    scope: collection
+    description: PMTiles MUST have rel="pmtiles" link when provided
+    rationale: |
+      Follows web-map-links STAC extension for discoverability.
+    validation: |
+      If collection has PMTiles asset:
+        assert any link has rel="pmtiles"
+    references:
+      - formats/vector.md#recommended-formats

--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -20,14 +20,21 @@ rules:
   - id: RULE-0001
     level: error
     scope: asset
-    description: Asset hrefs in published catalogs MUST be absolute S3 URLs
+    description: Asset hrefs in published catalogs MUST be absolute HTTPS URLs to S3-compatible storage
     rationale: |
       Portolan catalogs are designed for S3-compatible object storage.
       Absolute URLs ensure assets can be fetched without ambiguity.
     validation: |
       For each asset.href in collection.json or item.json:
         if catalog.is_published:
-          assert href.startswith("https://") and ".s3." in href
+          assert href.startswith("https://")
+          # Accepted providers (non-exhaustive):
+          # - AWS S3: *.s3.amazonaws.com, *.s3.*.amazonaws.com
+          # - DigitalOcean Spaces: *.digitaloceanspaces.com
+          # - Cloudflare R2: *.r2.cloudflarestorage.com
+          # - Backblaze B2: *.backblazeb2.com
+          # - Wasabi: *.wasabisys.com
+          # - MinIO: any hostname (custom deployments)
     references:
       - core.md#asset-urls
 
@@ -83,6 +90,56 @@ rules:
       valid:
         - "tunnels/tunnels.parquet"
         - "boundaries/districts/districts.parquet"
+
+  - id: RULE-0012
+    level: error
+    scope: versions
+    description: current_version MUST match the last entry in versions array
+    rationale: |
+      current_version is a convenience field that MUST be consistent with
+      the versions array. Inconsistency causes sync failures and confuses tooling.
+    validation: |
+      if current_version is not null:
+        assert versions is not empty
+        assert current_version == versions[-1].version
+      else:
+        assert versions is empty
+    references:
+      - versions.md#current-version
+
+  - id: RULE-0013
+    level: error
+    scope: versions
+    description: changes array MUST only reference keys that exist in assets
+    rationale: |
+      The changes array documents which assets changed in a version.
+      Referencing non-existent keys indicates data corruption or typos.
+    validation: |
+      For each version in versions:
+        for change_key in version.changes:
+          assert change_key in version.assets
+
+  - id: RULE-0014
+    level: error
+    scope: versions
+    description: Version strings MUST be unique within versions array
+    rationale: |
+      Each version represents a distinct point in time. Duplicate version
+      strings make history ambiguous and break rollback functionality.
+    validation: |
+      version_strings = [v.version for v in versions]
+      assert len(version_strings) == len(set(version_strings))
+
+  - id: RULE-0015
+    level: warning
+    scope: versions
+    description: Versions SHOULD be ordered chronologically (oldest first)
+    rationale: |
+      The spec defines versions array as "oldest first" for consistent tooling.
+      Out-of-order versions may cause incorrect diff calculations.
+    validation: |
+      timestamps = [parse_iso8601(v.created) for v in versions]
+      assert timestamps == sorted(timestamps)
 
   # =============================================================================
   # Collection ID Rules
@@ -159,8 +216,16 @@ rules:
       No absolute filesystem paths should leak into metadata.
     validation: |
       For each link in catalog.json with rel in [root, self, parent, child]:
+        # Unix absolute paths
         assert not link.href.startswith("/")
+        # file:// URLs
         assert not link.href.startswith("file://")
+        # Windows absolute paths (C:\, D:\, etc.)
+        assert not re.match(r'^[A-Za-z]:', link.href)
+        # Windows UNC paths (\\server\share)
+        assert not link.href.startswith("\\\\")
+        # Any URI scheme (http://, ftp://, s3://, etc.)
+        assert not re.match(r'^[a-zA-Z][a-zA-Z0-9+.-]*://', link.href)
     references:
       - structure.md#stac-conventions
       - core.md#link-paths
@@ -261,3 +326,25 @@ rules:
         assert any link has rel="pmtiles"
     references:
       - formats/vector.md#recommended-formats
+
+  # =============================================================================
+  # Version History Rules
+  # =============================================================================
+
+  - id: RULE-0070
+    level: warning
+    scope: collection
+    description: Collections SHOULD include a version-history link
+    rationale: |
+      The version-history link (rel="version-history") enables discovery of
+      the versions.json manifest. While not strictly required, it improves
+      STAC client compatibility and enables version-aware browsing.
+    validation: |
+      For each collection.json:
+        warn if no link has rel="version-history"
+        if link with rel="version-history" exists:
+          assert link.href ends with "versions.json"
+          assert link.type == "application/json"
+    references:
+      - core.md#version-history-link
+      - versions.md

--- a/schema/versions.schema.json
+++ b/schema/versions.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/versions.schema.json",
+  "title": "Portolan Versions Manifest",
+  "description": "Schema for versions.json - tracks version history, asset checksums, and sync state per collection. See https://github.com/portolan-sdi/portolan-spec/blob/main/versions.md",
+  "type": "object",
+  "required": ["spec_version", "current_version", "versions"],
+  "additionalProperties": false,
+  "properties": {
+    "spec_version": {
+      "type": "string",
+      "description": "Schema version for the versions.json format",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["1.0.0"]
+    },
+    "current_version": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The latest version string (semantic versioning)",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        },
+        {
+          "type": "null",
+          "description": "Null if no versions exist yet"
+        }
+      ]
+    },
+    "versions": {
+      "type": "array",
+      "description": "List of version entries, oldest first",
+      "items": {
+        "$ref": "#/$defs/VersionEntry"
+      }
+    }
+  },
+  "$defs": {
+    "VersionEntry": {
+      "type": "object",
+      "description": "A single version entry in the version history",
+      "required": ["version", "created", "breaking", "assets", "changes"],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Semantic version string (e.g., '1.0.0', '1.0.0-beta', '1.0.0+build.123')",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        },
+        "created": {
+          "type": "string",
+          "description": "ISO 8601 timestamp in UTC (must end with 'Z')",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$",
+          "examples": ["2024-01-15T10:30:00Z", "2024-01-15T10:30:00.123Z"]
+        },
+        "breaking": {
+          "type": "boolean",
+          "description": "True if this version has breaking changes (schema changes, column removals, CRS changes)"
+        },
+        "assets": {
+          "type": "object",
+          "description": "Map of asset keys to asset metadata. Keys are collection-relative paths.",
+          "additionalProperties": {
+            "$ref": "#/$defs/AssetEntry"
+          }
+        },
+        "changes": {
+          "type": "array",
+          "description": "List of asset keys that changed in this version (new or modified)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schema": {
+          "$ref": "#/$defs/SchemaInfo",
+          "description": "Optional schema fingerprint for breaking change detection (ADR-0005)"
+        },
+        "message": {
+          "type": "string",
+          "description": "Optional human-readable description of the change"
+        }
+      }
+    },
+    "AssetEntry": {
+      "type": "object",
+      "description": "Metadata for a single asset (file) within a version",
+      "required": ["sha256", "size_bytes", "href"],
+      "additionalProperties": false,
+      "properties": {
+        "sha256": {
+          "type": "string",
+          "description": "SHA-256 checksum of the file content",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "description": "File size in bytes",
+          "minimum": 0
+        },
+        "href": {
+          "type": "string",
+          "description": "Catalog-root-relative path to the asset (e.g., 'boundaries/districts/districts.parquet')",
+          "minLength": 1
+        },
+        "source_path": {
+          "type": "string",
+          "description": "Optional relative path to the original source file (e.g., the GeoJSON that was converted to this GeoParquet)"
+        },
+        "source_mtime": {
+          "type": "number",
+          "description": "Optional Unix timestamp of the source file when conversion occurred. Used to detect when source has changed."
+        },
+        "mtime": {
+          "type": "number",
+          "description": "Optional Unix timestamp of the asset file itself. Used for fast-path change detection (ADR-0017)."
+        }
+      }
+    },
+    "SchemaInfo": {
+      "type": "object",
+      "description": "Schema information for breaking change detection (ADR-0005)",
+      "required": ["type", "fingerprint"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Schema type identifier (e.g., 'geoparquet', 'cog')",
+          "examples": ["geoparquet", "cog"]
+        },
+        "fingerprint": {
+          "type": "object",
+          "description": "Type-specific schema fingerprint for change detection",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/schema/versions.schema.json
+++ b/schema/versions.schema.json
@@ -10,7 +10,7 @@
     "spec_version": {
       "type": "string",
       "description": "Schema version for the versions.json format",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
       "examples": ["1.0.0"]
     },
     "current_version": {
@@ -18,7 +18,7 @@
         {
           "type": "string",
           "description": "The latest version string (semantic versioning)",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
         },
         {
           "type": "null",
@@ -44,7 +44,7 @@
         "version": {
           "type": "string",
           "description": "Semantic version string (e.g., '1.0.0', '1.0.0-beta', '1.0.0+build.123')",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
         },
         "created": {
           "type": "string",
@@ -106,11 +106,13 @@
           "description": "Optional relative path to the original source file (e.g., the GeoJSON that was converted to this GeoParquet)"
         },
         "source_mtime": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 0,
           "description": "Optional Unix timestamp of the source file when conversion occurred. Used to detect when source has changed."
         },
         "mtime": {
-          "type": "number",
+          "type": "integer",
+          "minimum": 0,
           "description": "Optional Unix timestamp of the asset file itself. Used for fast-path change detection (ADR-0017)."
         }
       }


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #23: extract machine-readable schemas from spec prose.

- **`schema/versions.schema.json`** — Full versions.json schema including CLI's undocumented fields (`schema`, `message`, `mtime`, `source_path`, `source_mtime`) with strict semver and ISO 8601 validation patterns
- **`schema/collection.schema.json`** — STAC Collection + Portolan extensions, extends STAC schemas via `$ref`
- **`schema/catalog.schema.json`** — STAC Catalog + Portolan requirements (SELF_CONTAINED, relative links)
- **`schema/rules.yaml`** — 16 validation rules for things JSON Schema can't express (S3 URLs, content inspection, naming conventions)
- **`schema/README.md`** — Usage documentation

## Design Decisions

1. **Aligned with CLI reality** — Schemas include fields from `portolan-cli/versions.py` that aren't in spec prose (discovered during research). This means Phase 2 (CLI integration) should be smooth.

2. **Extend STAC via `$ref`** — Collection and catalog schemas use `$ref` to STAC's official schemas, keeping Portolan schemas small and authoritative.

3. **Strict validation** — Semver regex, ISO 8601 patterns, SHA-256 hex validation. Catches malformed data early.

4. **`rules.yaml` for semantic rules** — Things like "hrefs MUST be absolute S3 URLs" can't be expressed in JSON Schema, so they're documented in YAML for CLI/registry to implement.

## Test Plan

- [x] All JSON schemas parse correctly
- [x] `rules.yaml` parses correctly with 16 rules
- [x] `versions.schema.json` correctly validates:
  - Valid examples (including CLI optional fields)
  - Rejects invalid semver (`v1.0`)
  - Rejects invalid timestamps (`2024-01-15 10:30:00`)
  - Rejects invalid SHA-256 (too short)

## Next Steps (not this PR)

- **Phase 2**: Add `tests/spec_compliance/` to CLI that validates against these schemas
- **Phase 3**: Spec CI that runs CLI tests on schema changes
- **Phase 4**: Registry imports schemas for validation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)