### PR TITLE
sync: Update spec from portolan-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ cloud-native geospatial data.
   - [Vector data](formats/vector.md)
   - [Raster data](formats/raster.md)
   - [Point clouds](formats/pointcloud.md)
+  - [Tabular (non-geospatial) data](formats/tabular.md)
 - [Best practices](best-practices.md) - Recommended conventions
+- [AI & LLM integration](ai-integration.md) - llms.txt requirements for agent discoverability
 
 ## Architectural Decisions
 
@@ -30,9 +32,11 @@ Spec-related decisions are tracked in the CLI repository's ADR directory:
 
 - [ADR-0005: versions.json as Single Source of Truth](../context/shared/adr/0005-versions-json-source-of-truth.md)
 - [ADR-0032: Nested Catalogs with Flat Collections](../context/shared/adr/0032-nested-catalogs-with-flat-collections.md)
+- [ADR-0047: Non-Geo Tabular Data Support](../context/shared/adr/0047-non-geo-tabular-data-support.md)
 - [ADR-0049: STAC-GeoParquet as Scalability Requirement](../context/shared/adr/0049-stac-geoparquet-scalability.md)
 - [ADR-0050: PMTiles as Visualization Requirement](../context/shared/adr/0050-pmtiles-visualization-requirement.md)
 - [ADR-0051: SELF_CONTAINED Catalog Type](../context/shared/adr/0051-self-contained-catalog-type.md)
+- [ADR-0052: Require llms.txt for AI/LLM Integration](../context/shared/adr/0052-llms-txt-requirement.md)
 
 For all architectural decisions, see [context/shared/adr/](../context/shared/adr/).
 

