### PR TITLE
sync: Update spec from portolan-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the canonical Portolan specification.
 
-**Spec version: `0.1.0`** ([SemVer](https://semver.org/), pre-1.0). The
+**Spec version: `0.1.1`** ([SemVer](https://semver.org/), pre-1.0). The
 canonical machine-readable home is
 [`schema/spec-version.json`](schema/spec-version.json). See
 [Versioning](#versioning) below for the bump policy.

--- a/ai-integration.md
+++ b/ai-integration.md
@@ -42,14 +42,14 @@ A catalog-level `llms.txt` provides an overview of the entire catalog or sub-cat
 
 #### Collection-Level llms.txt
 
-A collection-level `llms.txt` provides everything an AI agent needs to work with a specific dataset. It **SHOULD** include:
+A collection-level `llms.txt` provides everything an AI agent needs to work with a specific collection. It **SHOULD** include:
 
-- **What the dataset is** — a plain-language description, including source, provider, and license
+- **What the collection is** — a plain-language description, including source, provider, and license
 - **How to access the data** — URLs and working code examples for loading the data (e.g., DuckDB SQL, Python)
 - **Schema documentation** — all field names, types, and meanings, ideally as a table
 - **Data quality notes** — sentinel values, privacy suppressions, known quirks, or caveats that would trip up a naive query
 - **Example queries** — practical, working examples showing common analysis patterns
-- **Related datasets** — cross-references to complementary collections, including join keys and how to combine them
+- **Related collections** — cross-references to complementary collections, including join keys and how to combine them
 
 #### General Guidance
 

--- a/best-practices.md
+++ b/best-practices.md
@@ -34,7 +34,7 @@ items = gpd.read_parquet(
 
 ### PMTiles
 
-For vector datasets, **SHOULD** include PMTiles derivatives for web visualization.
+For vector collections, **SHOULD** include PMTiles derivatives for web visualization.
 
 - **SHOULD** provide `.pmtiles` when a GeoParquet file exceeds 10 MB
 - **MUST** provide `.pmtiles` when a GeoParquet file exceeds 100 MB
@@ -129,24 +129,24 @@ The `portolan:styles` property on the collection is a JSON array of asset keys i
 
 #### Best Practices
 
-1. **Create multiple styles for rich datasets.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each (e.g., buildings by age, by use, by height).
+1. **Create multiple styles for rich collections.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each (e.g., buildings by age, by use, by height).
 
 2. **Vary default styles across a catalog.** Each collection should have a visually distinct default color so the catalog is not monotone. Use subject matter to inform color choices — water in blues, vegetation in greens, built environment in warm tones.
 
 3. **Use data-driven styling.** Leverage Mapbox GL expressions (`interpolate`, `match`, `case`, `step`) to reveal patterns. Include a description explaining what the colors represent.
 
-4. **Consider label layers.** For datasets with names (roads, monuments, admin areas), include a label layer or a dedicated "with labels" style variant.
+4. **Consider label layers.** For collections with names (roads, monuments, admin areas), include a label layer or a dedicated "with labels" style variant.
 
 ## Documentation
 
-- **SHOULD** include collection-level READMEs for datasets with:
+- **SHOULD** include collection-level READMEs for collections with:
   - Multiple years of data
   - Multiple source agencies or methodologies
   - Complex versioning or update schedules
 
 ## Metadata
 
-- **SHOULD** provide machine-readable metadata in Parquet format for datasets with:
+- **SHOULD** provide machine-readable metadata in Parquet format for collections with:
   - Many coded/categorical variables
   - Complex classification schemes
   - Variables requiring detailed definitions

--- a/core.md
+++ b/core.md
@@ -88,13 +88,14 @@ Asset hrefs **MUST** be absolute S3 URLs:
 
 ## Link Paths
 
-STAC link relations (`root`, `self`, `child`, `parent`) **SHOULD** use relative paths within the catalog structure:
+STAC link relations (`root`, `self`, `child`, `parent`) **SHOULD** use relative paths within the catalog structure. Hierarchy is built from nested catalogs, so `child` links point from a catalog down to its intermediate catalogs or leaf collections, never from one collection to another (see [structure.md](structure.md#nested-catalogs-flat-collections)). This is an intermediate catalog linking to a leaf collection:
 
 ```json
 "links": [
-  {"rel": "root", "href": "./catalog.json", "type": "application/json"},
-  {"rel": "self", "href": "./collection.json", "type": "application/json"},
-  {"rel": "child", "href": "./2022/collection.json", "type": "application/json"}
+  {"rel": "root", "href": "../catalog.json", "type": "application/json"},
+  {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
+  {"rel": "self", "href": "./catalog.json", "type": "application/json"},
+  {"rel": "child", "href": "./air-quality/collection.json", "type": "application/json", "title": "Air Quality"}
 ]
 ```
 

--- a/examples/tabular-collection.json
+++ b/examples/tabular-collection.json
@@ -3,7 +3,7 @@
   "stac_version": "1.1.0",
   "id": "eurostat-electricity-prices",
   "title": "Industrial electricity prices by country",
-  "description": "Half-yearly industrial electricity prices (EUR/kWh, including taxes) by European country. Non-geospatial tabular dataset. Source: Eurostat nrg_pc_205.",
+  "description": "Half-yearly industrial electricity prices (EUR/kWh, including taxes) by European country. Non-geospatial tabular data. Source: Eurostat nrg_pc_205.",
   "license": "CC-BY-4.0",
   "portolan:geospatial": false,
   "stac_extensions": [

--- a/extensions.md
+++ b/extensions.md
@@ -10,15 +10,17 @@ These extensions are recognized as importable geospatial data:
 |-----------|--------|------|--------------|-------|
 | `.parquet` | GeoParquet | Vector | Yes | Requires geo metadata (content inspection) |
 | `.geojson` | GeoJSON | Vector | No | Converts to GeoParquet |
-| `.json` | GeoJSON | Vector | No | Content inspected for GeoJSON structure |
+| `.json` | JSON | Vector | No | Content-inspected: GeoJSON → GeoParquet; STAC metadata and other JSON are skipped |
 | `.shp` | Shapefile | Vector | No | Converts to GeoParquet |
 | `.gpkg` | GeoPackage | Vector | No | Converts to GeoParquet |
+| `.gdb` | FileGDB (Esri) | Vector | No | Directory format; converts all layers to GeoParquet |
 | `.fgb` | FlatGeobuf | Vector | Yes | Cloud-native, passed through |
 | `.csv` | CSV | Vector/Tabular | No | Content inspected: geometry columns → GeoParquet; no geometry → tabular (if enabled) |
+| `.tsv` | TSV | Vector/Tabular | No | Content inspected: geometry columns → GeoParquet; no geometry → tabular (if enabled) |
 | `.tif`, `.tiff` | GeoTIFF/COG | Raster | Depends | Content inspected for COG compliance |
 | `.jp2` | JPEG2000 | Raster | No | Converts to COG |
 
-Files with these extensions are candidates for `portolan dataset add`.
+Files with these extensions are candidates for `portolan add`.
 
 ### Non-Cloud-Native Format Handling
 
@@ -43,10 +45,21 @@ Some formats require content inspection to determine type and cloud-native statu
 - **`.csv`**: Checked for geometry columns (lat/lon, WKT, WKB)
   - If geometry columns found → GeoParquet conversion
   - If no geometry columns → tabular (requires `tabular.enabled: true`)
-- **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry)
+- **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry). STAC metadata (identified by `stac_version`) is **not** GeoJSON and is skipped.
 - **`.tif`/`.tiff`**: Validated against COG spec (internal tiling, overviews)
 
 Files that fail content inspection are treated as convertible (vector), tabular (if enabled), or rejected (raster without geo info).
+
+## Additional Cloud-Native Formats
+
+These are already cloud-native and passed through without conversion, but they
+are not plain single-suffix files, so they are recognized by dedicated handling
+rather than a simple extension lookup:
+
+| Extension | Format | Type | Notes |
+|-----------|--------|------|-------|
+| `.zarr` | Zarr | Raster/Array | Directory store; recognized as a directory, not a file extension |
+| `.copc.laz` | COPC | Point cloud | Compound extension; cloud-optimized point cloud. Distinct from plain `.las`/`.laz` (unsupported, see below) |
 
 ## Sidecar Files
 
@@ -58,11 +71,13 @@ These extensions are recognized as sidecar files belonging to a primary asset:
 | `.shx` | Shapefile index |
 | `.prj` | Shapefile projection |
 | `.cpg` | Shapefile code page |
-| `.sbn`, `.sbx` | Shapefile spatial index |
+| `.sbn`, `.sbx` | Shapefile spatial index (Esri) |
+| `.qix` | Shapefile spatial index (QGIS/GDAL) |
 | `.ovr` | Raster overview (pyramid) |
+| `.tfw` | Raster world file (georeferencing) |
 | `.xml` | Auxiliary metadata (aux.xml, etc.) |
 
-Sidecar files are **not** imported directly. When importing a `.shp` file, its sidecars are read automatically.
+Sidecar files are **not** imported directly. When importing a `.shp` file, its sidecars are read automatically. Compound sidecar names (e.g. `.shp.xml`, `.aux.xml`) are matched by appending the pattern to the primary file's stem; a bare `.xml` also catches them since `Path.suffix` returns only the last extension.
 
 ## Visualization Formats
 
@@ -82,25 +97,27 @@ These are **derivatives**, not primary data. PMTiles **SHOULD** be generated fro
 | `versions.json` | Portolan version manifest |
 | `styles/*.json` | Mapbox GL / MapLibre style definitions (see [best-practices.md#visualization-styles](best-practices.md#visualization-styles)) |
 
-These files have semantic meaning and are not imported as datasets.
+These files have semantic meaning and are not imported as data.
 
 ## Thumbnail/Preview
 
 | Extension | Handling |
 |-----------|----------|
-| `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif` | Treated as thumbnails if < 1 MiB (1,048,576 bytes) |
+| `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.svg` | Treated as thumbnails if < 1 MiB (1,048,576 bytes) |
 
 Small images are assumed to be previews, not raster data.
 
 ## Unsupported Formats
 
-These formats are explicitly rejected with informative error messages:
+These formats are explicitly rejected with informative error messages. They are
+still assigned a media type so that, if present as companion files, assets remain
+well-typed.
 
-| Extension | Format | Reason |
-|-----------|--------|--------|
-| `.nc`, `.netcdf` | NetCDF | Not yet supported |
-| `.h5`, `.hdf5` | HDF5 | Not yet supported |
-| `.las`, `.laz` | LAS/LAZ | Use COPC format instead |
+| Extension | Format | Media Type | Reason |
+|-----------|--------|------------|--------|
+| `.nc`, `.netcdf` | NetCDF | `application/x-netcdf` | Not yet supported |
+| `.h5`, `.hdf5` | HDF5 | `application/x-hdf5` | Not yet supported |
+| `.las`, `.laz` | LAS/LAZ | `application/vnd.las`, `application/vnd.laszip` | Plain point clouds; use COPC (`.copc.laz`) instead |
 
 ## Tabular Formats
 
@@ -134,7 +151,7 @@ The following are skipped during directory scans:
 ## Extension vs. Role
 
 STAC uses **asset roles** to describe purpose, not file extensions. The extensions above are used for:
-1. **Import classification** — determining if a file can be added as a dataset
+1. **Import classification** — determining if a file can be added as data
 2. **Format detection** — deciding which conversion pipeline to use
 
 Once imported, the STAC asset's `roles` field (e.g., `["data"]`, `["thumbnail"]`) provides machine-readable semantics.

--- a/formats/pointcloud.md
+++ b/formats/pointcloud.md
@@ -8,4 +8,4 @@
 
 ## Status
 
-This format addendum is a stub. Full requirements will be developed after completing a reference point cloud dataset implementation.
+This format addendum is a stub. Full requirements will be developed after completing a reference point cloud implementation.

--- a/formats/raster.md
+++ b/formats/raster.md
@@ -8,4 +8,4 @@
 
 ## Status
 
-This format addendum is a stub. Full requirements will be developed after completing a reference raster dataset implementation.
+This format addendum is a stub. Full requirements will be developed after completing a reference raster implementation.

--- a/formats/tabular.md
+++ b/formats/tabular.md
@@ -1,6 +1,6 @@
 # Tabular (Non-Geospatial) Data Format Requirements
 
-Portolan supports **non-geospatial tabular datasets** as companion data alongside geospatial layers. This enables catalogs to include tables keyed by time, administrative code, or category rather than by location.
+Portolan supports **non-geospatial tabular data** as companion data alongside geospatial layers. This enables catalogs to include tables keyed by time, administrative code, or category rather than by location.
 
 ## Scope
 

--- a/formats/vector.md
+++ b/formats/vector.md
@@ -9,7 +9,7 @@
 
 ## Collection-Level Assets
 
-When a vector dataset is represented as a single file (GeoParquet, FlatGeobuf, or any other supported format), it **MUST** be represented as a collection-level asset rather than wrapped in a STAC item. The item indirection adds no value for single-file datasets.
+When vector data is represented as a single file (GeoParquet, FlatGeobuf, or any other supported format), it **MUST** be represented as a collection-level asset rather than wrapped in a STAC item. The item indirection adds no value for single-file data.
 
 ```json
 {
@@ -43,18 +43,18 @@ tunnels/
 
 No item directory or item JSON is needed.
 
-## Partitioned Datasets
+## Partitioned Collections
 
 GeoParquet files larger than approximately 2 GB **SHOULD** be spatially partitioned into multiple files, following the guidance in [Best Practices for Distributing GeoParquet](https://github.com/opengeospatial/geoparquet/blob/main/format-specs/distributing-geoparquet.md#spatial-partitioning).
 
-When a dataset is partitioned:
+When a collection is partitioned:
 
 - Each partition file **MUST** be represented as a STAC item within the collection, with its spatial extent (bbox) reflecting the data in that partition.
-- The collection description **SHOULD** include the glob pattern that tools can use to access all partitions as a single dataset, since most users want a single URL they can pass to their analysis tools rather than enumerating STAC items. For example:
+- The collection description **SHOULD** include the glob pattern that tools can use to access all partitions at once, since most users want a single URL they can pass to their analysis tools rather than enumerating STAC items. For example:
 
   > Access all partitions: `s3://bucket/buildings/*.parquet`
 
-### Directory Layout for Partitioned Datasets
+### Directory Layout for Partitioned Collections
 
 ```
 buildings/
@@ -74,7 +74,7 @@ Each partition file also has a corresponding STAC item linked from the collectio
   - Optimized for web map rendering
   - Cloud-native, range-request friendly
   - PMTiles **MUST** be represented as a collection-level asset, not only at the item level — this ensures the visualization derivative is always discoverable alongside the data without navigating into items
-  - When PMTiles are provided, **MUST** add a `rel: "pmtiles"` link following the [web-map-links](https://github.com/stac-extensions/web-map-links) STAC extension
+  - When PMTiles are provided, **MUST** add a collection-level `rel: "pmtiles"` link following the [web-map-links](https://github.com/stac-extensions/web-map-links) STAC extension (v1.3.0). The link uses `type: "application/vnd.pmtiles"`, carries a `pmtiles:layers` array of default-visible vector layers, and the collection **MUST** declare `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json` in `stac_extensions`. The link and the PMTiles asset coexist
 
 ## Styling
 

--- a/schema/catalog-versions.schema.json
+++ b/schema/catalog-versions.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/catalog-versions.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan Catalog Versions Index",
   "description": "Schema for the root-level versions.json that indexes collection sync state. Different from collection-level versions.json.",
   "type": "object",
@@ -24,21 +24,41 @@
       "description": "ISO 8601 timestamp when catalog was initialized",
       "format": "date-time"
     },
+    "updated": {
+      "type": "string",
+      "description": "ISO 8601 timestamp when catalog data was last updated (i.e. the last `add`). Distinct from per-collection `synced_at`, which tracks the last push to cloud storage.",
+      "format": "date-time"
+    },
     "collections": {
       "type": "object",
-      "description": "Map of collection IDs to their sync state",
+      "description": "Map of collection IDs to their state",
       "additionalProperties": {
         "type": "object",
-        "description": "Collection sync state",
+        "description": "Per-collection state",
         "properties": {
           "current_version": {
             "type": ["string", "null"],
             "description": "Current version of this collection"
           },
+          "updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this collection's data was last updated locally (i.e. the last `add`)"
+          },
           "synced_at": {
             "type": "string",
             "format": "date-time",
-            "description": "When this collection was last synced"
+            "description": "When this collection was last synced to cloud storage (i.e. the last `push`)"
+          },
+          "asset_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of assets in the current version of this collection"
+          },
+          "total_size_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total size in bytes of the assets in the current version of this collection"
           }
         }
       }

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/catalog.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan STAC Catalog",
   "description": "Schema for Portolan-compliant STAC Catalogs. Extends the STAC Catalog schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [

--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/collection.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan STAC Collection",
   "description": "Schema for Portolan-compliant STAC Collections. Extends the STAC Collection schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [

--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -19,7 +19,7 @@
 # spec/schema/spec-version.json; see spec/README.md#versioning for the bump
 # policy (e.g. raising a rule's level from warning to error is a breaking
 # change and bumps the spec version).
-spec_version: "0.1.0"
+spec_version: "0.1.1"
 
 rules:
   # =============================================================================
@@ -114,7 +114,7 @@ rules:
       else:
         assert versions is empty
     references:
-      - versions.md#current-version
+      - versions.md#root-level
 
   - id: RULE-0013
     level: error
@@ -242,22 +242,27 @@ rules:
   - id: RULE-0041
     level: error
     scope: catalog
-    description: Catalog MUST have flat hierarchy (no nested sub-collections)
+    description: Collections MUST be leaves; a collection MUST NOT contain a child collection
     rationale: |
-      Flat hierarchy simplifies tooling and versioning boundaries.
+      Hierarchy is built from nested catalogs, not nested collections (ADR-0032).
+      Intermediate levels are catalogs; collections are always leaves. Keeping
+      collections flat preserves STAC API compatibility (APIs index collections
+      flat) while catalogs above them provide thematic organization.
     validation: |
       For each collection in catalog:
-        assert collection has no child collections
-        # Collections contain items directly
+        for link in collection.links where link.rel == "child":
+          assert link points to a catalog.json, not a collection.json
+        # Collections hold assets or item subdirs directly, never child collections
     references:
-      - structure.md#flat-hierarchy
+      - structure.md#nested-catalogs-flat-collections
+      - ../context/shared/adr/0032-nested-catalogs-with-flat-collections.md
 
   - id: RULE-0042
     level: error
     scope: collection
-    description: Single-file datasets MUST be collection-level assets
+    description: Single-file collections MUST use collection-level assets
     rationale: |
-      Item indirection adds no value for single-file datasets.
+      Item indirection adds no value for single-file collections.
     validation: |
       If collection contains exactly one data file:
         assert file is in collection.assets, not wrapped in item
@@ -327,14 +332,21 @@ rules:
   - id: RULE-0061
     level: error
     scope: collection
-    description: PMTiles MUST have rel="pmtiles" link when provided
+    description: PMTiles MUST have a rel="pmtiles" web-map-links link when provided
     rationale: |
-      Follows web-map-links STAC extension for discoverability.
+      Follows the web-map-links STAC extension (v1.3.0) for discoverability: the
+      PMTiles derivative must be reachable as a collection-level link, not only as
+      an asset. The link and the asset coexist.
     validation: |
       If collection has PMTiles asset:
         assert any link has rel="pmtiles"
+        assert that link has type="application/vnd.pmtiles"
+        assert "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json"
+               in collection.stac_extensions
     references:
       - formats/vector.md#recommended-formats
+      - https://github.com/stac-extensions/web-map-links
+    code_rule: pmtiles_link
 
   # =============================================================================
   # Visualization Styles Rules
@@ -380,7 +392,7 @@ rules:
         for style_key in collection["portolan:styles"]:
           assert style_key in collection.assets
     references:
-      - best-practices.md#portolan-styles-manifest
+      - best-practices.md#portolanstyles-manifest
 
   - id: RULE-0068
     level: error
@@ -440,7 +452,7 @@ rules:
           assert file exists at link.href
     references:
       - ai-integration.md
-      - core.md#ai-llm-integration
+      - core.md#ai--llm-integration
 
   - id: RULE-0081
     level: error
@@ -448,7 +460,7 @@ rules:
     description: Collections MUST include llms.txt link
     rationale: |
       Collection-level llms.txt provides everything an agent needs to work
-      with a specific dataset: schema docs, query examples, data quality notes.
+      with a specific collection: schema docs, query examples, data quality notes.
     validation: |
       For each collection.json:
         assert any link has rel="llms"
@@ -458,7 +470,7 @@ rules:
           assert file exists at link.href
     references:
       - ai-integration.md
-      - core.md#ai-llm-integration
+      - core.md#ai--llm-integration
 
   - id: RULE-0082
     level: warning
@@ -469,7 +481,7 @@ rules:
       Missing key sections reduce the file's value to AI agents.
     validation: |
       For catalog llms.txt:
-        warn if file does not mention collections or datasets
+        warn if file does not mention collections or items
         warn if no code examples present
         warn if no license information present
     references:
@@ -569,7 +581,7 @@ rules:
     scope: collection
     description: Tabular collections MUST use collection-level assets
     rationale: |
-      Single-file tabular datasets should not be wrapped in STAC items.
+      Single-file tabular data should not be wrapped in STAC items.
       Collection-level assets are simpler and match the vector data pattern.
     validation: |
       If the collection is tabular (portolan:geospatial == false, or detected as
@@ -750,7 +762,7 @@ rules:
     description: Partitioned collections SHOULD have consistent Hive-style structure
     rationale: |
       Mixed partition keys, orphan data files at the collection root, or a
-      missing partition:scheme make a partitioned dataset ambiguous to query
+      missing partition:scheme make a partitioned collection ambiguous to query
       engines that rely on the Hive key=value convention.
     validation: |
       For each collection with key=value partition directories:
@@ -758,7 +770,7 @@ rules:
         warn if there are orphan .parquet files at the collection root
         warn if collection.json is missing the partition:scheme field
     references:
-      - formats/vector.md#partitioned-datasets
+      - formats/vector.md#partitioned-collections
     code_rule: partition_structure
 
   - id: RULE-0131
@@ -773,5 +785,5 @@ rules:
         read the Parquet schema (footer) of every partition file
         assert all files share the same set of column names
     references:
-      - formats/vector.md#partitioned-datasets
+      - formats/vector.md#partitioned-collections
     code_rule: partition_schema_consistency

--- a/schema/spec-version.json
+++ b/schema/spec-version.json
@@ -2,7 +2,7 @@
   "$id": "https://portolan.dev/schema/spec-version.json",
   "title": "Portolan Specification Version",
   "description": "Canonical machine-readable home for the Portolan specification version. Tools (the CLI, the read-only mirror, reis, and external conformance checkers) read spec_version from this file to claim or verify conformance against a specific version of the Portolan spec. See spec/README.md#versioning for the bump policy. This is distinct from the versions.json manifest schema version (versions.schema.json).",
-  "spec_version": "0.1.0",
+  "spec_version": "0.1.1",
   "versioning": "semver",
   "stability": "pre-release",
   "policy": "https://github.com/portolan-sdi/portolan-cli/blob/main/spec/README.md#versioning"

--- a/schema/versions.schema.json
+++ b/schema/versions.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/versions.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan Versions Manifest",
   "description": "Schema for versions.json - tracks version history, asset checksums, and sync state per collection. See https://github.com/portolan-sdi/portolan-spec/blob/main/versions.md",
   "type": "object",
@@ -115,6 +115,16 @@
           "type": "number",
           "minimum": 0,
           "description": "Optional Unix timestamp of the asset file itself. Used for fast-path change detection (ADR-0017). NOTE: Accepts number (not just integer) because Python's os.stat().st_mtime returns floats. This relaxation should be upstreamed to portolan-spec."
+        },
+        "feature_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional feature/row count (pixel count for rasters) captured when the asset was tracked. Freshness heuristic (ADR-0017): lets a touched-but-identical asset read fresh instead of stale."
+        },
+        "schema_fingerprint": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional hash of the asset schema captured when the asset was tracked. Freshness heuristic (ADR-0017): a change indicates a breaking schema change."
         }
       }
     },

--- a/structure.md
+++ b/structure.md
@@ -37,13 +37,13 @@ Only Portolan-internal tooling configuration lives in `.portolan/`. STAC metadat
 
 ## Collection Level
 
-Each collection is a top-level subdirectory of the project root, named with the collection ID.
+Each collection lives in a subdirectory named with its collection ID. For a nested collection the ID is a POSIX path (e.g. `environment/air-quality`) and the directory sits under one or more intermediate catalog directories (see [Nested Catalogs, Flat Collections](#nested-catalogs-flat-collections)).
 
 | File | Required | Description |
 |------|----------|-------------|
 | `collection.json` | **MUST** | STAC Collection metadata |
 | `versions.json` | **MUST** | Version history and checksums (see [versions.md](versions.md)) |
-| `{item_id}/` | — | One directory per dataset item |
+| `{item_id}/` | — | One directory per item |
 
 Collection IDs **SHOULD**:
 - Contain only lowercase letters, numbers, hyphens, and underscores
@@ -69,7 +69,7 @@ When a collection contains a single data file (e.g., one GeoParquet file), the d
 
 ## Item Level
 
-Items are used when a collection contains multiple data files — for example, partitioned datasets or multi-file raster mosaics.
+Items are used when a collection contains multiple data files — for example, partitioned collections or multi-file raster mosaics.
 
 Each item is a subdirectory of the collection named with the item ID.
 
@@ -81,20 +81,40 @@ Each item is a subdirectory of the collection named with the item ID.
 
 Item IDs are derived from the item directory name. By convention, item directories **SHOULD** be named after the primary data file's stem (e.g., source file `census.shp` goes into item directory `census/`).
 
-## Flat Hierarchy
+## Nested Catalogs, Flat Collections
 
-Portolan catalogs use a **flat hierarchy**: collections contain items directly, with no nested sub-collections.
+Portolan organizes hierarchy with **nested catalogs**, not nested collections ([ADR-0032](../context/shared/adr/0032-nested-catalogs-with-flat-collections.md)). Intermediate levels are catalogs (`catalog.json`); collections are always leaves. A collection **MUST NOT** contain a child collection. This keeps collections flat for STAC API compatibility while still allowing thematic organization above them.
+
+Directory mapping:
+
+| Directory | File | Role |
+|-----------|------|------|
+| Root | `catalog.json` | Root catalog |
+| Level above a collection | `catalog.json` | Intermediate (thematic) catalog |
+| Data directory | `collection.json` | Leaf collection (holds vector assets or item subdirs) |
+| Subdirectory within a collection | `catalog.json` | Organizes many items below a collection |
+
+A nested collection's ID is its POSIX path from the catalog root (e.g. `environment/air-quality`). `portolan add` writes a `catalog.json` at each intermediate level and links parent → child down to the leaf `collection.json`.
 
 ```
-# Correct (flat)
-census-2020/tracts/tracts.parquet
-census-2020/blocks/blocks.parquet
+# Correct: intermediate levels are catalogs, collections are leaves
+environment/
+├── catalog.json                 ← intermediate catalog
+├── air-quality/
+│   ├── collection.json          ← leaf collection (data)
+│   └── pm25.parquet
+└── water-quality/
+    ├── collection.json          ← leaf collection (data)
+    └── turbidity.parquet
 
-# Incorrect (nested)
-census/2020/tracts/tracts.parquet
+# Incorrect: a collection containing a child collection
+environment/
+├── collection.json              ← collection with a child collection (not allowed)
+└── air-quality/
+    └── collection.json
 ```
 
-This simplifies tooling and avoids ambiguity about where versioning boundaries lie.
+Deep nesting is allowed; each level above the leaf is a catalog. Catalogs may also appear *below* a collection to organize its items (for example, a raster collection grouping items by year).
 
 ## STAC Conventions
 
@@ -111,7 +131,7 @@ Portolan catalogs **MUST** be saved as `SELF_CONTAINED` (pystac terminology), me
 | Catalog ID | `portolan-catalog` |
 | Collection license | `other` (STAC 1.1 keyword for a license not covered by SPDX; add a `rel="license"` link when the concrete license is known) |
 
-These defaults can be overridden during catalog creation or dataset import.
+These defaults can be overridden during catalog creation or import.
 
 ## Examples
 

--- a/versions.md
+++ b/versions.md
@@ -87,6 +87,11 @@ The collection directory name **MUST NOT** appear in the asset key. The asset ke
 | `sha256` | string | **MUST** | SHA-256 checksum of the file content |
 | `size_bytes` | integer | **MUST** | File size in bytes |
 | `href` | string | **MUST** | Catalog-root-relative path to the asset (e.g., `"boundaries/districts/districts.parquet"`) |
+| `source_path` | string | *MAY* | Relative path to the original source file (e.g., the GeoJSON converted to this GeoParquet) |
+| `source_mtime` | number | *MAY* | Unix timestamp of the source file when conversion occurred; used to detect when the source has changed |
+| `mtime` | number | *MAY* | Unix timestamp of the asset file itself; fast-path change detection (ADR-0017) |
+| `feature_count` | integer | *MAY* | Feature/row count (pixel count for rasters) when tracked; freshness heuristic (ADR-0017) |
+| `schema_fingerprint` | string | *MAY* | Hash of the asset schema when tracked; a change indicates a breaking schema change (ADR-0017) |
 
 ## Versioning Rules
 


### PR DESCRIPTION
Automated spec sync from portolan-cli.

**Source commit:** portolan-sdi/portolan-cli@ebda48355ba7ca06b5e8c38d267ea53384156861
**Triggered by:** fix: collection-level asset freshness — check reports STALE that --fix/add cannot clear (#512) (#606)

* fix: persist freshness heuristics for collection-level assets so check clears (#512)

`portolan check` reported `metadata_fresh: N stale` for collection-level vector
assets (ADR-0031) that neither `check --metadata --fix` nor `portolan add .`
could clear — violating the scan-check invariant that check must never report
an issue `--fix` cannot resolve.

Root cause: `_batch_update_versions` wrote only the `mtime` field to a
collection-level asset's versions.json entry, but the freshness check
(`_check_collection_level_asset`) read `source_mtime` as its baseline — never
written for these assets — so `stored_mtime` was None → `is_stale` → "new_file"
→ perpetual STALE. `--fix` skips collection-level assets by design and re-`add`
sees the file unchanged, so nothing backfilled it. The heuristic fields the
check also reads (`feature_count`, `schema_fingerprint`) were written by no code
path and forbidden by the versions.json schema.

Fix (both halves):
- Read side (metadata/scan.py): use `source_mtime ?? mtime` as the freshness
  baseline so existing catalogs (which already carry `mtime`) read FRESH with no
  re-add; only escalate to BREAKING when a stored `schema_fingerprint` actually
  exists to compare against, so a mtime-only entry degrades to STALE, never a
  blocking BREAKING.
- Write side: add optional `feature_count` + `schema_fingerprint` to the `Asset`
  model (serialize/parse, both backends) and persist `source_mtime` + heuristics
  for collection-level freshness-checkable assets in `_batch_update_versions`, so
  newly-added catalogs survive clone/touch (touched-but-identical → FRESH).
  `update_versions_tracking` now preserves these on `--fix`.
- Spec (ADR-0048): versions.schema.json gains the two optional AssetEntry fields
  and versions.md documents them.

Tests: real add → scan → FRESH (the true regression, red before), an
existing-catalog mtime-only entry reads FRESH, a heuristic-less entry never
escalates to BREAKING, and Asset heuristic round-trips.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

* fix: heal cloned/touched collection-level assets via content-hash fallback (#512)

Adversarial-review follow-up to the #512 freshness fix. The read-side
`source_mtime ?? mtime` fallback only heals catalogs whose asset files still
carry their original add-time mtime. A `git clone` / checkout / `cp -r` resets
mtimes, so a pre-fix (mtime-only, no heuristic baseline) entry then has
`current_mtime != stored_mtime`; with no stored `schema_fingerprint`,
`is_stale` forces STALE. That STALE is unclearable: `--fix` skips
collection-level assets ("re-run add"), and a plain `add` skips too because
`is_current`'s sha256 slow-path sees identical content — re-violating the
scan-check invariant for the common clone workflow. Only `add --force` cleared
it.

Fix (`_check_collection_level_asset`): when there is no schema-fingerprint
baseline, fall back to comparing the stored `sha256` against the asset's
content hash — the same tiebreaker `is_current` uses — so a byte-identical
asset reads FRESH. `check` and `add` now agree by construction, and every
remaining STALE corresponds to a real content change a plain `add` will pick
up (so the existing fix hints are correct). Gated on the missing baseline so
newer (heuristic-carrying) catalogs never pay the hash; files only, so
directory assets fall through to the mtime path.

Also make `update_versions_tracking` internally consistent: refresh `mtime`
alongside `source_mtime` (both now describe the current file) instead of
leaving a current `source_mtime` next to a stale `mtime`.

Tests: touched-but-identical mtime-only entry reads FRESH (RED before the
fallback, GREEN after); a genuinely changed asset is not masked as FRESH.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---------

Co-authored-by: agent-farm <agent-farm@users.noreply.github.com>
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

The portolan-cli repository is the source of truth for the Portolan
specification. This PR syncs changes from `portolan-cli/spec/` to
the portolan-spec mirror.

See [ADR-0048](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0048-cli-as-spec-source.md) for rationale.

---
_Auto-generated by [sync-spec](https://github.com/portolan-sdi/portolan-cli/blob/main/.github/workflows/sync-spec.yml)_