### PR TITLE
Move Portolan STAC extension/profile into stac/

### DIFF
--- a/.github/workflows/publish-schema.yaml
+++ b/.github/workflows/publish-schema.yaml
@@ -1,0 +1,98 @@
+name: Publish Schema
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build site with new version
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          mkdir -p "_site/portolan/${VERSION}"
+          cp stac/json-schema/schema.json "_site/portolan/${VERSION}/"
+
+          # Try to fetch existing versions manifest, default to empty array
+          if curl -sfL https://portolan-sdi.github.io/portolan-spec/portolan/versions.json -o /tmp/versions.json 2>/dev/null; then
+            # Download each existing version's schema to preserve them
+            for ver in $(jq -r '.[]' /tmp/versions.json 2>/dev/null); do
+              if [ "$ver" != "$VERSION" ]; then
+                mkdir -p "_site/portolan/${ver}"
+                curl -sfL "https://portolan-sdi.github.io/portolan-spec/portolan/${ver}/schema.json" \
+                  -o "_site/portolan/${ver}/schema.json" 2>/dev/null || true
+              fi
+            done
+            # Add new version to manifest
+            jq --arg v "$VERSION" '. + [$v] | unique' /tmp/versions.json > _site/portolan/versions.json
+          else
+            # First deployment - create fresh manifest
+            echo "[\"${VERSION}\"]" > _site/portolan/versions.json
+          fi
+
+          # Create index page listing all versions
+          cat > _site/portolan/index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>Portolan STAC Profile</title>
+            <style>
+              body { font-family: system-ui, sans-serif; max-width: 600px; margin: 2rem auto; padding: 0 1rem; }
+              h1 { color: #333; }
+              ul { list-style: none; padding: 0; }
+              li { margin: 0.5rem 0; }
+              a { color: #0066cc; }
+            </style>
+          </head>
+          <body>
+            <h1>Portolan STAC Profile</h1>
+            <p>JSON Schema for the <a href="https://github.com/portolan-sdi/portolan-spec">Portolan STAC profile</a>.</p>
+            <h2>Available Versions</h2>
+            <ul id="versions"></ul>
+            <script>
+              fetch('versions.json')
+                .then(r => r.json())
+                .then(versions => {
+                  const ul = document.getElementById('versions');
+                  versions.sort().reverse().forEach(v => {
+                    const li = document.createElement('li');
+                    li.innerHTML = `<a href="${v}/schema.json">${v}</a>`;
+                    ul.appendChild(li);
+                  });
+                });
+            </script>
+          </body>
+          </html>
+          HTMLEOF
+
+          # Root index redirects to the schema listing
+          cat > _site/index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="refresh" content="0; url=portolan/">
+            <title>Portolan</title>
+          </head>
+          <body>
+            <a href="portolan/">Portolan schemas</a>
+          </body>
+          </html>
+          HTMLEOF
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test-stac-profile.yaml
+++ b/.github/workflows/test-stac-profile.yaml
@@ -1,0 +1,20 @@
+name: Test STAC Profile
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: stac
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm test

--- a/stac/.gitignore
+++ b/stac/.gitignore
@@ -1,0 +1,2 @@
+/package-lock.json
+/node_modules

--- a/stac/.remarkrc.yaml
+++ b/stac/.remarkrc.yaml
@@ -1,0 +1,5 @@
+plugins:
+  - remark-preset-lint-consistent
+  - remark-preset-lint-recommended
+  - - remark-validate-links
+    - repository: "https://github.com/portolan-sdi/portolan-spec"

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial version of the Portolan extension.
+- Field: `portolan:version`, required on Catalog, Collection, and Item.
+- JSON Schema covering the specification's schema-checkable structural
+  requirements: non-empty titles and descriptions, titles on `child`/`item`
+  links, `type`, `roles`, `file:size`, and `file:checksum` required on every
+  asset, https-only absolute asset hrefs, collection `license` never the
+  deprecated `proprietary`, WGS84 bbox range validity, and the
+  `rel: "agents"` link (with `type`) on Catalogs and Collections.
+- Examples for a root catalog, a single-file vector collection, and a
+  partitioned vector collection with an item.

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to the Portolan STAC profile will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -9,13 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial version of the Portolan extension.
-- Field: `portolan:version`, required on Catalog, Collection, and Item.
+- Initial version of the Portolan STAC profile, moved from the
+  `stac-portolan-extension` repository into `stac/`.
 - JSON Schema covering the specification's schema-checkable structural
   requirements: non-empty titles and descriptions, titles on `child`/`item`
-  links, `type`, `roles`, `file:size`, and `file:checksum` required on every
-  asset, https-only absolute asset hrefs, collection `license` never the
-  deprecated `proprietary`, WGS84 bbox range validity, and the
-  `rel: "agents"` link (with `type`) on Catalogs and Collections.
+  links, no `self` links with relative typed structural links, `type`,
+  `roles`, `file:size`, and `file:checksum` required on every asset,
+  https-only absolute asset hrefs, `providers` with a producer and a
+  reachable host, collection `license` never the deprecated `proprietary`,
+  WGS84 bbox range validity, and the `rel: "agents"` link (with `type`) on
+  Catalogs and Collections.
 - Examples for a root catalog, a single-file vector collection, and a
   partitioned vector collection with an item.
+
+### Changed
+
+- No `portolan:`-prefixed fields are defined: the versioned schema URI in
+  `stac_extensions` is the single signal of specification version, declared
+  on catalogs and collections only (items inherit conformance).

--- a/stac/README.md
+++ b/stac/README.md
@@ -1,28 +1,158 @@
-# Portolan STAC Profile
+# Portolan Extension
 
-> **Scaffold — work in progress.** This directory will hold the Portolan STAC
-> profile and any Portolan-specific STAC extension schemas. It is being authored
-> separately; this README marks the slot in the repo structure.
+> **Work in Progress** — This extension is under active development. Field names, requirement levels, and the extension URL may change before the first stable release.
 
-Portolan is a [STAC](https://stacspec.org/) profile: it constrains and extends STAC
-1.1.0 rather than competing with it. This directory is the normative home for that
-profile — the machine-readable counterpart to the prose in
-[`specs/portolan/`](../specs/portolan/).
+- **Title:** Portolan
+- **Identifier:** <https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json>
+- **Field Name Prefix:** portolan
+- **Scope:** Catalog, Collection, Item
+- **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
 
-## Intended layout
+A [Portolan](https://github.com/portolan-sdi) catalog is a directory of STAC metadata and cloud-native geospatial data, served from plain object storage and consumable with zero infrastructure. Following the approach of the [CEOS-ARD extension](https://github.com/stac-extensions/ceos-ard), this repository is both a **minimal extension** — one field, `portolan:version`, plus a JSON Schema for the structural requirements checkable from STAC JSON alone — and a **profile**: how the Portolan specification uses STAC and existing extensions, which link relations, media types, and roles it requires, and where full validation happens.
 
-Following the pattern of the [CEOS-ARD STAC
-extension](https://github.com/stac-extensions), this directory will contain:
+Declaring this extension is a claim of conformance, not proof of it: an object conforms only by passing the Portolan validator (see [Validation](#validation)).
 
-- **`README.md`** (this file) — the profile itself: which STAC extensions Portolan
-  requires versus recommends, the exact schema URIs and versions to pin, and how
-  they are used. This is the source referenced by
-  [`core.md` → Recommended STAC Extensions](../specs/portolan/core.md#recommended-stac-extensions).
-- **`json-schema/`** — JSON Schema documents for any Portolan-specific extension
-  fields, published under `portolan-sdi.org` and declared in a catalog's
-  `stac_extensions` array (e.g. `https://portolan-sdi.org/portolan/v0.1.0/schema.json`).
+## Fields
 
-## Status
+| Field Name       | Type   | Description |
+| ---------------- | ------ | ----------- |
+| portolan:version | string | **REQUIRED.** The Portolan specification version the object was authored against (`0.1.0` for this schema), set to the same version as the declared schema URI, so tools can filter by specification version without resolving URIs. This is the *specification* version — dataset versioning uses the [version extension](https://github.com/stac-extensions/version). |
 
-The profile content is under active development. Until it lands here, the normative
-requirements are the prose in [`specs/portolan/`](../specs/portolan/).
+On Catalogs and Collections the field sits at the top level; on Items it sits in `properties`. All objects within a catalog SHOULD declare the same `portolan:version`; a validator flags a mismatch with the root catalog as a warning, not an error — a mixed-version catalog remains valid.
+
+Other `portolan:`-prefixed fields are under discussion in the specification (e.g. the tabular marker, style manifests) and are intentionally neither validated nor rejected by this schema until settled — see [Open questions](#open-questions).
+
+## What the schema enforces
+
+Beyond `portolan:version`, the schema encodes the specification's structural requirements that STAC core leaves optional:
+
+- Every Catalog and Collection has a non-empty `title` and `description`; every `child` and `item` link carries a `title` (spec: Human-Readable Titles).
+- Every asset has `href`, a media `type`, at least one `role`, and `file:size` + `file:checksum` (spec: Assets). The checksum's multihash encoding is verified by tooling, not schema.
+- Absolute asset hrefs use `https` — `s3://` and other bucket schemes are rejected; relative hrefs are allowed (spec: Assets).
+- Collection `license` is never the deprecated `proprietary`; SPDX validity and the `rel: "license"` link required with `other` are checked by tooling (spec: License).
+- Every `bbox` — collection extent and item — contains only in-range WGS84 coordinates, with no sentinel "effectively infinite" values (spec: Bounding Boxes and Spatial Extent).
+- Every Catalog and Collection links its `AGENTS.md` with `rel: "agents"` and `type: "text/markdown"` (spec: AGENTS.md).
+
+## STAC Extensions
+
+Portolan reuses established extensions rather than re-encoding the same information under `portolan:`. This table is the **normative registry** of the extensions the profile uses — the requirement level, the condition under which it applies, and the exact schema URI to pin in `stac_extensions`. The specification defers to this table rather than restating it.
+
+Requirement keywords per BCP 14; a conditional MUST applies only when its condition holds.
+
+| Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
+| ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
+| [Portolan][] | `https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog, collection, and item |
+| [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | Every object with assets: `file:size` + `file:checksum` (multihash) on each asset |
+| [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When a PMTiles asset is present: the `rel: "pmtiles"` link |
+| [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |
+| [Raster][] | `https://stac-extensions.github.io/raster/v2.0.0/schema.json`               | **MUST**    | When band-level detail is provided |
+| [Vector][] | `https://stac-extensions.github.io/vector/v0.1.0/schema.json`               | **MUST**    | When layer-level detail is provided |
+| [Table][] | `https://stac-extensions.github.io/table/v1.2.0/schema.json`                | SHOULD      | Tabular collections: document columns with `table:columns` |
+| [Alternate Assets][] | `https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json`     | SHOULD      | Expose `s3://` alternates for absolute `https` asset hrefs |
+| [Render][] | `https://stac-extensions.github.io/render/v2.0.0/schema.json`               | SHOULD      | Continuous rasters rendering from source (draw-time colorization) |
+| [Projection][] | `https://stac-extensions.github.io/projection/v2.0.0/schema.json`           | MAY         | CRS / projection of the data |
+| [Scientific][] | `https://stac-extensions.github.io/scientific/v1.0.0/schema.json`           | MAY         | Citation / DOI |
+| [Contacts][] | `https://stac-extensions.github.io/contacts/v0.1.1/schema.json`             | MAY         | Responsible parties |
+| [Attribution][] | `https://stac-extensions.github.io/attribution/v0.1.0/schema.json`          | MAY         | Display attribution |
+| [Themes][] | `https://stac-extensions.github.io/themes/v1.0.0/schema.json`               | MAY         | Thematic classification |
+
+Note that `item_assets` needs no extension — it is a core field in STAC 1.1.
+
+As the profile grows, per-format requirement sets (vector, raster, tabular) may split into separate subprofile documents, as CEOS-ARD does for optical and SAR.
+
+[Portolan]: https://github.com/portolan-sdi/portolan-spec
+[File Info]: https://github.com/stac-extensions/file
+[Web Map Links]: https://github.com/stac-extensions/web-map-links
+[Version]: https://github.com/stac-extensions/version
+[Raster]: https://github.com/stac-extensions/raster
+[Vector]: https://github.com/stac-extensions/vector
+[Table]: https://github.com/stac-extensions/table
+[Projection]: https://github.com/stac-extensions/projection
+[Alternate Assets]: https://github.com/stac-extensions/alternate-assets
+[Render]: https://github.com/stac-extensions/render
+[Scientific]: https://github.com/stac-extensions/scientific
+[Contacts]: https://github.com/stac-extensions/contacts
+[Attribution]: https://github.com/stac-extensions/attribution
+[Themes]: https://github.com/stac-extensions/themes
+
+## Profile
+
+### Link relations
+
+| `rel` | Where | Notes |
+| ----- | ----- | ----- |
+| `root`, `self`, `parent` | All objects (root catalog has no `parent`) | Structural links carry `type: "application/json"` (`application/geo+json` for links to items) |
+| `child` / `item` | Catalogs and collections, one per child | MUST carry a `title` |
+| `collection` | Items | — |
+| `agents` | Catalog, Collection | Points to `AGENTS.md`, `type: "text/markdown"` |
+| `via` | Collection | Original canonical source when data is mirrored, `type: "text/html"` |
+| `canonical` | Collection | Mirror only: the source's own STAC root, MUST when the source publishes STAC |
+| `license` | Collection | License text, MUST when `license` is `other` |
+| `pmtiles` | Collection | Per web-map-links v1.3.0, with `pmtiles:layers`, when a PMTiles asset is present |
+
+Every link in a catalog MUST resolve — a link that 404s is a conformance failure. This is a crawling check, outside JSON Schema.
+
+### Media types and roles
+
+| Format | Media type | Typical role |
+| ------ | ---------- | ------------ |
+| GeoParquet / Parquet | `application/vnd.apache.parquet` | `data` |
+| COG | `image/tiff; application=geotiff; profile=cloud-optimized` | `data` |
+| PMTiles | `application/vnd.pmtiles` | `visual` |
+| COPC | `application/vnd.laszip+copc` | `data` |
+| Thumbnail | `image/png` or `image/jpeg` | `thumbnail` |
+| Sidecar metadata | (format-specific) | `metadata`, `iso-19115` |
+| MapLibre style | `application/vnd.mapbox.style+json` | `style` (Portolan-defined role) |
+
+### Formats
+
+Every collection and item is available in a cloud-optimized format; full requirements live in the specification's format sections, and the data-file internals are validated by tooling, not schema:
+
+- **Vector** — GeoParquet 1.1/2.0 (compression, spatial ordering, row-group statistics), paired with a PMTiles visualization derivative and MapLibre styles.
+- **Raster** — COG with embedded per-band GDAL statistics in the leading header block.
+- **Tabular (non-geospatial)** — Parquet as a collection-level asset, columns documented with the table extension, spatial requirements relaxed.
+- **Point cloud** — reserved; COPC, pending a reference implementation.
+
+## Validation
+
+Per the specification, validation runs in separable passes:
+
+1. **Structural** — STAC 1.1.0 core schemas.
+2. **Metadata** — every requirement checkable from metadata alone. This extension's schema is the machine-checkable core of this pass; link resolution needs a crawler.
+3. **Data** — requirements that need asset bytes (GeoParquet spatial ordering, row-group statistics, embedded COG statistics). Run by `portolan check`, MAY run independently.
+
+Hosting requirements (HTTP Range support, CORS on all metadata and asset files) are properties of the server, validated by probe.
+
+## Open questions
+
+Tracked in the specification and deliberately **not** settled by this repository; the schema neither validates nor rejects the affected fields:
+
+1. **The `portolan:version` property itself** — whether the duplicate property stays, or the versioned schema URI in `stac_extensions` becomes the single version signal. The schema currently requires the property, following the spec's Conformance and Versioning section; if it is removed, the extension remains valid STAC with no fields at all — the declared URI is then the only conformance and version claim (CEOS-ARD style).
+2. **Tabular marker** — explicit `portolan:geospatial: false` vs deriving non-spatial status from the data.
+3. **Styles as assets vs links** — and, downstream, whether a `portolan:styles` manifest is needed. The examples here show styles as assets with `roles: ["style"]`, illustrating one candidate; pending this ruling, they deliberately omit the `portolan:styles` manifest that the spec's PMTiles section currently mandates.
+4. **Relative vs absolute structural links** — note STAC 1.1 core already requires `self` hrefs to be absolute; the examples use relative structural links with an absolute `self`.
+
+## Examples
+
+- [Root catalog](examples/catalog.json)
+- [Single-file vector collection](examples/vector-collection.json) — GeoParquet + PMTiles + style + thumbnail as collection-level assets
+- [Partitioned vector collection](examples/vector-partitioned-collection.json) and [partition item](examples/vector-partitioned-item.json)
+
+The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository.
+
+## Building and Testing
+
+This repository uses [stac-node-validator](https://github.com/stac-utils/stac-node-validator) to validate examples against the schema:
+
+```bash
+npm install
+npm test
+```
+
+## Contributing
+
+This extension is maintained by the [Portolan SDI](https://github.com/portolan-sdi) project. Issues and pull requests are welcome.
+
+## License
+
+Apache-2.0

--- a/stac/README.md
+++ b/stac/README.md
@@ -1,34 +1,34 @@
-# Portolan Extension
+# Portolan STAC Profile
 
-> **Work in Progress** — This extension is under active development. Field names, requirement levels, and the extension URL may change before the first stable release.
+> **Work in Progress** — This profile is under active development. Requirement levels and the schema URL may change before the first stable release.
 
 - **Title:** Portolan
 - **Identifier:** <https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json>
-- **Field Name Prefix:** portolan
-- **Scope:** Catalog, Collection, Item
+- **Field Name Prefix:** portolan (reserved; no fields defined in v0.1)
+- **Scope:** Catalog, Collection — Items inherit conformance from their collection
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
 
-A [Portolan](https://github.com/portolan-sdi) catalog is a directory of STAC metadata and cloud-native geospatial data, served from plain object storage and consumable with zero infrastructure. Following the approach of the [CEOS-ARD extension](https://github.com/stac-extensions/ceos-ard), this repository is both a **minimal extension** — one field, `portolan:version`, plus a JSON Schema for the structural requirements checkable from STAC JSON alone — and a **profile**: how the Portolan specification uses STAC and existing extensions, which link relations, media types, and roles it requires, and where full validation happens.
+A [Portolan](https://github.com/portolan-sdi) catalog is a directory of STAC metadata and cloud-native geospatial data, served from plain object storage and consumable with zero infrastructure. Following the approach of the [CEOS-ARD extension](https://github.com/stac-extensions/ceos-ard), this directory is both a **minimal extension** — a JSON Schema for the structural requirements checkable from STAC JSON alone — and a **profile**: how the [Portolan specification](../specs/portolan/) uses STAC and existing extensions, which link relations, media types, and roles it requires, and where full validation happens.
 
 Declaring this extension is a claim of conformance, not proof of it: an object conforms only by passing the Portolan validator (see [Validation](#validation)).
 
 ## Fields
 
-| Field Name       | Type   | Description |
-| ---------------- | ------ | ----------- |
-| portolan:version | string | **REQUIRED.** The Portolan specification version the object was authored against (`0.1.0` for this schema), set to the same version as the declared schema URI, so tools can filter by specification version without resolving URIs. This is the *specification* version — dataset versioning uses the [version extension](https://github.com/stac-extensions/version). |
+This extension defines **no fields**. The versioned schema URI declared in `stac_extensions` is the single signal of specification version; no separate version property exists (spec: Conformance and Versioning). Dataset versioning uses the [version extension](https://github.com/stac-extensions/version), never `portolan:` fields.
 
-On Catalogs and Collections the field sits at the top level; on Items it sits in `properties`. All objects within a catalog SHOULD declare the same `portolan:version`; a validator flags a mismatch with the root catalog as a warning, not an error — a mixed-version catalog remains valid.
+Declaration happens at the catalog and collection level only — every catalog and collection MUST declare the schema URI in `stac_extensions`; items inherit conformance from their collection and do not declare it. All objects within a catalog SHOULD declare the same URI; a validator flags a mismatch with the root catalog as a warning, not an error — a mixed-version catalog remains valid.
 
-Other `portolan:`-prefixed fields are under discussion in the specification (e.g. the tabular marker, style manifests) and are intentionally neither validated nor rejected by this schema until settled — see [Open questions](#open-questions).
+The `portolan:` prefix stays reserved for future use.
 
 ## What the schema enforces
 
-Beyond `portolan:version`, the schema encodes the specification's structural requirements that STAC core leaves optional:
+The schema encodes the specification's structural requirements that STAC core leaves optional:
 
 - Every Catalog and Collection has a non-empty `title` and `description`; every `child` and `item` link carries a `title` (spec: Human-Readable Titles).
+- No object carries a `self` link, and structural links (`root`, `parent`, `child`, `item`, `collection`) are relative and carry `type: "application/json"` (`application/geo+json` for links to items), keeping a catalog fully portable (spec: Links).
 - Every asset has `href`, a media `type`, at least one `role`, and `file:size` + `file:checksum` (spec: Assets). The checksum's multihash encoding is verified by tooling, not schema.
 - Absolute asset hrefs use `https` — `s3://` and other bucket schemes are rejected; relative hrefs are allowed (spec: Assets).
+- Every Collection declares `providers` with at least one `producer` and a `host` reachable through `url` or `email`; that the host is exactly one and listed last is checked by tooling (spec: Providers).
 - Collection `license` is never the deprecated `proprietary`; SPDX validity and the `rel: "license"` link required with `other` are checked by tooling (spec: License).
 - Every `bbox` — collection extent and item — contains only in-range WGS84 coordinates, with no sentinel "effectively infinite" values (spec: Bounding Boxes and Spatial Extent).
 - Every Catalog and Collection links its `AGENTS.md` with `rel: "agents"` and `type: "text/markdown"` (spec: AGENTS.md).
@@ -41,9 +41,9 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
-| [Portolan][] | `https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog, collection, and item |
+| [Portolan][] | `https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
 | [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | Every object with assets: `file:size` + `file:checksum` (multihash) on each asset |
-| [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When a PMTiles asset is present: the `rel: "pmtiles"` link |
+| [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |
 | [Raster][] | `https://stac-extensions.github.io/raster/v2.0.0/schema.json`               | **MUST**    | When band-level detail is provided |
 | [Vector][] | `https://stac-extensions.github.io/vector/v0.1.0/schema.json`               | **MUST**    | When layer-level detail is provided |
@@ -52,7 +52,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 | [Render][] | `https://stac-extensions.github.io/render/v2.0.0/schema.json`               | SHOULD      | Continuous rasters rendering from source (draw-time colorization) |
 | [Projection][] | `https://stac-extensions.github.io/projection/v2.0.0/schema.json`           | MAY         | CRS / projection of the data |
 | [Scientific][] | `https://stac-extensions.github.io/scientific/v1.0.0/schema.json`           | MAY         | Citation / DOI |
-| [Contacts][] | `https://stac-extensions.github.io/contacts/v0.1.1/schema.json`             | MAY         | Responsible parties |
+| [Contacts][] | `https://stac-extensions.github.io/contacts/v0.1.1/schema.json`             | MAY         | Richer contact info; never replaces url-or-email on the host provider |
 | [Attribution][] | `https://stac-extensions.github.io/attribution/v0.1.0/schema.json`          | MAY         | Display attribution |
 | [Themes][] | `https://stac-extensions.github.io/themes/v1.0.0/schema.json`               | MAY         | Thematic classification |
 
@@ -79,18 +79,20 @@ As the profile grows, per-format requirement sets (vector, raster, tabular) may 
 
 ### Link relations
 
+Objects MUST NOT include a `self` link, and all structural links MUST be relative (pystac `SELF_CONTAINED` convention), so a catalog can be moved or rehosted without rewriting any file.
+
 | `rel` | Where | Notes |
 | ----- | ----- | ----- |
-| `root`, `self`, `parent` | All objects (root catalog has no `parent`) | Structural links carry `type: "application/json"` (`application/geo+json` for links to items) |
-| `child` / `item` | Catalogs and collections, one per child | MUST carry a `title` |
-| `collection` | Items | — |
+| `root`, `parent` | All objects (root catalog has no `parent`) | Relative; `type: "application/json"` |
+| `child` / `item` | Catalogs and collections, one per child | Relative, typed (`application/geo+json` for items); MUST carry a `title` |
+| `collection` | Items | Relative; `type: "application/json"` |
 | `agents` | Catalog, Collection | Points to `AGENTS.md`, `type: "text/markdown"` |
-| `via` | Collection | Original canonical source when data is mirrored, `type: "text/html"` |
+| `via` | Collection | Mirror only: the original source, `type: "text/html"` |
 | `canonical` | Collection | Mirror only: the source's own STAC root, MUST when the source publishes STAC |
 | `license` | Collection | License text, MUST when `license` is `other` |
-| `pmtiles` | Collection | Per web-map-links v1.3.0, with `pmtiles:layers`, when a PMTiles asset is present |
+| `pmtiles` | Collection | Per web-map-links v1.3.0, with `pmtiles:layers`, when PMTiles are provided |
 
-Every link in a catalog MUST resolve — a link that 404s is a conformance failure. This is a crawling check, outside JSON Schema.
+Whether a catalog is official or a mirror is derived from its providers (producer = host means official); a mirror records each sync in the core `updated` field. Every link in a catalog MUST resolve — a link that 404s is a conformance failure. This is a crawling check, outside JSON Schema.
 
 ### Media types and roles
 
@@ -104,13 +106,15 @@ Every link in a catalog MUST resolve — a link that 404s is a conformance failu
 | Sidecar metadata | (format-specific) | `metadata`, `iso-19115` |
 | MapLibre style | `application/vnd.mapbox.style+json` | `style` (Portolan-defined role) |
 
+Styles are STAC assets: each style file is a collection-level asset with `roles: ["style"]`, discovered by filtering assets on that role — no separate manifest exists (spec: Visualization Styles).
+
 ### Formats
 
 Every collection and item is available in a cloud-optimized format; full requirements live in the specification's format sections, and the data-file internals are validated by tooling, not schema:
 
-- **Vector** — GeoParquet 1.1/2.0 (compression, spatial ordering, row-group statistics), paired with a PMTiles visualization derivative and MapLibre styles.
+- **Vector** — GeoParquet 1.1/2.0 (compression, spatial ordering, row-group statistics); a PMTiles visualization derivative SHOULD be provided, registered through the `rel: "pmtiles"` link (an asset only when also intended for distribution), with MapLibre styles as `style` assets.
 - **Raster** — COG with embedded per-band GDAL statistics in the leading header block.
-- **Tabular (non-geospatial)** — Parquet as a collection-level asset, columns documented with the table extension, spatial requirements relaxed.
+- **Tabular (non-geospatial)** — Parquet as a collection-level asset, columns documented with the table extension, spatial requirements relaxed. No marker property: a tabular collection is identified by its data, a Parquet asset with no geometry column.
 - **Point cloud** — reserved; COPC, pending a reference implementation.
 
 ## Validation
@@ -118,19 +122,16 @@ Every collection and item is available in a cloud-optimized format; full require
 Per the specification, validation runs in separable passes:
 
 1. **Structural** — STAC 1.1.0 core schemas.
-2. **Metadata** — every requirement checkable from metadata alone. This extension's schema is the machine-checkable core of this pass; link resolution needs a crawler.
+2. **Metadata** — every requirement checkable from metadata alone. This profile's schema is the machine-checkable core of this pass; link resolution needs a crawler.
 3. **Data** — requirements that need asset bytes (GeoParquet spatial ordering, row-group statistics, embedded COG statistics). Run by `portolan check`, MAY run independently.
 
 Hosting requirements (HTTP Range support, CORS on all metadata and asset files) are properties of the server, validated by probe.
 
 ## Open questions
 
-Tracked in the specification and deliberately **not** settled by this repository; the schema neither validates nor rejects the affected fields:
+Tracked in the specification and deliberately **not** settled by this schema:
 
-1. **The `portolan:version` property itself** — whether the duplicate property stays, or the versioned schema URI in `stac_extensions` becomes the single version signal. The schema currently requires the property, following the spec's Conformance and Versioning section; if it is removed, the extension remains valid STAC with no fields at all — the declared URI is then the only conformance and version claim (CEOS-ARD style).
-2. **Tabular marker** — explicit `portolan:geospatial: false` vs deriving non-spatial status from the data.
-3. **Styles as assets vs links** — and, downstream, whether a `portolan:styles` manifest is needed. The examples here show styles as assets with `roles: ["style"]`, illustrating one candidate; pending this ruling, they deliberately omit the `portolan:styles` manifest that the spec's PMTiles section currently mandates.
-4. **Relative vs absolute structural links** — note STAC 1.1 core already requires `self` hrefs to be absolute; the examples use relative structural links with an absolute `self`.
+1. **Raster styling** — how raster styles are expressed (colormaps, legends, continuous vs. categorical vs. multiband) is under discussion in [`specs/incubating/raster-styling.md`](../specs/incubating/raster-styling.md); the MapLibre style requirements are vector-only for now.
 
 ## Examples
 
@@ -138,11 +139,11 @@ Tracked in the specification and deliberately **not** settled by this repository
 - [Single-file vector collection](examples/vector-collection.json) — GeoParquet + PMTiles + style + thumbnail as collection-level assets
 - [Partitioned vector collection](examples/vector-partitioned-collection.json) and [partition item](examples/vector-partitioned-item.json)
 
-The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository.
+The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository. Per the spec's Links section the examples carry no `self` links and use only relative structural hrefs.
 
 ## Building and Testing
 
-This repository uses [stac-node-validator](https://github.com/stac-utils/stac-node-validator) to validate examples against the schema:
+The profile uses [stac-node-validator](https://github.com/stac-utils/stac-node-validator) to validate the examples against the schema. From `stac/`:
 
 ```bash
 npm install
@@ -151,7 +152,7 @@ npm test
 
 ## Contributing
 
-This extension is maintained by the [Portolan SDI](https://github.com/portolan-sdi) project. Issues and pull requests are welcome.
+This profile is maintained by the [Portolan SDI](https://github.com/portolan-sdi) project. Issues and pull requests are welcome.
 
 ## License
 

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -1,0 +1,41 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json"
+  ],
+  "id": "andalusia-open-geodata",
+  "title": "Andalusia Open Geodata",
+  "description": "Cloud-native mirror of open geospatial datasets for Andalusia, Spain. Vector data is published as GeoParquet with PMTiles visualization derivatives.",
+  "portolan:version": "0.1.0",
+  "links": [
+    {
+      "rel": "root",
+      "href": "https://data.example.org/andalusia/catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "https://data.example.org/andalusia/catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "./municipal-boundaries/collection.json",
+      "type": "application/json",
+      "title": "Municipal Boundaries of Andalusia"
+    },
+    {
+      "rel": "child",
+      "href": "./buildings/collection.json",
+      "type": "application/json",
+      "title": "Buildings of Andalusia"
+    },
+    {
+      "rel": "agents",
+      "href": "./AGENTS.md",
+      "type": "text/markdown",
+      "title": "Guidance for AI agents"
+    }
+  ]
+}

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -7,16 +7,11 @@
   "id": "andalusia-open-geodata",
   "title": "Andalusia Open Geodata",
   "description": "Cloud-native mirror of open geospatial datasets for Andalusia, Spain. Vector data is published as GeoParquet with PMTiles visualization derivatives.",
-  "portolan:version": "0.1.0",
+  "updated": "2026-07-15T09:30:00Z",
   "links": [
     {
       "rel": "root",
-      "href": "https://data.example.org/andalusia/catalog.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "self",
-      "href": "https://data.example.org/andalusia/catalog.json",
+      "href": "./catalog.json",
       "type": "application/json"
     },
     {

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -10,7 +10,7 @@
   "title": "Municipal Boundaries of Andalusia",
   "description": "Administrative boundaries of the 785 municipalities of Andalusia, Spain. Single-file GeoParquet collection with a PMTiles visualization derivative and a default MapLibre style.",
   "license": "CC-BY-4.0",
-  "portolan:version": "0.1.0",
+  "updated": "2026-07-15T09:30:00Z",
   "keywords": [
     "boundaries",
     "administrative",
@@ -107,11 +107,6 @@
     {
       "rel": "parent",
       "href": "../catalog.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "self",
-      "href": "https://data.example.org/andalusia/municipal-boundaries/collection.json",
       "type": "application/json"
     },
     {

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -1,0 +1,139 @@
+{
+  "type": "Collection",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json",
+    "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
+    "https://stac-extensions.github.io/file/v2.1.0/schema.json"
+  ],
+  "id": "municipal-boundaries",
+  "title": "Municipal Boundaries of Andalusia",
+  "description": "Administrative boundaries of the 785 municipalities of Andalusia, Spain. Single-file GeoParquet collection with a PMTiles visualization derivative and a default MapLibre style.",
+  "license": "CC-BY-4.0",
+  "portolan:version": "0.1.0",
+  "keywords": [
+    "boundaries",
+    "administrative",
+    "municipalities",
+    "andalusia"
+  ],
+  "providers": [
+    {
+      "name": "Instituto de Estadística y Cartografía de Andalucía",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://www.juntadeandalucia.es/institutodeestadisticaycartografia"
+    },
+    {
+      "name": "Portolan SDI",
+      "roles": [
+        "processor",
+        "host"
+      ],
+      "url": "https://github.com/portolan-sdi"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -7.523,
+          35.938,
+          -1.63,
+          38.729
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2025-01-01T00:00:00Z",
+          null
+        ]
+      ]
+    }
+  },
+  "assets": {
+    "data": {
+      "href": "./municipal-boundaries.parquet",
+      "type": "application/vnd.apache.parquet",
+      "title": "Municipal boundaries (GeoParquet)",
+      "description": "GeoParquet 1.1, zstd-compressed, spatially ordered, with a bbox covering column and per-row-group statistics.",
+      "roles": [
+        "data"
+      ],
+      "file:size": 18874368,
+      "file:checksum": "1220b7e2c5f0a913d64c8a1e5f27b3960d4c8e2a71f5b90c3d6e8a2b4c7d9e1f3a50"
+    },
+    "visual": {
+      "href": "./municipal-boundaries.pmtiles",
+      "type": "application/vnd.pmtiles",
+      "title": "Municipal boundaries (PMTiles)",
+      "roles": [
+        "visual"
+      ],
+      "file:size": 9437184,
+      "file:checksum": "12203c8e5a2f7b1d9046e3c8f5a2b7d1e4906c3f8a5b2e7d1c4f9a63b8e5d2c7f1a4"
+    },
+    "style-default": {
+      "href": "./styles/default.json",
+      "type": "application/vnd.mapbox.style+json",
+      "title": "Default MapLibre style",
+      "roles": [
+        "style"
+      ],
+      "file:size": 2048,
+      "file:checksum": "12209f4e2b7c5a1d8036f9e2c5b8a1d4e7003c6f9b2e5a8d1c4b7f0a3d6e9c2f5b81"
+    },
+    "thumbnail": {
+      "href": "./thumbnail.png",
+      "type": "image/png",
+      "title": "Preview rendered with the default style",
+      "roles": [
+        "thumbnail"
+      ],
+      "file:size": 145728,
+      "file:checksum": "1220e1a4d7b02c5f8a3e6d9c2b5f8a1e4d70b3c6a9f2e5d8b1c4a7f0e3d6b9c2a5f8"
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "https://data.example.org/andalusia/municipal-boundaries/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "pmtiles",
+      "href": "./municipal-boundaries.pmtiles",
+      "type": "application/vnd.pmtiles",
+      "title": "Web map tiles",
+      "pmtiles:layers": [
+        "municipal-boundaries"
+      ]
+    },
+    {
+      "rel": "via",
+      "href": "https://www.juntadeandalucia.es/institutodeestadisticaycartografia/DERA",
+      "type": "text/html",
+      "title": "Original source (DERA)"
+    },
+    {
+      "rel": "agents",
+      "href": "./AGENTS.md",
+      "type": "text/markdown",
+      "title": "Guidance for AI agents"
+    }
+  ]
+}

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -1,0 +1,134 @@
+{
+  "type": "Collection",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json",
+    "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
+    "https://stac-extensions.github.io/file/v2.1.0/schema.json"
+  ],
+  "id": "buildings",
+  "title": "Buildings of Andalusia",
+  "description": "Building footprints for Andalusia, Spain, partitioned by province into one GeoParquet file per province. All partitions can be read at once with the glob pattern `https://data.example.org/andalusia/buildings/*/*.parquet`.",
+  "license": "CC-BY-4.0",
+  "portolan:version": "0.1.0",
+  "keywords": [
+    "buildings",
+    "footprints",
+    "cadastre",
+    "andalusia"
+  ],
+  "providers": [
+    {
+      "name": "Dirección General del Catastro",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://www.catastro.hacienda.gob.es"
+    },
+    {
+      "name": "Portolan SDI",
+      "roles": [
+        "processor",
+        "host"
+      ],
+      "url": "https://github.com/portolan-sdi"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -7.523,
+          35.938,
+          -1.63,
+          38.729
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2025-06-01T00:00:00Z",
+          null
+        ]
+      ]
+    }
+  },
+  "assets": {
+    "visual": {
+      "href": "./buildings.pmtiles",
+      "type": "application/vnd.pmtiles",
+      "title": "Buildings (PMTiles)",
+      "roles": [
+        "visual"
+      ],
+      "file:size": 268435456,
+      "file:checksum": "1220d5a8e1b4c7f0a3d6e9b2c5f8a1d4e7b0c3f6a9d2e5b8c1f4a7d0e3b6c9f2a5d8"
+    },
+    "style-default": {
+      "href": "./styles/default.json",
+      "type": "application/vnd.mapbox.style+json",
+      "title": "Default MapLibre style",
+      "roles": [
+        "style"
+      ],
+      "file:size": 2304,
+      "file:checksum": "12207b0e3d6c9f2a5b8e1d4c7f0a3b6e9d2c5f8b1e4a7d0c3f6b9e2a5d8c1f4b7e0"
+    },
+    "thumbnail": {
+      "href": "./thumbnail.png",
+      "type": "image/png",
+      "title": "Preview rendered with the default style",
+      "roles": [
+        "thumbnail"
+      ],
+      "file:size": 138204,
+      "file:checksum": "1220a6d9c2f5b8e1a4d7c0f3b6a9e2d5c8f1b4e7a0d3c6f9b2e5a8d1c4f7b0e3a6d9"
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "https://data.example.org/andalusia/buildings/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./buildings-sevilla/item.json",
+      "type": "application/geo+json",
+      "title": "Buildings — Seville province"
+    },
+    {
+      "rel": "pmtiles",
+      "href": "./buildings.pmtiles",
+      "type": "application/vnd.pmtiles",
+      "title": "Web map tiles",
+      "pmtiles:layers": [
+        "buildings"
+      ]
+    },
+    {
+      "rel": "via",
+      "href": "https://www.catastro.hacienda.gob.es/webinspire/index.html",
+      "type": "text/html",
+      "title": "Original source (Spanish Cadastre INSPIRE services)"
+    },
+    {
+      "rel": "agents",
+      "href": "./AGENTS.md",
+      "type": "text/markdown",
+      "title": "Guidance for AI agents"
+    }
+  ]
+}

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -10,7 +10,7 @@
   "title": "Buildings of Andalusia",
   "description": "Building footprints for Andalusia, Spain, partitioned by province into one GeoParquet file per province. All partitions can be read at once with the glob pattern `https://data.example.org/andalusia/buildings/*/*.parquet`.",
   "license": "CC-BY-4.0",
-  "portolan:version": "0.1.0",
+  "updated": "2026-07-15T09:30:00Z",
   "keywords": [
     "buildings",
     "footprints",
@@ -96,11 +96,6 @@
     {
       "rel": "parent",
       "href": "../catalog.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "self",
-      "href": "https://data.example.org/andalusia/buildings/collection.json",
       "type": "application/json"
     },
     {

--- a/stac/examples/vector-partitioned-item.json
+++ b/stac/examples/vector-partitioned-item.json
@@ -2,7 +2,6 @@
   "type": "Feature",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],
   "id": "buildings-sevilla",
@@ -41,8 +40,7 @@
     38.211
   ],
   "properties": {
-    "datetime": "2025-06-01T00:00:00Z",
-    "portolan:version": "0.1.0"
+    "datetime": "2025-06-01T00:00:00Z"
   },
   "assets": {
     "data": {
@@ -72,11 +70,6 @@
       "rel": "collection",
       "href": "../collection.json",
       "type": "application/json"
-    },
-    {
-      "rel": "self",
-      "href": "https://data.example.org/andalusia/buildings/buildings-sevilla/item.json",
-      "type": "application/geo+json"
     }
   ]
 }

--- a/stac/examples/vector-partitioned-item.json
+++ b/stac/examples/vector-partitioned-item.json
@@ -1,0 +1,82 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json",
+    "https://stac-extensions.github.io/file/v2.1.0/schema.json"
+  ],
+  "id": "buildings-sevilla",
+  "collection": "buildings",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -6.542,
+          36.85
+        ],
+        [
+          -4.653,
+          36.85
+        ],
+        [
+          -4.653,
+          38.211
+        ],
+        [
+          -6.542,
+          38.211
+        ],
+        [
+          -6.542,
+          36.85
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    -6.542,
+    36.85,
+    -4.653,
+    38.211
+  ],
+  "properties": {
+    "datetime": "2025-06-01T00:00:00Z",
+    "portolan:version": "0.1.0"
+  },
+  "assets": {
+    "data": {
+      "href": "./sevilla.parquet",
+      "type": "application/vnd.apache.parquet",
+      "title": "Buildings — Seville province (GeoParquet)",
+      "description": "GeoParquet 1.1 partition, zstd-compressed, spatially ordered, bbox covering column with row-group statistics.",
+      "roles": [
+        "data"
+      ],
+      "file:size": 734003200,
+      "file:checksum": "1220a3f8250f8d9a2ad48f6f1d375e0b1c8e3f6a90cc4b2d17e5a8b9c0d1e2f3a4b5"
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "https://data.example.org/andalusia/buildings/buildings-sevilla/item.json",
+      "type": "application/geo+json"
+    }
+  ]
+}

--- a/stac/json-schema/schema.json
+++ b/stac/json-schema/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json#",
-  "title": "Portolan Extension",
-  "description": "The portolan:version field plus the schema-checkable structural requirements of the Portolan specification. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
+  "title": "Portolan STAC Profile",
+  "description": "The schema-checkable structural requirements of the Portolan specification. The versioned schema URI declared in stac_extensions is the single signal of specification version; no portolan-prefixed fields are defined. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
   "oneOf": [
     {
       "$comment": "STAC Catalogs.",
@@ -20,13 +20,10 @@
           "$ref": "#/definitions/stac_extensions"
         },
         {
-          "$ref": "#/definitions/fields"
-        },
-        {
           "$ref": "#/definitions/human_readable"
         },
         {
-          "$ref": "#/definitions/titled_links"
+          "$ref": "#/definitions/links_conformant"
         },
         {
           "$ref": "#/definitions/agents_link"
@@ -49,13 +46,10 @@
           "$ref": "#/definitions/stac_extensions"
         },
         {
-          "$ref": "#/definitions/fields"
-        },
-        {
           "$ref": "#/definitions/human_readable"
         },
         {
-          "$ref": "#/definitions/titled_links"
+          "$ref": "#/definitions/links_conformant"
         },
         {
           "$ref": "#/definitions/agents_link"
@@ -65,6 +59,9 @@
         },
         {
           "$ref": "#/definitions/license_not_proprietary"
+        },
+        {
+          "$ref": "#/definitions/providers_conformant"
         },
         {
           "properties": {
@@ -89,7 +86,7 @@
       ]
     },
     {
-      "$comment": "STAC Items. Portolan fields live in properties.",
+      "$comment": "STAC Items. Items do not declare the Portolan schema URI — declaration happens at the catalog and collection level only, and items inherit conformance from their collection. This branch is applied to items by the Portolan validator, not via stac_extensions.",
       "type": "object",
       "allOf": [
         {
@@ -101,14 +98,7 @@
           }
         },
         {
-          "$ref": "#/definitions/stac_extensions"
-        },
-        {
-          "required": ["properties"],
           "properties": {
-            "properties": {
-              "$ref": "#/definitions/fields"
-            },
             "bbox": {
               "$ref": "#/definitions/valid_bbox"
             }
@@ -118,7 +108,7 @@
           "$ref": "#/definitions/assets_typed_and_roled"
         },
         {
-          "$ref": "#/definitions/titled_links"
+          "$ref": "#/definitions/links_conformant"
         }
       ]
     }
@@ -133,18 +123,6 @@
           "contains": {
             "const": "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json"
           }
-        }
-      }
-    },
-    "fields": {
-      "$comment": "Only portolan:version is defined in v0.1. Other portolan-prefixed fields under discussion (e.g. portolan:geospatial, portolan:styles) are intentionally not validated and not rejected.",
-      "type": "object",
-      "required": ["portolan:version"],
-      "properties": {
-        "portolan:version": {
-          "type": "string",
-          "enum": ["0.1.0"],
-          "description": "Portolan specification version this object was authored against, set to the same version as the declared schema URI. This is the specification version, not the dataset version — dataset versioning uses the STAC version extension."
         }
       }
     },
@@ -163,30 +141,95 @@
         }
       }
     },
-    "titled_links": {
-      "$comment": "Every child and item link carries a human-readable title so browsers can render names without fetching every child.",
+    "links_conformant": {
+      "$comment": "Objects never carry a self link; a catalog is fully portable (pystac SELF_CONTAINED convention). Structural links (root, parent, child, item, collection) are relative and carry the required media type. Every child and item link carries a human-readable title so browsers can render names without fetching every child. Whether every link resolves is a crawling check performed by Portolan tooling.",
       "type": "object",
       "properties": {
         "links": {
           "type": "array",
           "items": {
-            "if": {
-              "required": ["rel"],
-              "properties": {
-                "rel": {
-                  "enum": ["child", "item"]
+            "allOf": [
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "self"
+                    }
+                  }
+                },
+                "then": false
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "enum": ["root", "parent", "child", "collection"]
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "const": "application/json"
+                    },
+                    "href": {
+                      "type": "string",
+                      "minLength": 1,
+                      "not": {
+                        "pattern": "://"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "item"
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "const": "application/geo+json"
+                    },
+                    "href": {
+                      "type": "string",
+                      "minLength": 1,
+                      "not": {
+                        "pattern": "://"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "enum": ["child", "item"]
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["title"],
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
               }
-            },
-            "then": {
-              "required": ["title"],
-              "properties": {
-                "title": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              }
-            }
+            ]
           }
         }
       }
@@ -210,6 +253,55 @@
               }
             }
           }
+        }
+      }
+    },
+    "providers_conformant": {
+      "$comment": "Every collection identifies at least one producer and a host provider reachable through url or email (spec: Providers). That there is exactly one host, listed last, is checked by Portolan tooling, as is deriving official-vs-mirror from producer and host.",
+      "type": "object",
+      "required": ["providers"],
+      "properties": {
+        "providers": {
+          "type": "array",
+          "minItems": 1,
+          "allOf": [
+            {
+              "contains": {
+                "type": "object",
+                "required": ["roles"],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "producer"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "contains": {
+                "type": "object",
+                "required": ["roles"],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "host"
+                    }
+                  }
+                },
+                "anyOf": [
+                  {
+                    "required": ["url"]
+                  },
+                  {
+                    "required": ["email"]
+                  }
+                ]
+              }
+            }
+          ]
         }
       }
     },

--- a/stac/json-schema/schema.json
+++ b/stac/json-schema/schema.json
@@ -1,0 +1,340 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json#",
+  "title": "Portolan Extension",
+  "description": "The portolan:version field plus the schema-checkable structural requirements of the Portolan specification. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
+  "oneOf": [
+    {
+      "$comment": "STAC Catalogs.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Catalog"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/fields"
+        },
+        {
+          "$ref": "#/definitions/human_readable"
+        },
+        {
+          "$ref": "#/definitions/titled_links"
+        },
+        {
+          "$ref": "#/definitions/agents_link"
+        }
+      ]
+    },
+    {
+      "$comment": "STAC Collections.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/fields"
+        },
+        {
+          "$ref": "#/definitions/human_readable"
+        },
+        {
+          "$ref": "#/definitions/titled_links"
+        },
+        {
+          "$ref": "#/definitions/agents_link"
+        },
+        {
+          "$ref": "#/definitions/assets_typed_and_roled"
+        },
+        {
+          "$ref": "#/definitions/license_not_proprietary"
+        },
+        {
+          "properties": {
+            "extent": {
+              "type": "object",
+              "properties": {
+                "spatial": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/valid_bbox"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "$comment": "STAC Items. Portolan fields live in properties.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "required": ["properties"],
+          "properties": {
+            "properties": {
+              "$ref": "#/definitions/fields"
+            },
+            "bbox": {
+              "$ref": "#/definitions/valid_bbox"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/assets_typed_and_roled"
+        },
+        {
+          "$ref": "#/definitions/titled_links"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json"
+          }
+        }
+      }
+    },
+    "fields": {
+      "$comment": "Only portolan:version is defined in v0.1. Other portolan-prefixed fields under discussion (e.g. portolan:geospatial, portolan:styles) are intentionally not validated and not rejected.",
+      "type": "object",
+      "required": ["portolan:version"],
+      "properties": {
+        "portolan:version": {
+          "type": "string",
+          "enum": ["0.1.0"],
+          "description": "Portolan specification version this object was authored against, set to the same version as the declared schema URI. This is the specification version, not the dataset version — dataset versioning uses the STAC version extension."
+        }
+      }
+    },
+    "human_readable": {
+      "$comment": "Every Catalog and Collection carries a non-empty title and description. Whether a title is a raw slug is checked by Portolan tooling, not by schema.",
+      "type": "object",
+      "required": ["title", "description"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "titled_links": {
+      "$comment": "Every child and item link carries a human-readable title so browsers can render names without fetching every child.",
+      "type": "object",
+      "properties": {
+        "links": {
+          "type": "array",
+          "items": {
+            "if": {
+              "required": ["rel"],
+              "properties": {
+                "rel": {
+                  "enum": ["child", "item"]
+                }
+              }
+            },
+            "then": {
+              "required": ["title"],
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "agents_link": {
+      "$comment": "Every Catalog and Collection links its AGENTS.md with rel 'agents' and type text/markdown. The target's existence is a link-resolution check performed by crawling validators.",
+      "type": "object",
+      "required": ["links"],
+      "properties": {
+        "links": {
+          "type": "array",
+          "contains": {
+            "type": "object",
+            "required": ["rel", "href", "type"],
+            "properties": {
+              "rel": {
+                "const": "agents"
+              },
+              "type": {
+                "const": "text/markdown"
+              }
+            }
+          }
+        }
+      }
+    },
+    "assets_typed_and_roled": {
+      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. Every asset also carries file:size and file:checksum (spec: Assets); the checksum's multihash encoding is verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["href", "type", "roles", "file:size", "file:checksum"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "minLength": 1,
+                "anyOf": [
+                  {
+                    "pattern": "^https://"
+                  },
+                  {
+                    "not": {
+                      "pattern": "://"
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "roles": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "file:size": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "file:checksum": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "license_not_proprietary": {
+      "$comment": "The deprecated STAC 1.1 value 'proprietary' is banned; use an SPDX identifier, or 'other' plus a rel 'license' link. SPDX validity and the conditional license link are checked by Portolan tooling.",
+      "type": "object",
+      "properties": {
+        "license": {
+          "not": {
+            "const": "proprietary"
+          }
+        }
+      }
+    },
+    "valid_bbox": {
+      "$comment": "WGS84 ranges exclude sentinel 'effectively infinite' values (e.g. ±1.79e308). NaN and Infinity cannot be expressed in JSON, so they fail at the parser. south <= north is checked by Portolan tooling.",
+      "type": "array",
+      "oneOf": [
+        {
+          "minItems": 4,
+          "maxItems": 4,
+          "items": [
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            }
+          ]
+        },
+        {
+          "minItems": 6,
+          "maxItems": 6,
+          "items": [
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/elevation"
+            },
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/elevation"
+            }
+          ]
+        }
+      ]
+    },
+    "longitude": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "latitude": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "elevation": {
+      "type": "number",
+      "minimum": -100000,
+      "maximum": 100000
+    }
+  }
+}

--- a/stac/package.json
+++ b/stac/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "portolan-stac-profile",
+  "version": "0.1.0",
+  "description": "Portolan STAC profile — JSON Schema for the schema-checkable requirements plus a CEOS-ARD-style profile over reused STAC extensions",
+  "scripts": {
+    "test": "npm run check-markdown && npm run check-examples",
+    "check-markdown": "remark . --frail",
+    "check-examples": "stac-node-validator examples/*.json --schemaMap https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator examples/*.json --schemaMap https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json=./json-schema/schema.json --format"
+  },
+  "devDependencies": {
+    "stac-node-validator": "^1.3.2",
+    "remark-cli": "^12.0.0",
+    "remark-lint": "^10.0.0",
+    "remark-preset-lint-consistent": "^6.0.0",
+    "remark-preset-lint-recommended": "^7.0.0",
+    "remark-validate-links": "^13.0.0"
+  }
+}


### PR DESCRIPTION
Moves the STAC profile from [stac-portolan-extension](https://github.com/portolan-sdi/stac-portolan-extension) (portolan-sdi/stac-portolan-extension#1) into `stac/`, replacing the scaffold, and adapts it to the consolidated v0.1 spec. That repo gets archived once this merges.

- **Schema URI** — `https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json` for now (path matches the intended `portolan-sdi.org/portolan/v0.1.0/schema.json`, so only the host changes later). 404s until a release is tagged and Pages is enabled; CI uses `--schemaMap`.
- **Adapted to the spec** — no `portolan:` fields (the schema URI is the single version signal; declaration is catalog/collection-level, items inherit); schema now also enforces no-`self` + relative typed structural links, and providers (producer + host with url/email). Former open questions (styles as assets, tabular marker, relative links) resolved per the spec; raster styling stays open.
- **Contents** — profile README (normative extensions registry, link relations, media types/roles), JSON Schema, 4 examples (mirrors carry `updated`), validation tooling under `stac/`.
- **CI** — examples + markdown checked on every PR (violations verified to fail); schema published to GitHub Pages on release.