--- a/ai-integration.md
+++ b/ai-integration.md
@@ -1,0 +1,59 @@
+# AI & LLM Integration
+
+This section covers practices for making Portolan catalogs discoverable and usable by AI agents and large language models. This is a rapidly evolving area — the recommendations here represent early patterns that have proven effective and will be refined as the community gains experience.
+
+## llms.txt
+
+[llms.txt](https://llmstxt.org/) is an emerging standard for providing LLM-friendly documentation alongside web resources. In Portolan, every catalog and collection includes an `llms.txt` file that gives AI agents the context they need to discover, understand, and query the data.
+
+### Requirements
+
+Every catalog and collection **MUST** include an `llms.txt` file in markdown format.
+
+The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
+
+```json
+{
+  "rel": "llms",
+  "href": "./llms.txt",
+  "type": "text/markdown",
+  "title": "Agent/LLM usage guide"
+}
+```
+
+- The `href` **MUST** use a relative path (consistent with `SELF_CONTAINED` catalog type)
+- The `type` **MUST** be `text/markdown`
+- `llms.txt` is a **link**, not an asset — it describes the data, it is not the data itself
+
+### Content Recommendations
+
+These recommendations are early and expected to evolve. They reflect patterns that have worked well in practice but are not exhaustive.
+
+#### Catalog-Level llms.txt
+
+A catalog-level `llms.txt` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
+
+- A summary of what the catalog contains and who publishes it
+- A list of all collections with brief descriptions (what each contains, feature count, key fields)
+- Data access patterns (base URLs, S3 paths, code examples)
+- Coordinate system conventions used across the catalog
+- License information
+- Pointers to collection-level `llms.txt` files for detailed documentation
+
+#### Collection-Level llms.txt
+
+A collection-level `llms.txt` provides everything an AI agent needs to work with a specific dataset. It **SHOULD** include:
+
+- **What the dataset is** — a plain-language description, including source, provider, and license
+- **How to access the data** — URLs and working code examples for loading the data (e.g., DuckDB SQL, Python)
+- **Schema documentation** — all field names, types, and meanings, ideally as a table
+- **Data quality notes** — sentinel values, privacy suppressions, known quirks, or caveats that would trip up a naive query
+- **Example queries** — practical, working examples showing common analysis patterns
+- **Related datasets** — cross-references to complementary collections, including join keys and how to combine them
+
+#### General Guidance
+
+- **SHOULD** be written for an AI agent audience — concise, structured, and practical
+- **SHOULD** favor concrete examples over abstract descriptions
+- **SHOULD** include working code that an agent can adapt, not just pseudocode
+- **SHOULD** call out non-obvious pitfalls (e.g., coordinate systems in meters vs. degrees, coded values, null conventions)

--- a/core.md
+++ b/core.md
@@ -12,9 +12,11 @@ project/
 │   ├── config.yaml
 │   └── state.json
 ├── catalog.json
+├── llms.txt
 ├── versions.json
 └── {collection_id}/
     ├── collection.json
+    ├── llms.txt
     ├── versions.json
     └── {item_id}/
         └── data.parquet
@@ -25,6 +27,16 @@ project/
 - **MUST** be a valid STAC Catalog or Collection
 - **MUST** follow STAC specification version 1.0.0 or later
 - **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
+
+### Spatial Extent for Tabular Collections
+
+STAC requires `extent.spatial.bbox` for Collections. For **tabular (non-geospatial) collections** (`portolan:geospatial: false`):
+
+- `extent.spatial.bbox` represents the **area of interest** (AOI) the data pertains to, not a geometric footprint
+- Portolan CLI **always provides** `extent.spatial` via automatic AOI inheritance from sibling collections (or global fallback)
+- Portolan validators treat the bbox as informational metadata, not a constraint
+
+See [formats/tabular.md](formats/tabular.md) for full tabular collection requirements.
 
 ## Data Storage
 
@@ -92,6 +104,13 @@ This is standard STAC practice for provenance and enables consumers to trace dat
 - **MUST** include a `README.md` at the catalog root
 - README content requirements: Title, description, license, and data provenance at minimum
 
+## AI & LLM Integration
+
+- **MUST** include an `llms.txt` file at both the catalog root and each collection directory
+- **MUST** link `llms.txt` in the STAC JSON `links` array with `rel: "llms"`
+
+See [ai-integration.md](ai-integration.md) for full requirements and content recommendations.
+
 ## Versioning
 
 - **MUST** include version tracking via `versions.json` manifest file (see [versions.md](versions.md))
@@ -123,5 +142,6 @@ Additional requirements apply based on data type. See format addenda:
 - [Vector data](formats/vector.md)
 - [Raster data](formats/raster.md)
 - [Point cloud data](formats/pointcloud.md)
+- [Tabular (non-geospatial) data](formats/tabular.md)
 
 Format addenda are normative and define **MUST** requirements, not suggestions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,18 @@ This directory contains reference implementations of Portolan catalogs.
 
 ## Available Examples
 
+### Tabular Collection (Non-Geospatial)
+
+A reference implementation of a tabular (non-geospatial) collection.
+
+- **File**: [tabular-collection.json](tabular-collection.json)
+- **Demonstrates**:
+  - `portolan:geospatial: false` flag for non-spatial data
+  - STAC Table extension for schema documentation
+  - Temporal extent without spatial extent
+  - Collection-level assets for single-file tabular data
+  - Provenance link to source (Eurostat)
+
 ### Argentina 2022 Census
 
 A complete implementation of Argentina's 2022 census data as a Portolan catalog.

--- a/examples/tabular-collection.json
+++ b/examples/tabular-collection.json
@@ -1,0 +1,86 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "eurostat-electricity-prices",
+  "title": "Industrial electricity prices by country",
+  "description": "Half-yearly industrial electricity prices (EUR/kWh, including taxes) by European country. Non-geospatial tabular dataset. Source: Eurostat nrg_pc_205.",
+  "license": "CC-BY-4.0",
+  "portolan:geospatial": false,
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [[-25, 34, 45, 72]]
+    },
+    "temporal": {
+      "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "providers": [
+    {
+      "name": "Eurostat",
+      "roles": ["producer", "licensor"],
+      "url": "https://ec.europa.eu/eurostat"
+    }
+  ],
+  "table:columns": [
+    {
+      "name": "geo",
+      "type": "string",
+      "description": "Country code (Eurostat / ISO-3166-1 alpha-2)"
+    },
+    {
+      "name": "period",
+      "type": "string",
+      "description": "Reporting half-year, e.g. 2024-S1"
+    },
+    {
+      "name": "price_eur_kwh",
+      "type": "double",
+      "description": "Industrial electricity price, EUR/kWh, including taxes"
+    }
+  ],
+  "assets": {
+    "data": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/eurostat-electricity-prices/electricity-prices.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "title": "Electricity prices data"
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "./collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "version-history",
+      "href": "./versions.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "llms",
+      "href": "./llms.txt",
+      "type": "text/markdown",
+      "title": "Agent/LLM usage guide"
+    },
+    {
+      "rel": "via",
+      "href": "https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_205/default/table",
+      "type": "text/html",
+      "title": "Source: Eurostat — Electricity prices for non-household consumers"
+    }
+  ]
+}

