### PR TITLE
sync: Update spec from portolan-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cloud-native geospatial data.
   - [Point clouds](formats/pointcloud.md)
   - [Tabular (non-geospatial) data](formats/tabular.md)
 - [Best practices](best-practices.md) - Recommended conventions
-- [AI & LLM integration](ai-integration.md) - llms.txt requirements for agent discoverability
+- [AI & LLM integration](ai-integration.md) - AGENTS.md requirements for agent discoverability
 
 ## Architectural Decisions
 
@@ -41,7 +41,7 @@ Spec-related decisions are tracked in the CLI repository's ADR directory:
 - [ADR-0049: STAC-GeoParquet as Scalability Requirement](../context/shared/adr/0049-stac-geoparquet-scalability.md)
 - [ADR-0050: PMTiles as Visualization Requirement](../context/shared/adr/0050-pmtiles-visualization-requirement.md)
 - [ADR-0051: SELF_CONTAINED Catalog Type](../context/shared/adr/0051-self-contained-catalog-type.md)
-- [ADR-0052: Require llms.txt for AI/LLM Integration](../context/shared/adr/0052-llms-txt-requirement.md)
+- [ADR-0052: Require AGENTS.md for AI/LLM Integration](../context/shared/adr/0052-llms-txt-requirement.md)
 
 For all architectural decisions, see [context/shared/adr/](../context/shared/adr/).
 

--- a/ai-integration.md
+++ b/ai-integration.md
@@ -2,20 +2,20 @@
 
 This section covers practices for making Portolan catalogs discoverable and usable by AI agents and large language models. This is a rapidly evolving area — the recommendations here represent early patterns that have proven effective and will be refined as the community gains experience.
 
-## llms.txt
+## AGENTS.md
 
