### PR TITLE
Move format-specific style details from core to formats

### DIFF
--- a/specs/incubating/raster-styling.md
+++ b/specs/incubating/raster-styling.md
@@ -2,8 +2,9 @@
 
 **Status: open, under discussion ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)).**
 
-The [Visualization Styles](../portolan/core.md#visualization-styles) requirements in
-core are **vector-only**: they describe MapLibre GL style files for PMTiles. How
+Portolan's [Visualization Styles](../portolan/core.md#visualization-styles)
+requirements are currently **vector-only**: the concrete style format, defined in
+[`formats.md`](../portolan/formats.md), is a MapLibre GL style file for PMTiles. How
 raster styles are expressed is unspecified.
 
 Open questions:

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -425,21 +425,14 @@ needs no separate style file.
 ### Visualization Styles
 
 When a collection provides a render path it MUST provide at least one style telling
-clients how to draw it, in a compatible format. For PMTiles that is a MapLibre GL
-style file (MapLibre GL style spec v8) in a `styles/` subdirectory, with media type
-`application/vnd.mapbox.style+json`, a complete, self-contained JSON loadable
-directly by MapLibre GL JS. By convention such a file sets `version` 8, a
-human-readable `name`, `sources.data.url` as the relative path from `styles/` to
-the PMTiles file (typically `../filename.pmtiles`), and `layers[].source` to
-`"data"`.
+clients how to draw it, in a format appropriate to that render path. Style files are
+STAC assets: each style MUST be registered as a collection-level asset with `roles:
+["style"]`, alongside the data and thumbnail. A client or agent discovers a
+collection's styles by filtering assets on that role, so no separate manifest is
+needed and this specification defines none. Where multiple styles exist, the default
+SHOULD be listed first.
 
-Style files are STAC assets. Each style MUST be registered as a collection-level
-asset with `roles: ["style"]`, alongside the data and thumbnail; a client or agent
-discovers a collection's styles by filtering assets on that role, so no separate
-manifest is needed and this specification defines none. Where multiple styles
-exist, the default SHOULD be listed first.
-
-> **OPEN — raster styling.** How raster styles are expressed (colormaps, legends,
-> continuous vs. categorical vs. multiband) is unspecified and under discussion.
-> The MapLibre style requirements above are vector-only. See
-> [`specs/incubating/raster-styling.md`](../incubating/raster-styling.md).
+The concrete style format is defined per data format in [`formats.md`](formats.md):
+for vector (PMTiles) it is a MapLibre GL style file, while raster styling is still
+under discussion (see
+[`specs/incubating/raster-styling.md`](../incubating/raster-styling.md)).

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -62,10 +62,14 @@ rather than download, it is expressed as a link by default; when a provider inte
 the PMTiles file as a genuine distribution format of the data, it MAY additionally
 be registered as a collection-level asset, and the link and the asset then coexist.
 
-When PMTiles are provided, the collection MUST include visualization styles as
-standalone STAC assets (complete MapLibre files in `{collection}/styles/`) with the
-`["style"]` role, per [Visualization Styles](core.md#visualization-styles); no
-separate manifest is defined.
+When PMTiles are provided, the collection MUST include at least one visualization
+style as a standalone STAC asset with the `["style"]` role, registered per
+[Visualization Styles](core.md#visualization-styles). For PMTiles the style is a
+MapLibre GL style file (MapLibre GL style spec v8) in a `styles/` subdirectory, with
+media type `application/vnd.mapbox.style+json`, a complete, self-contained JSON
+loadable directly by MapLibre GL JS. By convention such a file sets `version` 8, a
+human-readable `name`, `sources.data.url` as the relative path from `styles/` to the
+PMTiles file (typically `../filename.pmtiles`), and `layers[].source` to `"data"`.
 
 ### Partitioned Collections
 


### PR DESCRIPTION
Per Chris' review comment: the core spec should just say that styles are
required, and each format should define what that means for it.

- **`core.md`** keeps the format-agnostic contract: a collection with a render
  path MUST provide at least one style, registered as a collection-level asset
  with `roles: ["style"]`, default listed first. It no longer describes any
  particular style file, and points to `formats.md` for the concrete format.
- **`formats.md`** (Vector) absorbs the PMTiles-specific detail: the MapLibre
  GL style file, its media type, and the `styles/` conventions.
- **`raster-styling.md`** cross-reference updated to point at `formats.md` for
  the vector style detail.

The `#visualization-styles` anchor is preserved, so existing links from
`best-practices/styling.md`, `raster-styling.md`, and within `core.md` still
resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)