### PR TITLE
Add proposal process documentation (Phase 5 of #23)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,21 @@ We welcome contributions to the Portolan specification!
 - **Issues**: Open an issue to report bugs, ask questions, or suggest improvements.
 - **Discussion**: Join the `#portolan` channel in the [Cloud Native Geospatial Forum Slack](https://cloudnativegeo.org/join/) to discuss ideas and collaborate with the community.
 
+## Proposing New Features
+
+New features follow a **CLI-first workflow**: the spec documents what the CLI does, not what it might do someday. This prevents drift between prose and implementation.
+
+If you have a feature idea:
+
+1. Open a PR or issue describing the feature
+2. If accepted, it's tracked in [PROPOSALS.md](PROPOSALS.md)
+3. The CLI implements the feature
+4. The spec is updated to document it
+
+PRs that propose spec changes without corresponding CLI implementation will be redirected to the proposal process.
+
+See [issue #23](https://github.com/portolan-sdi/portolan-spec/issues/23) for background.
+
 ## Code of Conduct
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.

--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -1,0 +1,33 @@
+# Proposals
+
+Features proposed but not yet implemented in the CLI.
+
+## Status Definitions
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Under discussion, not committed |
+| **Accepted** | Will be implemented, pending CLI work |
+| **Implemented** | CLI support shipped, spec updated |
+| **Declined** | Won't implement (with rationale) |
+
+## Active Proposals
+
+| Proposal | Status | Discussion | CLI Issue |
+|----------|--------|------------|-----------|
+| (none yet) | | | |
+
+## Process
+
+1. Open a PR or issue describing the feature
+2. Discussion happens; if accepted, added here as "Accepted"
+3. CLI implements the feature
+4. Spec is updated, proposal moves to "Implemented"
+
+## Why This Process?
+
+The CLI is the source of truth. The spec documents what the CLI does, not what it might do someday. This prevents drift between prose and implementation.
+
+Existing PRs that may follow this process: [#20](https://github.com/portolan-sdi/portolan-spec/pull/20), [#21](https://github.com/portolan-sdi/portolan-spec/pull/21), [#22](https://github.com/portolan-sdi/portolan-spec/pull/22).
+
+See [issue #23](https://github.com/portolan-sdi/portolan-spec/issues/23) for background on the CLI-first workflow.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Portolan provides a standardized way for municipalities, NGOs, and other organiz
 - [Best practices](best-practices.md) - Recommended conventions
 - [Architectural decisions](DECISIONS.md) - Key design decisions and rationale
 - [Process](process.md) - How we develop this spec
+- [Proposals](PROPOSALS.md) - Features proposed but not yet implemented
 
 ## Examples
 

--- a/process.md
+++ b/process.md
@@ -18,9 +18,21 @@ Key architectural decisions and their rationale are documented in [DECISIONS.md]
 
 ## Changes and Contributions
 
-- Changes to the specification are proposed via pull request
+The specification follows a **CLI-first workflow**: the spec documents what the [portolan-cli](https://github.com/portolan-sdi/portolan-cli) does, not what it might do someday. This prevents drift between prose and implementation.
+
+### Documenting Existing Features
+
+- Changes to document existing CLI behavior are proposed via pull request
 - PRs are discussed before merging
 - Consensus among core team members is required for changes to core requirements
+
+### Proposing New Features
+
+- New feature ideas are tracked in [PROPOSALS.md](PROPOSALS.md)
+- Once accepted, the CLI implements the feature first
+- The spec is updated after CLI implementation ships
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Versioning
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -71,9 +71,11 @@ Schemas follow the same versioning as the spec. The `spec_version` field in `ver
 
 ## Contributing
 
-When updating schemas:
+New schema fields require CLI implementation first — see [CONTRIBUTING.md](../CONTRIBUTING.md) for the proposal process.
+
+When updating schemas for implemented features:
 
 1. Update the JSON Schema files
 2. Update `rules.yaml` if needed
-3. Ensure CLI tests pass against new schemas (Phase 2)
-4. Update prose documentation to match (if schemas add new fields)
+3. Ensure CLI tests pass against new schemas
+4. Update prose documentation to match


### PR DESCRIPTION
## Summary

- Create `PROPOSALS.md` to track features proposed but not yet implemented in the CLI
- Update `CONTRIBUTING.md` to explain the CLI-first workflow
- Reference existing proposal PRs (#20, #21, #22) as candidates for this process

## Context

Issue #23 established machine-readable schemas to sync CLI ↔ Spec. Phases 1-4 are complete:
- Phase 1: `schema/` directory with JSON schemas
- Phase 2: CLI validates against schemas (51 tests)
- Phase 3: Sync workflow pushes CLI schema changes → Spec PRs
- Phase 4: *(not applicable)*

Phase 5 addresses the pattern of PRs proposing spec changes without backing CLI implementation. The new process documentation clarifies:
1. Proposals go to `PROPOSALS.md` (explicitly "not yet implemented")
2. Features graduate to the spec only after CLI ships them
3. Contributors understand this workflow upfront

## Changes

| File | Change |
|------|--------|
| `PROPOSALS.md` | New file with status tracking table and process explanation |
| `CONTRIBUTING.md` | Added "Proposing New Features" section |

## Test plan

- [x] Links in both files point to correct targets
- [x] Status table renders correctly in GitHub markdown
- [x] Tone matches existing repo documentation

Closes #23 (Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)