-[llms.txt](https://llmstxt.org/) is an emerging standard for providing LLM-friendly documentation alongside web resources. In Portolan, every catalog and collection includes an `llms.txt` file that gives AI agents the context they need to discover, understand, and query the data.
+[AGENTS.md](https://agents.md/) is an emerging cross-tool standard for a Markdown file that gives AI agents the context they need to work with a project. In Portolan, every catalog and collection includes an `AGENTS.md` file that gives AI agents the context they need to discover, understand, and query the data. (Portolan previously used `llms.txt` for this role; `AGENTS.md` replaces it.)
 
 ### Requirements
 
-Every catalog and collection **MUST** include an `llms.txt` file in markdown format.
+Every catalog and collection **MUST** include an `AGENTS.md` file in Markdown format.
 
-The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
+The `AGENTS.md` file **MUST** be referenced in the STAC JSON `links` array:
 
 ```json
 {
-  "rel": "llms",
-  "href": "./llms.txt",
+  "rel": "agents",
+  "href": "./AGENTS.md",
   "type": "text/markdown",
   "title": "Agent/LLM usage guide"
 }
@@ -23,26 +23,26 @@ The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
 
 - The `href` **MUST** use a relative path (consistent with `SELF_CONTAINED` catalog type)
 - The `type` **MUST** be `text/markdown`
-- `llms.txt` is a **link**, not an asset — it describes the data, it is not the data itself
+- `AGENTS.md` is a **link**, not an asset — it describes the data, it is not the data itself
 
 ### Content Recommendations
 
-These recommendations are early and expected to evolve. They reflect patterns that have worked well in practice but are not exhaustive.
+The requirement is only that `AGENTS.md` exist and be linked — its content is open-ended. The recommendations below are early and expected to evolve; they reflect patterns that have worked well in practice but are not exhaustive. Favor content that is **not already in the README** and that helps an agent use the data.
 
-#### Catalog-Level llms.txt
+#### Catalog-Level AGENTS.md
 
-A catalog-level `llms.txt` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
+A catalog-level `AGENTS.md` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
 
 - A summary of what the catalog contains and who publishes it
 - A list of all collections with brief descriptions (what each contains, feature count, key fields)
 - Data access patterns (base URLs, S3 paths, code examples)
 - Coordinate system conventions used across the catalog
 - License information
-- Pointers to collection-level `llms.txt` files for detailed documentation
+- Pointers to collection-level `AGENTS.md` files for detailed documentation
 
-#### Collection-Level llms.txt
+#### Collection-Level AGENTS.md
 
-A collection-level `llms.txt` provides everything an AI agent needs to work with a specific collection. It **SHOULD** include:
+A collection-level `AGENTS.md` provides everything an AI agent needs to work with a specific collection. It **SHOULD** include:
 
 - **What the collection is** — a plain-language description, including source, provider, and license
 - **How to access the data** — URLs and working code examples for loading the data (e.g., DuckDB SQL, Python)

--- a/core.md
+++ b/core.md
@@ -11,11 +11,11 @@ project/
 ├── .portolan/
 │   └── config.yaml
 ├── catalog.json
-├── llms.txt
+├── AGENTS.md
 ├── versions.json
 └── {collection_id}/
     ├── collection.json
-    ├── llms.txt
+    ├── AGENTS.md
     ├── versions.json
     └── {item_id}/
         └── data.parquet
@@ -137,8 +137,8 @@ This is standard STAC practice for provenance and enables consumers to trace dat
 
 ## AI & LLM Integration
 
-- **MUST** include an `llms.txt` file at both the catalog root and each collection directory
-- **MUST** link `llms.txt` in the STAC JSON `links` array with `rel: "llms"`
+- **MUST** include an `AGENTS.md` file at both the catalog root and each collection directory
+- **MUST** link `AGENTS.md` in the STAC JSON `links` array with `rel: "agents"`
 
 See [ai-integration.md](ai-integration.md) for full requirements and content recommendations.
 

--- a/examples/tabular-collection.json
+++ b/examples/tabular-collection.json
@@ -71,8 +71,8 @@
       "type": "application/json"
     },
     {
-      "rel": "llms",
-      "href": "./llms.txt",
+      "rel": "agents",
+      "href": "./AGENTS.md",
       "type": "text/markdown",
       "title": "Agent/LLM usage guide"
     },

--- a/formats/tabular.md
+++ b/formats/tabular.md
@@ -161,7 +161,7 @@ When conversion is enabled (`tabular.convert: true`), both the source file and c
 eurostat-electricity-prices/
   collection.json
   versions.json
-  llms.txt
+  AGENTS.md
   electricity-prices.parquet
   electricity-prices.csv        (source, if converted)
 ```
@@ -214,7 +214,7 @@ No item directory or item JSON is needed.
     {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
     {"rel": "self", "href": "./collection.json", "type": "application/json"},
     {"rel": "version-history", "href": "./versions.json", "type": "application/json"},
-    {"rel": "llms", "href": "./llms.txt", "type": "text/markdown", "title": "Agent/LLM usage guide"},
+    {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown", "title": "Agent/LLM usage guide"},
     {
       "rel": "via",
       "href": "https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_205/default/table",
@@ -236,4 +236,4 @@ For tabular collections:
 - **No spatial extent requirement** — `extent.spatial` is optional
 - **No geometry validation** — there is no geometry to validate
 
-All other Portolan core requirements apply unchanged: absolute S3 asset hrefs (when published), relative STAC links, `providers`, provenance via `rel: "via"`, `README.md`, `llms.txt`, and `versions.json` tracking.
+All other Portolan core requirements apply unchanged: absolute S3 asset hrefs (when published), relative STAC links, `providers`, provenance via `rel: "via"`, `README.md`, `AGENTS.md`, and `versions.json` tracking.

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -42,10 +42,18 @@
         },
         "links": {
           "type": "array",
-          "description": "Catalog links. MUST use relative paths (SELF_CONTAINED catalog type).",
+          "description": "Catalog links. MUST use relative paths (SELF_CONTAINED catalog type). MUST contain a rel='agents' AGENTS.md link (RULE-0080).",
           "items": {
             "$ref": "#/$defs/CatalogLink"
-          }
+          },
+          "contains": {
+            "type": "object",
+            "properties": {
+              "rel": { "const": "agents" }
+            },
+            "required": ["rel"]
+          },
+          "minContains": 1
         }
       }
     },
@@ -57,7 +65,7 @@
         "rel": {
           "type": "string",
           "description": "Link relation type",
-          "examples": ["root", "self", "child", "parent", "item", "llms"]
+          "examples": ["root", "self", "child", "parent", "item", "agents"]
         },
         "href": {
           "type": "string",
@@ -118,18 +126,18 @@
         {
           "if": {
             "properties": {
-              "rel": { "const": "llms" }
+              "rel": { "const": "agents" }
             },
             "required": ["rel"]
           },
           "then": {
-            "description": "LLM integration link - MUST point to llms.txt with text/markdown type",
+            "description": "AI/agent integration link - MUST point to AGENTS.md with text/markdown type",
             "required": ["type"],
             "properties": {
               "href": {
                 "type": "string",
-                "pattern": "(^|/)llms\\.txt$",
-                "description": "Must point to llms.txt file"
+                "pattern": "(^|/)AGENTS\\.md$",
+                "description": "Must point to AGENTS.md file"
               },
               "type": {
                 "const": "text/markdown"

--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -51,10 +51,18 @@
         },
         "links": {
           "type": "array",
-          "description": "Collection links with Portolan requirements. SHOULD include version-history link (see RULE-0070 in rules.yaml).",
+          "description": "Collection links with Portolan requirements. SHOULD include version-history link (see RULE-0070 in rules.yaml). MUST contain a rel='agents' AGENTS.md link (RULE-0081).",
           "items": {
             "$ref": "#/$defs/CollectionLink"
-          }
+          },
+          "contains": {
+            "type": "object",
+            "properties": {
+              "rel": { "const": "agents" }
+            },
+            "required": ["rel"]
+          },
+          "minContains": 1
         },
         "assets": {
           "type": "object",
@@ -157,12 +165,12 @@
         {
           "if": {
             "properties": {
-              "rel": { "const": "llms" }
+              "rel": { "const": "agents" }
             },
             "required": ["rel"]
           },
           "then": {
-            "$ref": "#/$defs/LlmsLink"
+            "$ref": "#/$defs/AgentsLink"
           }
         }
       ]
@@ -184,17 +192,17 @@
       },
       "required": ["rel", "href"]
     },
-    "LlmsLink": {
+    "AgentsLink": {
       "type": "object",
-      "description": "Link to llms.txt for AI/LLM integration - MUST be present",
+      "description": "Link to AGENTS.md for AI/agent integration - MUST be present",
       "properties": {
         "rel": {
-          "const": "llms"
+          "const": "agents"
         },
         "href": {
           "type": "string",
-          "pattern": "(^|/)llms\\.txt$",
-          "description": "Must point to llms.txt file"
+          "pattern": "(^|/)AGENTS\\.md$",
+          "description": "Must point to AGENTS.md file"
         },
         "type": {
           "const": "text/markdown"

--- a/schema/rules.yaml
+++ b/schema/rules.yaml
@@ -438,18 +438,18 @@ rules:
   - id: RULE-0080
     level: error
     scope: catalog
-    description: Catalogs MUST include llms.txt link
+    code_rule: agents_md_catalog_link
+    description: Catalogs MUST include AGENTS.md link
     rationale: |
       AI agents and LLMs are a primary audience for Portolan catalogs.
-      The llms.txt file provides context that STAC metadata alone cannot:
+      The AGENTS.md file provides context that STAC metadata alone cannot:
       plain-language descriptions, usage examples, and pitfalls to avoid.
     validation: |
       For catalog.json:
-        assert any link has rel="llms"
-        if link with rel="llms" exists:
-          assert link.href ends with "llms.txt"
-          assert link.type == "text/markdown"
-          assert file exists at link.href
+        assert any link has rel="agents"
+        assert link.href ends with "AGENTS.md"
+        assert link.type == "text/markdown"
+        assert file exists at link.href
     references:
       - ai-integration.md
       - core.md#ai--llm-integration
@@ -457,17 +457,17 @@ rules:
   - id: RULE-0081
     level: error
     scope: collection
-    description: Collections MUST include llms.txt link
+    code_rule: agents_md_collection_link
+    description: Collections MUST include AGENTS.md link
     rationale: |
-      Collection-level llms.txt provides everything an agent needs to work
+      Collection-level AGENTS.md provides everything an agent needs to work
       with a specific collection: schema docs, query examples, data quality notes.
     validation: |
       For each collection.json:
-        assert any link has rel="llms"
-        if link with rel="llms" exists:
-          assert link.href ends with "llms.txt"
-          assert link.type == "text/markdown"
-          assert file exists at link.href
+        assert any link has rel="agents"
+        assert link.href ends with "AGENTS.md"
+        assert link.type == "text/markdown"
+        assert file exists at link.href
     references:
       - ai-integration.md
       - core.md#ai--llm-integration
@@ -475,32 +475,32 @@ rules:
   - id: RULE-0082
     level: warning
     scope: catalog
-    description: Catalog llms.txt SHOULD include recommended content
+    description: Catalog AGENTS.md SHOULD include recommended content
     rationale: |
-      Effective llms.txt files follow established patterns for maximum utility.
+      Effective AGENTS.md files follow established patterns for maximum utility.
       Missing key sections reduce the file's value to AI agents.
     validation: |
-      For catalog llms.txt:
+      For catalog AGENTS.md:
         warn if file does not mention collections or items
         warn if no code examples present
         warn if no license information present
     references:
-      - ai-integration.md#catalog-level-llmstxt
+      - ai-integration.md#catalog-level-agentsmd
 
   - id: RULE-0083
     level: warning
     scope: collection
-    description: Collection llms.txt SHOULD include recommended content
+    description: Collection AGENTS.md SHOULD include recommended content
     rationale: |
-      Collection llms.txt should enable agents to immediately work with the data.
+      Collection AGENTS.md should enable agents to immediately work with the data.
       Schema documentation and query examples are particularly valuable.
     validation: |
-      For collection llms.txt:
+      For collection AGENTS.md:
         warn if no schema/field documentation present
         warn if no code/query examples present
         warn if no data access URLs present
     references:
-      - ai-integration.md#collection-level-llmstxt
+      - ai-integration.md#collection-level-agentsmd
 
   # =============================================================================
   # Tabular (Non-Geospatial) Data Rules


### PR DESCRIPTION
Automated spec sync from portolan-cli.

**Source commit:** portolan-sdi/portolan-cli@f82dc2eb92c16248a872d9cd3e1245338c125dac
**Triggered by:** feat(spec): mandate AGENTS.md (rel=agents) — enforce + generate it (#640)

* feat(spec): mandate AGENTS.md (rel=agents), enforce + generate it

Migrate the AI/agent metadata requirement from llms.txt to AGENTS.md
(Markdown, minimal, cross-tool convention) and actually enforce it end to
end — the requirement was previously specified everywhere and implemented
nowhere.

Spec/schema:
- ai-integration.md, core.md, README.md, formats/tabular.md, example JSON:
  rename llms.txt -> AGENTS.md and rel "llms" -> "agents"
- catalog/collection schemas now REQUIRE a rel="agents" link (contains
  clause), not just validate its shape if present; href regex -> AGENTS.md
- rules.yaml RULE-0080/0081 renamed and given code_rule mappings;
  RULE-0082/0083 renamed (remain spec-level warnings)

CLI:
- new framework-free leaf agents_md.py (scaffold + link helpers + gap
  detection), imported by both generation and validation
- CatalogAgentsMdLinkRule / CollectionAgentsMdLinkRule (RULE-0080/0081,
  error) registered in the runner
- init/add scaffold AGENTS.md and emit the link so fresh output is
  schema-valid; check --fix repair_agents_md backfills externally-modified
  catalogs; scaffolding never overwrites a human-authored AGENTS.md

Tests/fixtures:
- unit tests for the leaf, rules, generation, and repair
- schema now-required-link assertions; hermetic init/add generation asserts
- valid fixtures carry AGENTS.md + link; local regression fixture reproduces
  the portolan-nl "file present, root link absent" gap
- ADR-0052 updated to AGENTS.md and corrected to describe the real
  implementation

Closes: portolan-sdi/portolan-cli#479
Closes: portolan-sdi/portolan-cli#565
Refs: portolan-sdi/portolan-spec#38
Refs: portolan-sdi/portolan-spec#2

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* fix(add): exclude AGENTS.md from asset scanning; fix test fallout

AGENTS.md is a rel="agents" link, not a collection asset (ADR-0052) — add
AGENTS.md to IGNORED_FILES so add's directory scan (ADR-0028) does not
register the scaffolded file as a "documentation" asset.

Update tests that hand-build catalogs/collections to be spec-compliant now
that a valid catalog requires AGENTS.md: make fixture builders emit the
agents link + file, bump the DEFAULT_RULES count 17->19, and include the
generated AGENTS.md in add-external's file-list assertion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

The portolan-cli repository is the source of truth for the Portolan
specification. This PR syncs changes from `portolan-cli/spec/` to
the portolan-spec mirror.

See [ADR-0048](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0048-cli-as-spec-source.md) for rationale.

---
_Auto-generated by [sync-spec](https://github.com/portolan-sdi/portolan-cli/blob/main/.github/workflows/sync-spec.yml)_