### PR TITLE
sync: Update spec from portolan-cli

### DIFF
--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -494,7 +494,13 @@ rules:
       collections from spatial collections with missing extent. This enables
       validators and federation agents to route queries correctly.
     validation: |
-      If collection has no GeoParquet assets (no geo metadata in .parquet files):
+      Classify the collection by the content of its data assets: a collection
+      with any geospatial asset (GeoParquet, raster/COG, or other geo format) is
+      spatial; one with tabular assets (CSV/XLSX or plain Parquet) and no
+      geospatial asset is tabular. A Parquet asset is only counted when its file
+      is present and readable (an unreadable/remote Parquet is not assumed
+      tabular).
+      If the collection is tabular:
         assert collection["portolan:geospatial"] == false
     references:
       - formats/tabular.md#marking-collections-non-spatial
@@ -508,7 +514,8 @@ rules:
       is the primary semantic handle for consumers and agents. The table:columns
       property surfaces schema information in STAC without opening the Parquet file.
     validation: |
-      If collection["portolan:geospatial"] == false:
+      If the collection is tabular (portolan:geospatial == false, or detected as
+      tabular by asset content so the rule still applies before RULE-0090 is fixed):
         warn if "table:columns" not in collection
         warn if "https://stac-extensions.github.io/table" not in stac_extensions
     references:
@@ -542,7 +549,8 @@ rules:
       Most tabular data has a time dimension (time-series, reporting periods).
       Temporal extent enables time-based queries and browsing.
     validation: |
-      If collection["portolan:geospatial"] == false:
+      If the collection is tabular (portolan:geospatial == false, or detected as
+      tabular by asset content):
         warn if extent.temporal is not set and data appears to have time dimension
     references:
       - formats/tabular.md#temporal-extent
@@ -555,7 +563,8 @@ rules:
       Single-file tabular datasets should not be wrapped in STAC items.
       Collection-level assets are simpler and match the vector data pattern.
     validation: |
-      If collection["portolan:geospatial"] == false:
+      If the collection is tabular (portolan:geospatial == false, or detected as
+      tabular by asset content) and not partitioned (no partition:scheme):
         assert primary data is in collection.assets, not wrapped in items
     references:
       - formats/tabular.md#collection-level-assets


### PR DESCRIPTION
Automated spec sync from portolan-cli.

**Source commit:** portolan-sdi/portolan-cli@984049fd5f098fe893930ec5bdb9e89986675f74
**Triggered by:** feat(check): enforce tabular collection rules (RULE-0090–0094) (#481) (#533)

* feat(check): enforce tabular collection rules (RULE-0090–0094) (#481)

PR #480 documented the tabular-collection rules in spec/schema/rules.yaml
but nothing enforced them. Add four ValidationRule classes so `portolan
check` flags non-spatial collections that violate the conventions, plus a
`--fix` that backfills the geospatial flag.

- RULE-0090 (ERROR): tabular collections MUST set portolan:geospatial: false
- RULE-0091 (WARNING): SHOULD declare the STAC Table extension + table:columns
- RULE-0093 (WARNING): SHOULD have a temporal extent
- RULE-0094 (ERROR): MUST use collection-level assets, not item-wrapped data
  (partitioned collections exempt per ADR-0047)

A shared classify_collection_data() helper classifies a collection by actual
asset content (reusing is_geoparquet + the extension sets), so RULE-0090 fires
on tabular data only and never mislabels raster/COG collections. RULE-0091/
0093/0094 key off portolan:geospatial == false, matching the rules.yaml pseudocode.

--fix adds repair_tabular_flags() to metadata/fix.py, wired into the existing
metadata fix workflow alongside repair_titles_and_links.

RULE-0092 (info-only) and RULE-0095 (already enforced at scan/add time) are
intentionally out of scope.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* fix(check): harden tabular classification and align spec (#481)

Address review findings on PR #533:

- classify_collection_data no longer treats an unreadable/remote .parquet
  as tabular. is_geoparquet() returns False for both "plain Parquet" and
  "file missing/remote", so the old default raised a false RULE-0090 ERROR
  and drove --fix to stamp portolan:geospatial: false onto an actually-
  spatial collection (e.g. checked before its data is pulled). Such assets
  are now left unclassified. repair_tabular_flags inherits the fix.
- RULE-0091/0093/0094 now key off a shared _is_tabular_collection() (flag
  OR content), so a single `check` pass surfaces them even before RULE-0090
  backfills the flag, instead of hiding them until a second pass.
- Hidden-dir filtering in _iter_collections and repair_tabular_flags now
  uses parts relative to the catalog root, so a catalog under a dotted dir
  no longer skips every collection.
- rules.yaml RULE-0090/0091/0093/0094 updated to describe content-based
  detection, matching the implementation (ADR-0048: CLI is spec source).

Tests: missing-file/remote-href/mixed/empty classification, _summarize
truncation, content-detected-tabular warnings, repair no-op on missing
file, and an end-to-end `check --metadata --fix` backfill via the CLI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* fix(tests): filter Windows reserved device names from Hypothesis filenames

Hypothesis generated 'nul' as a subdirectory name, which is a reserved
device name on Windows (NUL, CON, PRN, AUX, COM1-COM9, LPT1-LPT9). Filter
these from the safe_filename strategy to prevent FileNotFoundError on
Windows CI.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

The portolan-cli repository is the source of truth for the Portolan
specification. This PR syncs changes from `portolan-cli/spec/` to
the portolan-spec mirror.

See [ADR-0048](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0048-cli-as-spec-source.md) for rationale.

---
_Auto-generated by [sync-spec](https://github.com/portolan-sdi/portolan-cli/blob/main/.github/workflows/sync-spec.yml)_