--- a/extensions.md
+++ b/extensions.md
@@ -14,7 +14,7 @@ These extensions are recognized as importable geospatial data:
 | `.shp` | Shapefile | Vector | No | Converts to GeoParquet |
 | `.gpkg` | GeoPackage | Vector | No | Converts to GeoParquet |
 | `.fgb` | FlatGeobuf | Vector | Yes | Cloud-native, passed through |
-| `.csv` | CSV with geometry | Vector | No | Converts to GeoParquet (requires lat/lon or WKT column) |
+| `.csv` | CSV | Vector/Tabular | No | Content inspected: geometry columns → GeoParquet; no geometry → tabular (if enabled) |
 | `.tif`, `.tiff` | GeoTIFF/COG | Raster | Depends | Content inspected for COG compliance |
 | `.jp2` | JPEG2000 | Raster | No | Converts to COG |
 
@@ -35,13 +35,18 @@ See [ADR-0014: Accept non-cloud-native formats](https://github.com/portolan-sdi/
 
 ### Content Inspection
 
-Some formats require content inspection to determine cloud-native status:
+Some formats require content inspection to determine type and cloud-native status:
 
-- **`.parquet`**: Checked for GeoParquet metadata (geo column info)
+- **`.parquet`**: Checked for GeoParquet metadata (`geo` key in schema metadata)
+  - If `geo` key present → GeoParquet (geospatial pipeline)
+  - If `geo` key absent → Plain Parquet (tabular pipeline, requires `tabular.enabled: true`)
+- **`.csv`**: Checked for geometry columns (lat/lon, WKT, WKB)
+  - If geometry columns found → GeoParquet conversion
+  - If no geometry columns → tabular (requires `tabular.enabled: true`)
 - **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry)
 - **`.tif`/`.tiff`**: Validated against COG spec (internal tiling, overviews)
 
-Files that fail content inspection are treated as convertible (vector) or rejected (raster without geo info).
+Files that fail content inspection are treated as convertible (vector), tabular (if enabled), or rejected (raster without geo info).
 
 ## Sidecar Files
 
@@ -97,6 +102,23 @@ These formats are explicitly rejected with informative error messages:
 | `.h5`, `.hdf5` | HDF5 | Not yet supported |
 | `.las`, `.laz` | LAS/LAZ | Use COPC format instead |
 
+## Tabular Formats
+
+These extensions are recognized as tabular data when `tabular.enabled: true` in `.portolan/config.yaml`:
+
+| Extension | Format | Handling |
+|-----------|--------|----------|
+| `.parquet` | Plain Parquet | Content inspection — no `geo` metadata key |
+| `.csv` | CSV | Content inspection — no geometry columns |
+| `.tsv` | TSV | Converts to Parquet |
+| `.xlsx`, `.xls` | Excel | Converts to Parquet |
+
+When `tabular.enabled` is `false` (default):
+- Tabular files with a companion geo file → tracked as companion assets
+- Standalone tabular files → rejected with helpful error message
+
+See [formats/tabular.md](formats/tabular.md) for full requirements.
+
 ## Ignored Files
 
 The following are skipped during directory scans:
@@ -107,10 +129,7 @@ The following are skipped during directory scans:
 | `.pyc`, `.pyo`, `.class`, `.o`, `.obj` | Compiled files |
 | `__pycache__/`, `.git/`, `.svn/`, `.hg/` | Build/VCS directories |
 | `.idea/`, `.vscode/`, `node_modules/`, `.tox/`, `.pytest_cache/` | IDE/tooling directories |
-| `.tsv`, `.xlsx`, `.xls` | Tabular data (not geospatial) |
 | `.md`, `.txt`, `.rst`, `.html`, `.htm` | Documentation |
-
-Note: `.csv` files are listed as importable above (with geometry columns) but are also commonly non-geospatial. The scan command classifies them as tabular data; the import command performs content inspection.
 
 ## Extension vs. Role
 

--- a/formats/tabular.md
+++ b/formats/tabular.md
@@ -1,0 +1,239 @@
+# Tabular (Non-Geospatial) Data Format Requirements
+
+Portolan supports **non-geospatial tabular datasets** as companion data alongside geospatial layers. This enables catalogs to include tables keyed by time, administrative code, or category rather than by location.
+
+## Scope
+
+Portolan is a **geospatial-first** catalog tool. Tabular support is scoped to companion data that relates to the same geographic area as the catalog's spatial layers — not general-purpose data cataloging.
+
+Examples of appropriate tabular data:
+- Census demographics linked by tract ID
+- Permit records keyed by parcel number
+- Budget allocations by administrative unit
+- Time-series data (electricity load, sensor readings)
+
+## Enabling Tabular Support
+
+Tabular data support is **opt-in** via `.portolan/config.yaml`:
+
+```yaml
+tabular:
+  enabled: true   # Track standalone tabular files as collection-level assets
+  convert: true   # Convert CSV/TSV/Excel to Parquet (default)
+```
+
+When `tabular.enabled` is `false` (default):
+- Tabular files **with** a companion geo file → tracked as companion assets
+- Tabular files **without** a companion geo file → rejected with helpful error
+
+When `tabular.enabled` is `true`:
+- Standalone tabular files → tracked as collection-level assets
+- A collection can be tabular-only (no geo data)
+
+## Recognized Formats
+
+| Extension | Format | Handling |
+|-----------|--------|----------|
+| `.parquet` | Plain Parquet | Content inspection — no `geo` metadata key |
+| `.csv` | CSV | Converts to Parquet |
+| `.tsv` | TSV | Converts to Parquet |
+| `.xlsx`, `.xls` | Excel | Converts to Parquet |
+
+### GeoParquet vs Plain Parquet Classification
+
+`.parquet` files are classified by content inspection:
+
+1. Read Parquet footer metadata (O(1) operation)
+2. Check for `b"geo"` key in schema metadata
+3. If present → GeoParquet (geo pipeline)
+4. If absent → Plain Parquet (tabular pipeline)
+
+## Marking Collections Non-Spatial
+
+Tabular collections **MUST** include the `portolan:geospatial` property:
+
+```json
+{
+  "type": "Collection",
+  "id": "electricity-prices",
+  "portolan:geospatial": false,
+  ...
+}
+```
+
+- `portolan:geospatial: false` → tabular collection, spatial extent relaxations apply
+- `portolan:geospatial: true` or absent → geospatial collection, all spatial requirements apply
+
+This explicit flag distinguishes *intentionally non-spatial* from *spatial but unmeasured*, enabling validators and federation agents to route queries correctly.
+
+## Spatial Extent Handling
+
+For tabular collections (`portolan:geospatial: false`):
+
+- `extent.spatial.bbox` represents the **area of interest** (AOI) the data pertains to, not a geometric footprint
+- Portolan CLI **always provides** `extent.spatial` via automatic AOI inheritance (see below)
+- Portolan validators treat the bbox as informational for tabular collections
+
+> **Note on STAC compliance**: The STAC Collection schema requires `extent.spatial`. While Portolan's semantic model considers spatial extent optional for tabular data, the CLI always provides it to maintain STAC schema compatibility. The `portolan:geospatial: false` flag signals that the bbox is an AOI, not a geometry footprint.
+
+### AOI Inheritance
+
+Portolan CLI computes `extent.spatial` automatically for tabular collections:
+
+1. **Explicit bbox** in `metadata.yaml` (manual override)
+2. **Inherit from sibling geo collections** — compute union bbox
+3. **Global fallback** `[-180, -90, 180, 90]` when no siblings exist
+
+This default is appropriate because companion tabular data typically pertains to the same geographic area as the catalog's spatial layers.
+
+**Limitation**: Union bbox computation uses simple min/max aggregation, which does NOT correctly handle antimeridian-crossing bboxes (where west > east). For catalogs with such collections, use an explicit bbox in `metadata.yaml`.
+
+## Temporal Extent
+
+Tabular collections **SHOULD** populate `extent.temporal` when the data has a time dimension:
+
+```json
+"extent": {
+  "temporal": {
+    "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+  }
+}
+```
+
+## Schema Documentation
+
+Tabular collections **SHOULD** describe their columns using the [STAC Table extension](https://github.com/stac-extensions/table):
+
+```json
+"stac_extensions": [
+  "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+],
+"table:columns": [
+  {"name": "geo", "type": "string", "description": "Country code (ISO-3166-1 alpha-2)"},
+  {"name": "period", "type": "string", "description": "Reporting half-year, e.g. 2024-S1"},
+  {"name": "price_eur_kwh", "type": "double", "description": "Price in EUR per kWh"}
+]
+```
+
+Because tabular data has no geometry to hint at its meaning, the schema is the primary semantic handle for consumers and agents.
+
+## Collection-Level Assets
+
+Tabular files become **collection-level assets** (not items), following the same pattern as single-file vector collections:
+
+```json
+{
+  "type": "Collection",
+  "id": "eurostat-electricity-prices",
+  "portolan:geospatial": false,
+  "assets": {
+    "data": {
+      "href": "./electricity-prices.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    }
+  }
+}
+```
+
+### Source File Tracking
+
+When conversion is enabled (`tabular.convert: true`), both the source file and converted Parquet are tracked as assets:
+
+```json
+"assets": {
+  "data": {
+    "href": "./electricity-prices.parquet",
+    "type": "application/vnd.apache.parquet",
+    "roles": ["data"]
+  },
+  "source": {
+    "href": "./electricity-prices.csv",
+    "type": "text/csv",
+    "roles": ["source"]
+  }
+}
+```
+
+## Directory Layout
+
+```
+eurostat-electricity-prices/
+  collection.json
+  versions.json
+  llms.txt
+  electricity-prices.parquet
+  electricity-prices.csv        (source, if converted)
+```
+
+No item directory or item JSON is needed.
+
+## Example: Complete Tabular Collection
+
+```json
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "eurostat-electricity-prices",
+  "title": "Industrial electricity prices by country",
+  "description": "Half-yearly industrial electricity prices (EUR/kWh) by European country. Source: Eurostat nrg_pc_205.",
+  "license": "CC-BY-4.0",
+  "portolan:geospatial": false,
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [[-25, 34, 45, 72]]
+    },
+    "temporal": {
+      "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "providers": [
+    {
+      "name": "Eurostat",
+      "roles": ["producer", "licensor"],
+      "url": "https://ec.europa.eu/eurostat"
+    }
+  ],
+  "table:columns": [
+    {"name": "geo", "type": "string", "description": "Country code (Eurostat / ISO-3166-1 alpha-2)"},
+    {"name": "period", "type": "string", "description": "Reporting half-year, e.g. 2024-S1"},
+    {"name": "price_eur_kwh", "type": "double", "description": "Industrial electricity price, EUR/kWh"}
+  ],
+  "assets": {
+    "data": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/eurostat-electricity-prices/electricity-prices.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    }
+  },
+  "links": [
+    {"rel": "root", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "self", "href": "./collection.json", "type": "application/json"},
+    {"rel": "version-history", "href": "./versions.json", "type": "application/json"},
+    {"rel": "llms", "href": "./llms.txt", "type": "text/markdown", "title": "Agent/LLM usage guide"},
+    {
+      "rel": "via",
+      "href": "https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_205/default/table",
+      "type": "text/html",
+      "title": "Source: Eurostat — Electricity prices for non-household consumers"
+    }
+  ]
+}
+```
+
+Note: The `extent.spatial.bbox` represents the European AOI (inherited or explicit), not geometry. No PMTiles or geometry validation apply to tabular collections.
+
+## What Does NOT Apply
+
+For tabular collections:
+
+- **No GeoParquet metadata** — the Parquet file has no `geo` key
+- **No PMTiles** — visualization derivatives are for spatial data
+- **No spatial extent requirement** — `extent.spatial` is optional
+- **No geometry validation** — there is no geometry to validate
+
+All other Portolan core requirements apply unchanged: absolute S3 asset hrefs (when published), relative STAC links, `providers`, provenance via `rel: "via"`, `README.md`, `llms.txt`, and `versions.json` tracking.

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -45,7 +45,7 @@
         "rel": {
           "type": "string",
           "description": "Link relation type",
-          "examples": ["root", "self", "child", "parent", "item"]
+          "examples": ["root", "self", "child", "parent", "item", "llms"]
         },
         "href": {
           "type": "string",
@@ -79,6 +79,28 @@
                 "not": {
                   "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://"
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "llms" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "LLM integration link - MUST point to llms.txt with text/markdown type",
+            "required": ["type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "pattern": "(^|/)llms\\.txt$",
+                "description": "Must point to llms.txt file"
+              },
+              "type": {
+                "const": "text/markdown"
               }
             }
           }

--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -18,6 +18,11 @@
         "type": {
           "const": "Collection"
         },
+        "portolan:geospatial": {
+          "type": "boolean",
+          "default": true,
+          "description": "False for tabular (non-geospatial) collections. When false, extent.spatial.bbox represents the area-of-interest (AOI) the data pertains to, not a geometric footprint. Note: STAC schema (via allOf) still requires extent.spatial; Portolan CLI provides this via AOI inheritance from sibling collections. See formats/tabular.md"
+        },
         "portolan:styles": {
           "type": "array",
           "description": "Ordered list of style asset keys. First entry is the default style. See best-practices.md#visualization-styles",
@@ -116,6 +121,17 @@
           "then": {
             "$ref": "#/$defs/VersionHistoryLink"
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "llms" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "$ref": "#/$defs/LlmsLink"
+          }
         }
       ]
     },
