### PR TITLE
sync: Update spec from portolan-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This directory contains the canonical Portolan specification.
 
+**Spec version: `0.1.0`** ([SemVer](https://semver.org/), pre-1.0). The
+canonical machine-readable home is
+[`schema/spec-version.json`](schema/spec-version.json). See
+[Versioning](#versioning) below for the bump policy.
+
 The **portolan-cli repository is the source of truth** for the spec. The
 [portolan-spec](https://github.com/portolan-sdi/portolan-spec) repository is a
 read-only mirror, automatically synced via CI on every merge to main.
@@ -48,6 +53,51 @@ For all architectural decisions, see [context/shared/adr/](../context/shared/adr
 
 See [examples/](examples/) for reference implementations.
 
+## Versioning
+
+The specification is versioned with [SemVer](https://semver.org/), starting
+pre-1.0. The version lives in exactly one canonical, machine-readable place:
+
+- [`schema/spec-version.json`](schema/spec-version.json) — read `spec_version`
+  from here to claim or verify conformance against a version of the Portolan
+  spec. Everything else (this README's header, the CLI's
+  `portolan_cli.constants.PORTOLAN_SPEC_VERSION`, and the
+  `portolan_spec_version` field in `portolan check --json` output) mirrors this
+  value.
+
+This is distinct from the `spec_version` field inside a `versions.json`
+manifest, which versions the [manifest schema](schema/versions.schema.json), not
+the specification as a whole. The check output deliberately names its field
+`portolan_spec_version` to avoid colliding with that manifest key.
+
+### Bump policy
+
+While the spec is pre-1.0, **any breaking change bumps the MINOR** version
+(e.g. `0.1.0` → `0.2.0`); non-breaking changes bump the PATCH. Once the spec
+reaches `1.0.0`, normal SemVer applies (breaking changes bump MAJOR).
+
+A change is **breaking** when a catalog that conformed to the previous version
+may no longer conform, or a tool built against the previous version may
+misvalidate. Examples:
+
+- Raising a rule's severity (e.g. `warning` → `error`) in `schema/rules.yaml`.
+- Adding a new `error`-level rule, or a new required field/constraint in any
+  schema (schema tightening).
+- Removing or renaming a field, rule id, or accepted value.
+- Changing the meaning of an existing field.
+
+A change is **non-breaking** (PATCH) when previously-conforming catalogs still
+conform. Examples:
+
+- Adding a new `warning`-level rule or an optional field.
+- Relaxing a constraint (e.g. `error` → `warning`, widening accepted values).
+- Editorial/documentation-only changes and clarifications.
+
+When you change the spec in a way that trips the criteria above, bump
+`spec_version` in `schema/spec-version.json` **and** the mirrored
+`PORTOLAN_SPEC_VERSION` constant in `portolan_cli/constants.py` in the same PR
+(a spec-compliance test fails if they drift).
+
 ## Making Changes
 
 To propose spec changes:
@@ -55,5 +105,7 @@ To propose spec changes:
 1. Open a PR in this repository (portolan-cli)
 2. Changes to `spec/` trigger review from spec maintainers
 3. On merge, CI syncs to portolan-spec automatically
+4. If the change is normative, bump `spec_version` per the
+   [bump policy](#bump-policy) above
 
 See [ADR-0048](../context/shared/adr/0048-cli-as-spec-source.md) for rationale.

--- a/core.md
+++ b/core.md
@@ -4,13 +4,12 @@ These requirements apply to all Portolan catalogs, regardless of data format.
 
 ## Catalog Structure
 
-A Portolan catalog is a directory with STAC metadata at the project root and internal tooling state in `.portolan/`. See [structure.md](structure.md) for the full directory layout.
+A Portolan catalog is a directory with STAC metadata at the project root and internal tooling configuration in `.portolan/`. See [structure.md](structure.md) for the full directory layout.
 
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml
-│   └── state.json
+│   └── config.yaml
 ├── catalog.json
 ├── llms.txt
 ├── versions.json
@@ -25,8 +24,29 @@ project/
 ## STAC Compliance
 
 - **MUST** be a valid STAC Catalog or Collection
-- **MUST** follow STAC specification version 1.0.0 or later
+- **MUST** follow STAC specification version 1.1.0
 - **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
+
+## Human-Readable Titles
+
+STAC Browser and other clients render `child`/`item` link titles directly; without them a client must fetch every child just to display its name. Portolan therefore requires human-readable titles throughout the catalog (see [ADR-0053](../context/shared/adr/0053-mandatory-human-readable-titles.md)):
+
+- Every `catalog.json` and `collection.json` **MUST** have a non-empty `title` and `description`
+- Titles **MUST** be human-readable — a raw slug (e.g. `snake_case`) or a technical namespace prefix (e.g. `ns:LayerName`) is not acceptable
+- Every `child` and `item` link **MUST** include a `title`
+
+`portolan check` enforces these at ERROR severity, and `portolan check --fix` auto-populates human-readable titles by humanizing slugs.
+
+## Bounding Box Validity
+
+Bounding boxes carry the spatial footprint that drives extent unions and map-UI browsing. Garbage coordinates poison the catalog-level extent and break viewers, so every `bbox` (catalog extent, collection extent, and item) **MUST**:
+
+- Contain no `NaN` or infinite values (including 3D elevation coordinates)
+- Contain no sentinel "effectively infinite" values (e.g. `±1.79e308`)
+- Have WGS84 coordinates within range (longitude in `[-180, 180]`, latitude in `[-90, 90]`)
+- Have `south <= north`
+
+`portolan check` enforces bbox validity at ERROR severity.
 
 ### Spatial Extent for Tabular Collections
 
@@ -37,6 +57,16 @@ STAC requires `extent.spatial.bbox` for Collections. For **tabular (non-geospati
 - Portolan validators treat the bbox as informational metadata, not a constraint
 
 See [formats/tabular.md](formats/tabular.md) for full tabular collection requirements.
+
+## Temporal Metadata
+
+Items **SHOULD** carry an explicit `datetime` (or `start_datetime`/`end_datetime` interval) describing when the data applies. Items added without a datetime receive a null temporal extent (an open interval) and are marked `portolan:datetime_provisional: true` (see [ADR-0035](../context/shared/adr/0035-temporal-extent-handling.md)).
+
+Provisional items are valid STAC but temporally incomplete:
+
+- They are accepted so ingestion is never blocked on unknown dates
+- `portolan check` flags them at WARNING severity
+- Enriching the datetime enables time-based browsing and clears the provisional flag
 
 ## Data Storage
 

--- a/examples/tabular-collection.json
+++ b/examples/tabular-collection.json
@@ -1,6 +1,6 @@
 {
   "type": "Collection",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "id": "eurostat-electricity-prices",
   "title": "Industrial electricity prices by country",
   "description": "Half-yearly industrial electricity prices (EUR/kWh, including taxes) by European country. Non-geospatial tabular dataset. Source: Eurostat nrg_pc_205.",

--- a/formats/tabular.md
+++ b/formats/tabular.md
@@ -173,7 +173,7 @@ No item directory or item JSON is needed.
 ```json
 {
   "type": "Collection",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "id": "eurostat-electricity-prices",
   "title": "Industrial electricity prices by country",
   "description": "Half-yearly industrial electricity prices (EUR/kWh) by European country. Source: Eurostat nrg_pc_205.",

--- a/schema/README.md
+++ b/schema/README.md
@@ -14,6 +14,7 @@ Original location: `https://github.com/portolan-sdi/portolan-spec/tree/main/sche
 
 | File | Description |
 |------|-------------|
+| `spec-version.json` | Canonical machine-readable Portolan spec version (SemVer) — see [Versioning](../README.md#versioning) |
 | `versions.schema.json` | JSON Schema for `versions.json` manifest |
 | `collection.schema.json` | JSON Schema for STAC Collections with Portolan extensions |
 | `catalog.schema.json` | JSON Schema for STAC Catalogs with Portolan extensions |
@@ -50,8 +51,8 @@ uv run pytest tests/spec_compliance/ -v
 ## Schema Notes
 
 The collection and catalog schemas reference external STAC schemas:
-- `https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json`
-- `https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json`
+- `https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json`
+- `https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json`
 
 For compliance testing, we use "Portolan-only" schemas (defined in `conftest.py`)
 that validate Portolan-specific requirements without requiring external $ref resolution.

--- a/schema/catalog-versions.schema.json
+++ b/schema/catalog-versions.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/catalog-versions.schema.json",
+  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
   "title": "Portolan Catalog Versions Index",
   "description": "Schema for the root-level versions.json that indexes collection sync state. Different from collection-level versions.json.",
   "type": "object",

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/catalog.schema.json",
+  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
   "title": "Portolan STAC Catalog",
   "description": "Schema for Portolan-compliant STAC Catalogs. Extends the STAC Catalog schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [
     {
-      "$ref": "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+      "$ref": "https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json"
     },
     {
       "$ref": "#/$defs/PortolanCatalogExtensions"
@@ -14,6 +15,7 @@
   "$defs": {
     "PortolanCatalogExtensions": {
       "type": "object",
+      "required": ["title", "description"],
       "properties": {
         "type": {
           "const": "Catalog"
@@ -27,6 +29,16 @@
           "type": "string",
           "description": "Catalog identifier. Defaults to 'portolan-catalog' if not specified.",
           "default": "portolan-catalog"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable catalog title. MUST be present and human-readable (not a raw slug). See RULE-0100 in rules.yaml and core.md#human-readable-titles."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable catalog description. MUST be non-empty. See RULE-0100 in rules.yaml."
         },
         "links": {
           "type": "array",
@@ -79,6 +91,26 @@
                 "not": {
                   "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://"
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": {
+                "enum": ["child", "item"]
+              }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "Child/item links MUST carry a human-readable title so clients can render them without dereferencing. See RULE-0102/RULE-0103 in rules.yaml.",
+            "required": ["title"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 1
               }
             }
           }

--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/collection.schema.json",
+  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
   "title": "Portolan STAC Collection",
   "description": "Schema for Portolan-compliant STAC Collections. Extends the STAC Collection schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [
     {
-      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json"
+      "$ref": "https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json"
     },
     {
       "$ref": "#/$defs/PortolanCollectionExtensions"
@@ -14,9 +15,20 @@
   "$defs": {
     "PortolanCollectionExtensions": {
       "type": "object",
+      "required": ["title", "description"],
       "properties": {
         "type": {
           "const": "Collection"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable collection title. MUST be present and human-readable (not a raw slug). See RULE-0101 in rules.yaml and core.md#human-readable-titles."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable collection description. MUST be non-empty. See RULE-0101 in rules.yaml."
         },
         "portolan:geospatial": {
           "type": "boolean",
@@ -82,6 +94,26 @@
         }
       },
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "rel": {
+                "enum": ["child", "item"]
+              }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "Child/item links MUST carry a human-readable title so clients can render them without dereferencing. See RULE-0102/RULE-0103 in rules.yaml.",
+            "required": ["title"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
         {
           "if": {
             "properties": {

--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -5,12 +5,21 @@
 #
 # Rule structure:
 #   id: Unique identifier (RULE-XXXX)
-#   level: error | warning
-#   scope: Where the rule applies (catalog, collection, item, asset, versions)
+#   level: error | warning | info
+#   scope: Where the rule applies (catalog, collection, item, asset, versions, config)
 #   description: Human-readable description
 #   rationale: Why this rule exists
 #   validation: How to validate (pseudo-code or description)
 #   references: Links to spec documentation
+#   code_rule: (optional) The `name` of the portolan_cli ValidationRule that
+#     enforces this rule, linking the spec entry to its CLI implementation.
+#     Feeds the rule-coverage matrix and lets tests assert spec/code parity.
+
+# Portolan specification version these rules belong to. The canonical home is
+# spec/schema/spec-version.json; see spec/README.md#versioning for the bump
+# policy (e.g. raising a rule's level from warning to error is a breaking
+# change and bumps the spec version).
+spec_version: "0.1.0"
 
 rules:
   # =============================================================================
@@ -582,3 +591,187 @@ rules:
           reject with message explaining how to enable
     references:
       - formats/tabular.md#enabling-tabular-support
+
+  # =============================================================================
+  # Metadata Quality Rules (human-readable titles/descriptions)
+  # =============================================================================
+  #
+  # Enforced by MandatoryTitlesRule (ERROR). STAC Browser renders child/item
+  # link titles directly, so missing or raw-slug titles force it to fetch every
+  # child just to display a name. See ADR-0053 and Issue #502.
+
+  - id: RULE-0100
+    level: error
+    scope: catalog
+    description: Catalogs MUST have a human-readable title and description
+    rationale: |
+      Titles and descriptions are the primary handle humans and agents use to
+      understand a catalog. A missing or raw-slug title (e.g. snake_case or a
+      "ns:Layer" namespace prefix) is not human-readable and degrades browsing.
+    validation: |
+      For catalog.json:
+        assert title is a non-empty string
+        assert title is human-readable (no underscores, no "prefix:Name" form)
+        assert description is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  - id: RULE-0101
+    level: error
+    scope: collection
+    description: Collections MUST have a human-readable title and description
+    rationale: |
+      Same as RULE-0100 at the collection level: a collection's title and
+      description are what map viewers and agents surface first.
+    validation: |
+      For each collection.json:
+        assert title is a non-empty string
+        assert title is human-readable (no underscores, no "prefix:Name" form)
+        assert description is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  - id: RULE-0102
+    level: error
+    scope: catalog
+    description: Child links MUST include a human-readable title
+    rationale: |
+      STAC Browser renders child link titles without dereferencing the target.
+      An untitled child link forces a fetch of every collection to show a name.
+    validation: |
+      For each link in catalog.json (or sub-catalog) with rel == "child":
+        assert link.title is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  - id: RULE-0103
+    level: error
+    scope: collection
+    description: Item links MUST include a human-readable title
+    rationale: |
+      As with child links, item link titles let clients render an item list
+      without fetching each item.json.
+    validation: |
+      For each link in collection.json with rel == "item":
+        assert link.title is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  # =============================================================================
+  # Bounding Box Validity Rules
+  # =============================================================================
+  #
+  # Enforced by BboxValidRule (ERROR). Garbage coordinates (inf/nan, sentinel
+  # values like ±1.79e308, or out-of-range lon/lat) poison catalog-level extent
+  # unions and break map-UI browsing. See Issue #516.
+
+  - id: RULE-0110
+    level: error
+    scope: catalog
+    description: Catalog extent bboxes MUST be valid
+    rationale: |
+      The catalog extent is the union of its collections; a single poisoned
+      coordinate makes the whole catalog un-browsable in a map UI.
+    validation: |
+      For each bbox in catalog.extent.spatial.bbox:
+        assert no coordinate is NaN or infinite
+        assert no coordinate exceeds a sane magnitude (sentinel poison)
+        assert lon in [-180, 180] and lat in [-90, 90]
+        assert south <= north
+    references:
+      - core.md#bounding-box-validity
+    code_rule: bbox_valid
+
+  - id: RULE-0111
+    level: error
+    scope: collection
+    description: Collection extent bboxes MUST be valid
+    rationale: |
+      Same validity constraints as RULE-0110 at the collection level.
+    validation: |
+      For each bbox in collection.extent.spatial.bbox:
+        assert no coordinate is NaN or infinite
+        assert no coordinate exceeds a sane magnitude (sentinel poison)
+        assert lon in [-180, 180] and lat in [-90, 90]
+        assert south <= north
+    references:
+      - core.md#bounding-box-validity
+    code_rule: bbox_valid
+
+  - id: RULE-0112
+    level: error
+    scope: item
+    description: Item bboxes MUST be valid
+    rationale: |
+      Invalid item bboxes propagate into the collection and catalog extents.
+    validation: |
+      For each item.json with a bbox:
+        assert no coordinate is NaN or infinite
+        assert no coordinate exceeds a sane magnitude (sentinel poison)
+        assert lon in [-180, 180] and lat in [-90, 90]
+        assert south <= north
+    references:
+      - core.md#bounding-box-validity
+    code_rule: bbox_valid
+
+  # =============================================================================
+  # Temporal Metadata Rules
+  # =============================================================================
+
+  - id: RULE-0120
+    level: warning
+    scope: item
+    description: Items SHOULD have an explicit datetime, not a provisional one
+    rationale: |
+      Items added without an explicit datetime get a null temporal extent and
+      are marked portolan:datetime_provisional=true (ADR-0035). They are valid
+      STAC but incomplete; enriching the datetime enables time-based browsing.
+    validation: |
+      For each item.json:
+        warn if properties["portolan:datetime_provisional"] is true
+    references:
+      - core.md#temporal-metadata
+    code_rule: provisional_datetime
+
+  # =============================================================================
+  # Partition Structure Rules (Hive-style partitioned collections)
+  # =============================================================================
+  #
+  # Enforced by PartitionStructureRule (WARNING) and
+  # PartitionSchemaConsistencyRule (ERROR). See ADR-0042 and ADR-0054.
+
+  - id: RULE-0130
+    level: warning
+    scope: collection
+    description: Partitioned collections SHOULD have consistent Hive-style structure
+    rationale: |
+      Mixed partition keys, orphan data files at the collection root, or a
+      missing partition:scheme make a partitioned dataset ambiguous to query
+      engines that rely on the Hive key=value convention.
+    validation: |
+      For each collection with key=value partition directories:
+        warn if partition directories use more than one partition key
+        warn if there are orphan .parquet files at the collection root
+        warn if collection.json is missing the partition:scheme field
+    references:
+      - formats/vector.md#partitioned-datasets
+    code_rule: partition_structure
+
+  - id: RULE-0131
+    level: error
+    scope: collection
+    description: All partition files in a collection MUST share the same schema
+    rationale: |
+      A partitioned collection is a single logical table split across files.
+      Divergent Parquet schemas across partitions break unified reads.
+    validation: |
+      For each collection with key=value partition directories:
+        read the Parquet schema (footer) of every partition file
+        assert all files share the same set of column names
+    references:
+      - formats/vector.md#partitioned-datasets
+    code_rule: partition_schema_consistency

--- a/schema/spec-version.json
+++ b/schema/spec-version.json
@@ -1,0 +1,9 @@
+{
+  "$id": "https://portolan.dev/schema/spec-version.json",
+  "title": "Portolan Specification Version",
+  "description": "Canonical machine-readable home for the Portolan specification version. Tools (the CLI, the read-only mirror, reis, and external conformance checkers) read spec_version from this file to claim or verify conformance against a specific version of the Portolan spec. See spec/README.md#versioning for the bump policy. This is distinct from the versions.json manifest schema version (versions.schema.json).",
+  "spec_version": "0.1.0",
+  "versioning": "semver",
+  "stability": "pre-release",
+  "policy": "https://github.com/portolan-sdi/portolan-cli/blob/main/spec/README.md#versioning"
+}

--- a/schema/versions.schema.json
+++ b/schema/versions.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/versions.schema.json",
+  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
   "title": "Portolan Versions Manifest",
   "description": "Schema for versions.json - tracks version history, asset checksums, and sync state per collection. See https://github.com/portolan-sdi/portolan-spec/blob/main/versions.md",
   "type": "object",

--- a/structure.md
+++ b/structure.md
@@ -1,14 +1,13 @@
 # Catalog Structure
 
-A Portolan catalog is a directory with STAC metadata and cloud-native geospatial data. Internal tooling state lives in `.portolan/`; all STAC-visible files live at the project root.
+A Portolan catalog is a directory with STAC metadata and cloud-native geospatial data. Internal tooling configuration lives in `.portolan/`; all STAC-visible files live at the project root.
 
 ## Directory Layout
 
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml                    # Internal: catalog configuration
-│   └── state.json                     # Internal: local sync state
+│   └── config.yaml                    # Internal: catalog configuration
 ├── catalog.json                       # STAC Catalog (root metadata)
 ├── versions.json                      # Catalog-level versioning
 └── {collection_id}/
@@ -22,7 +21,7 @@ project/
 
 | File | Required | Description |
 |------|----------|-------------|
-| `.portolan/` | **MUST** | Internal tooling directory (config, state) |
+| `.portolan/` | **MUST** | Internal tooling directory (config) |
 | `catalog.json` | **MUST** | STAC Catalog (root metadata) |
 | `versions.json` | **MUST** | Catalog-level version tracking |
 
@@ -33,9 +32,8 @@ The `.portolan` directory **MUST** exist at the project root. Tools **SHOULD** c
 | File | Required | Description |
 |------|----------|-------------|
 | `config.yaml` | **MUST** | Catalog configuration (sentinel file) |
-| `state.json` | **SHOULD** | Local sync state |
 
-Only Portolan-internal tooling state lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
+Only Portolan-internal tooling configuration lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
 
 ## Collection Level
 
@@ -109,9 +107,9 @@ Portolan catalogs **MUST** be saved as `SELF_CONTAINED` (pystac terminology), me
 
 | Property | Default Value |
 |----------|---------------|
-| STAC version | `1.0.0` |
+| STAC version | `1.1.0` |
 | Catalog ID | `portolan-catalog` |
-| Collection license | `proprietary` (SPDX identifier) |
+| Collection license | `other` (STAC 1.1 keyword for a license not covered by SPDX; add a `rel="license"` link when the concrete license is known) |
 
 These defaults can be overridden during catalog creation or dataset import.
 
@@ -122,8 +120,7 @@ A catalog with a single-file vector collection:
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml
-│   └── state.json
+│   └── config.yaml
 ├── catalog.json
 ├── versions.json
 └── districts/
@@ -139,8 +136,7 @@ A catalog with a partitioned vector collection (data > 2 GB):
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml
-│   └── state.json
+│   └── config.yaml
 ├── catalog.json
 ├── versions.json
 └── buildings/


### PR DESCRIPTION
Automated spec sync from portolan-cli.

**Source commit:** portolan-sdi/portolan-cli@b45d351e9fa7efbcb8cba58ff5cc13f77381a9ca
**Triggered by:** spec/code: standardize on STAC 1.1.0 everywhere (schemas, docs, license default) (#585)

* feat: standardize on STAC 1.1.0 everywhere; default license 'other' (#568)

Closes #568

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* fix: remove dead Catalog.STAC_VERSION constant (#585)

Closes #585

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---------

Co-authored-by: agent-farm <agent-farm@users.noreply.github.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

The portolan-cli repository is the source of truth for the Portolan
specification. This PR syncs changes from `portolan-cli/spec/` to
the portolan-spec mirror.

See [ADR-0048](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0048-cli-as-spec-source.md) for rationale.

---
_Auto-generated by [sync-spec](https://github.com/portolan-sdi/portolan-cli/blob/main/.github/workflows/sync-spec.yml)_