### PR TITLE
Require README.md link with rel: describedby

### DIFF
--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -387,8 +387,12 @@ coordinate-system conventions — anything non-obvious. See
 
 ## README.md
 
-Every catalog and collection MUST have a `README.md` containing at minimum a title,
-description, license, and data provenance.
+Every catalog and collection MUST have a `README.md` in Markdown, referenced in the
+STAC `links` array (`rel: "describedby"`, `type: text/markdown`). Like `AGENTS.md` it
+is a link, not an asset — it describes the data, it is not the data. `describedby` is
+the IANA-registered relation for a resource carrying a description of the linked
+resource, and is already common in STAC. The `README.md` MUST contain at minimum a
+title, description, license, and data provenance.
 
 ## Metadata
 


### PR DESCRIPTION
Closes #61.

The spec requires a `README.md` in every catalog and collection but never
defined how to link it, so the only way to find one was to guess the filename.
This mirrors how we already treat `AGENTS.md`: require a link in the STAC
`links` array so the profile schema can enforce it and link resolution can
confirm the file is actually there.

```json
{
  "rel": "describedby",
  "href": "./README.md",
  "type": "text/markdown"
}
```

`describedby` is the IANA-registered relation for a resource that carries a
description of the linked resource, and it is already common in STAC. Per
discussion on the issue, the link carries an explicit `text/markdown` media
type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)