@@ -135,6 +151,28 @@
         }
       },
       "required": ["rel", "href"]
+    },
+    "LlmsLink": {
+      "type": "object",
+      "description": "Link to llms.txt for AI/LLM integration - MUST be present",
+      "properties": {
+        "rel": {
+          "const": "llms"
+        },
+        "href": {
+          "type": "string",
+          "pattern": "(^|/)llms\\.txt$",
+          "description": "Must point to llms.txt file"
+        },
+        "type": {
+          "const": "text/markdown"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title, e.g., 'Agent/LLM usage guide'"
+        }
+      },
+      "required": ["rel", "href", "type"]
     },
     "PortolanAsset": {
       "type": "object",

--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -409,3 +409,167 @@ rules:
     references:
       - core.md#version-history-link
       - versions.md
+
+  # =============================================================================
+  # AI & LLM Integration Rules
+  # =============================================================================
+
+  - id: RULE-0080
+    level: error
+    scope: catalog
+    description: Catalogs MUST include llms.txt link
+    rationale: |
+      AI agents and LLMs are a primary audience for Portolan catalogs.
+      The llms.txt file provides context that STAC metadata alone cannot:
+      plain-language descriptions, usage examples, and pitfalls to avoid.
+    validation: |
+      For catalog.json:
+        assert any link has rel="llms"
+        if link with rel="llms" exists:
+          assert link.href ends with "llms.txt"
+          assert link.type == "text/markdown"
+          assert file exists at link.href
+    references:
+      - ai-integration.md
+      - core.md#ai-llm-integration
+
+  - id: RULE-0081
+    level: error
+    scope: collection
+    description: Collections MUST include llms.txt link
+    rationale: |
+      Collection-level llms.txt provides everything an agent needs to work
+      with a specific dataset: schema docs, query examples, data quality notes.
+    validation: |
+      For each collection.json:
+        assert any link has rel="llms"
+        if link with rel="llms" exists:
+          assert link.href ends with "llms.txt"
+          assert link.type == "text/markdown"
+          assert file exists at link.href
+    references:
+      - ai-integration.md
+      - core.md#ai-llm-integration
+
+  - id: RULE-0082
+    level: warning
+    scope: catalog
+    description: Catalog llms.txt SHOULD include recommended content
+    rationale: |
+      Effective llms.txt files follow established patterns for maximum utility.
+      Missing key sections reduce the file's value to AI agents.
+    validation: |
+      For catalog llms.txt:
+        warn if file does not mention collections or datasets
+        warn if no code examples present
+        warn if no license information present
+    references:
+      - ai-integration.md#catalog-level-llmstxt
+
+  - id: RULE-0083
+    level: warning
+    scope: collection
+    description: Collection llms.txt SHOULD include recommended content
+    rationale: |
+      Collection llms.txt should enable agents to immediately work with the data.
+      Schema documentation and query examples are particularly valuable.
+    validation: |
+      For collection llms.txt:
+        warn if no schema/field documentation present
+        warn if no code/query examples present
+        warn if no data access URLs present
+    references:
+      - ai-integration.md#collection-level-llmstxt
+
+  # =============================================================================
+  # Tabular (Non-Geospatial) Data Rules
+  # =============================================================================
+
+  - id: RULE-0090
+    level: error
+    scope: collection
+    description: Tabular collections MUST have portolan:geospatial set to false
+    rationale: |
+      The portolan:geospatial flag distinguishes intentionally non-spatial
+      collections from spatial collections with missing extent. This enables
+      validators and federation agents to route queries correctly.
+    validation: |
+      If collection has no GeoParquet assets (no geo metadata in .parquet files):
+        assert collection["portolan:geospatial"] == false
+    references:
+      - formats/tabular.md#marking-collections-non-spatial
+
+  - id: RULE-0091
+    level: warning
+    scope: collection
+    description: Tabular collections SHOULD use the STAC Table extension
+    rationale: |
+      Because tabular data has no geometry to hint at its meaning, the schema
+      is the primary semantic handle for consumers and agents. The table:columns
+      property surfaces schema information in STAC without opening the Parquet file.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        warn if "table:columns" not in collection
+        warn if "https://stac-extensions.github.io/table" not in stac_extensions
+    references:
+      - formats/tabular.md#schema-documentation
+      - https://github.com/stac-extensions/table
+
+  - id: RULE-0092
+    level: info
+    scope: collection
+    description: Tabular collection extent.spatial represents AOI, not geometry
+    rationale: |
+      STAC requires extent.spatial.bbox for collections. For tabular data with
+      no intrinsic spatial footprint, the bbox represents the area-of-interest
+      (AOI) the data pertains to. Portolan CLI always provides extent.spatial
+      via automatic AOI inheritance from sibling collections or global fallback.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        extent.spatial.bbox is treated as informational AOI, not a constraint
+        Portolan CLI auto-populates via AOI inheritance
+      If collection["portolan:geospatial"] == true or absent:
+        extent.spatial.bbox represents actual spatial footprint
+    references:
+      - formats/tabular.md#spatial-extent-handling
+      - core.md#spatial-extent-for-tabular-collections
+
+  - id: RULE-0093
+    level: warning
+    scope: collection
+    description: Tabular collections SHOULD have temporal extent when time-dimensioned
+    rationale: |
+      Most tabular data has a time dimension (time-series, reporting periods).
+      Temporal extent enables time-based queries and browsing.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        warn if extent.temporal is not set and data appears to have time dimension
+    references:
+      - formats/tabular.md#temporal-extent
+
+  - id: RULE-0094
+    level: error
+    scope: collection
+    description: Tabular collections MUST use collection-level assets
+    rationale: |
+      Single-file tabular datasets should not be wrapped in STAC items.
+      Collection-level assets are simpler and match the vector data pattern.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        assert primary data is in collection.assets, not wrapped in items
+    references:
+      - formats/tabular.md#collection-level-assets
+
+  - id: RULE-0095
+    level: warning
+    scope: config
+    description: Standalone tabular files require tabular.enabled config
+    rationale: |
+      Tabular support is opt-in to prevent accidentally sweeping in stray
+      CSV/Excel files. Users must explicitly enable it.
+    validation: |
+      If scan finds tabular files without companion geo files:
+        if not config["tabular"]["enabled"]:
+          reject with message explaining how to enable
+    references:
+      - formats/tabular.md#enabling-tabular-support


### PR DESCRIPTION
Automated spec sync from portolan-cli.

**Source commit:** portolan-sdi/portolan-cli@5837c5d7d1e153ad6c715d5c98817ea4af7450b0
**Triggered by:** docs(spec): add tabular (non-geospatial) data format specification (#480)

* docs(spec): add tabular (non-geospatial) data format specification

Complete spec documentation for non-geo tabular data support (implemented
in PR #449). This brings the spec up to date with the CLI implementation.

Changes:
- Add spec/formats/tabular.md — full format addendum documenting:
  - Config gate (tabular.enabled)
  - GeoParquet vs plain Parquet classification
  - portolan:geospatial property
  - AOI inheritance behavior
  - Collection-level asset modeling
- Update spec/extensions.md — add Tabular Formats section
- Update spec/core.md — spatial extent relaxation for tabular collections
- Update spec/schema/collection.schema.json — add portolan:geospatial property
- Add RULE-0090 through RULE-0095 to rules.yaml for tabular validation
- Add example tabular collection to spec/examples/
- Add test fixtures for valid/invalid tabular collections

Decisions:
- Property name: portolan:geospatial: false (boolean, backward compatible)
- table:columns: SHOULD level (warning, not blocking)

Closes portolan-spec#22 (implemented via CLI, spec now documented)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

* fix(spec): align tabular spec with implementation reality

Adversarial review of PR #480 revealed gaps between spec documentation
and actual behavior. This commit fixes:

**CLI Implementation:**
- Add `portolan:geospatial: false` to tabular collections in
  `_ensure_tabular_collection()` (RULE-0090)

**Spec Documentation:**
- Clarify that CLI always provides `extent.spatial` via AOI inheritance
- Update RULE-0092 from "MAY omit" to "represents AOI" (info level)
- Fix core.md section title and wording for consistency

**Fixtures:**
- Add `extent.spatial` to all tabular examples/fixtures (STAC schema
  requires it via allOf reference)
- Update invalid fixture description to reference RULE-0090

**Schema:**
- Add note about STAC allOf constraint in portolan:geospatial description

**Tests:**
- Add TestPortolanGeospatialFlag to verify CLI sets the flag

**ADR-0047:**
- Document the `portolan:geospatial` property decision (section 7)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>

The portolan-cli repository is the source of truth for the Portolan
specification. This PR syncs changes from `portolan-cli/spec/` to
the portolan-spec mirror.

See [ADR-0048](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0048-cli-as-spec-source.md) for rationale.

---
_Auto-generated by [sync-spec](https://github.com/portolan-sdi/portolan-cli/blob/main/.github/workflows/sync-spec.yml)_