### PR TITLE
Publish schema at canonical schema.portolan-sdi.org domain

### DIFF
--- a/.github/workflows/publish-schema.yaml
+++ b/.github/workflows/publish-schema.yaml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -19,27 +20,32 @@ jobs:
 
       - name: Build site from tracked schema versions
         env:
+          EVENT_NAME: ${{ github.event_name }}
           VERSION: ${{ github.ref_name }}
         run: |
           # Every schema version is tracked in the repo under
           # stac/json-schema/v<semver>/; the site is rebuilt from that tree,
-          # never from what is currently deployed.
-          if [ ! -f "stac/json-schema/${VERSION}/schema.json" ]; then
+          # never from what is currently deployed. The site is served at the
+          # root of schema.portolan-sdi.org, so versions deploy at /v<semver>/.
+          if [ "$EVENT_NAME" = "release" ] && [ ! -f "stac/json-schema/${VERSION}/schema.json" ]; then
             echo "::error::stac/json-schema/${VERSION}/schema.json not found for release ${VERSION}"
             exit 1
           fi
 
-          mkdir -p _site/portolan
+          mkdir -p _site
           for dir in stac/json-schema/v*/; do
             ver=$(basename "$dir")
-            mkdir -p "_site/portolan/${ver}"
-            cp "${dir}schema.json" "_site/portolan/${ver}/"
+            mkdir -p "_site/${ver}"
+            cp "${dir}schema.json" "_site/${ver}/"
           done
 
-          ls -d stac/json-schema/v*/ | xargs -n1 basename | jq -R . | jq -s . > _site/portolan/versions.json
+          ls -d stac/json-schema/v*/ | xargs -n1 basename | jq -R . | jq -s . > _site/versions.json
+
+          # Serve the custom domain on GitHub Pages
+          echo "schema.portolan-sdi.org" > _site/CNAME
 
           # Create index page listing all versions
-          cat > _site/portolan/index.html << 'HTMLEOF'
+          cat > _site/index.html << 'HTMLEOF'
           <!DOCTYPE html>
           <html>
           <head>
@@ -69,20 +75,6 @@ jobs:
                   });
                 });
             </script>
-          </body>
-          </html>
-          HTMLEOF
-
-          # Root index redirects to the schema listing
-          cat > _site/index.html << 'HTMLEOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta http-equiv="refresh" content="0; url=portolan/">
-            <title>Portolan</title>
-          </head>
-          <body>
-            <a href="portolan/">Portolan schemas</a>
           </body>
           </html>
           HTMLEOF

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ defined in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
 The specification is versioned with [SemVer](https://semver.org/), starting pre-1.0.
 A catalog declares the version it was authored against through the **Portolan STAC
 profile schema URI** in its `stac_extensions` array, e.g.
-`https://portolan-sdi.org/portolan/v0.1.0/schema.json`. That schema URI is the
+`https://schema.portolan-sdi.org/v0.1.0/schema.json`. That schema URI is the
 single signal of specification version; there is no separate version file (see
 [Conformance and Versioning](specs/portolan/core.md#conformance-and-versioning)).
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -78,7 +78,7 @@ versioned schema URI carries the specification version the object was authored
 against.
 
 Every catalog and collection MUST declare the versioned Portolan schema URI (e.g.
-`https://portolan-sdi.org/portolan/v0.1.0/schema.json`) in its `stac_extensions`
+`https://schema.portolan-sdi.org/v0.1.0/schema.json`) in its `stac_extensions`
 array. The schema URI is the single signal of specification version; no separate
 version property is defined. Declaration happens at the catalog and collection
 level only, since assets cannot carry `stac_extensions`, and items inherit

--- a/stac/README.md
+++ b/stac/README.md
@@ -3,7 +3,7 @@
 > **Work in Progress** — This profile is under active development. Requirement levels and the schema URL may change before the first stable release.
 
 - **Title:** Portolan
-- **Identifier:** <https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json>
+- **Identifier:** <https://schema.portolan-sdi.org/v0.1.0/schema.json>
 - **Field Name Prefix:** portolan (reserved; no fields defined in v0.1)
 - **Scope:** Catalog, Collection — Items inherit conformance from their collection
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
@@ -42,7 +42,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
-| [Portolan][] | `https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
+| [Portolan][] | `https://schema.portolan-sdi.org/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
 | [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | Every object with assets: `file:size` + `file:checksum` (multihash) on each asset |
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json"
+    "https://schema.portolan-sdi.org/v0.1.0/schema.json"
   ],
   "id": "andalusia-open-geodata",
   "title": "Andalusia Open Geodata",

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json",
+    "https://schema.portolan-sdi.org/v0.1.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json",
+    "https://schema.portolan-sdi.org/v0.1.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],

--- a/stac/json-schema/v0.1.0/schema.json
+++ b/stac/json-schema/v0.1.0/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json#",
+  "$id": "https://schema.portolan-sdi.org/v0.1.0/schema.json#",
   "title": "Portolan STAC Profile",
   "description": "The schema-checkable structural requirements of the Portolan specification. The versioned schema URI declared in stac_extensions is the single signal of specification version; no portolan-prefixed fields are defined. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
   "oneOf": [
@@ -127,7 +127,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://portolan-sdi.github.io/portolan-spec/portolan/v0.1.0/schema.json"
+            "const": "https://schema.portolan-sdi.org/v0.1.0/schema.json"
           }
         }
       }

--- a/stac/package.json
+++ b/stac/package.json
@@ -6,9 +6,9 @@
     "test": "npm run check-markdown && npm run check-version && npm run check-examples && npm run check-portolan",
     "check-markdown": "remark . --frail",
     "check-version": "node scripts/check-version.js",
-    "check-examples": "stac-node-validator examples/*.json --schemaMap https://portolan-sdi.github.io/portolan-spec/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json",
+    "check-examples": "stac-node-validator examples/*.json --schemaMap https://schema.portolan-sdi.org/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json",
     "check-portolan": "node scripts/check-portolan.js",
-    "format-examples": "stac-node-validator examples/*.json --schemaMap https://portolan-sdi.github.io/portolan-spec/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json --format"
+    "format-examples": "stac-node-validator examples/*.json --schemaMap https://schema.portolan-sdi.org/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json --format"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/stac/scripts/check-version.js
+++ b/stac/scripts/check-version.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // The package.json version is the single source of truth for the profile
-// version. The schema for the current version must exist under json-schema/,
-// and every reference to a versioned Portolan schema URI — in the schema
-// itself, the profile README, the examples, and the spec documents — must
-// match it.
+// version, and https://schema.portolan-sdi.org/v<version>/schema.json is the
+// single canonical schema URI. The schema for the current version must exist
+// under json-schema/, and every Portolan schema URI — in the schema itself,
+// the profile README, the examples, and the spec documents — must match the
+// canonical one exactly, host included.
 'use strict';
 
 const fs = require('fs');
@@ -12,15 +13,18 @@ const path = require('path');
 const root = path.join(__dirname, '..');
 const repo = path.join(root, '..');
 const version = require('../package.json').version;
-const expected = `v${version}`;
-const pattern = /portolan\/(v\d+\.\d+\.\d+)\/schema\.json/g;
+const canonical = `https://schema.portolan-sdi.org/v${version}/schema.json`;
+// Any URL that mentions portolan and ends in a versioned schema.json is a
+// Portolan schema URI candidate — this catches stale hosts (github.io, the
+// apex domain) as well as stale versions.
+const pattern = /https:\/\/[^\s"'`<>()\[\]]*portolan[^\s"'`<>()\[\]]*\/v\d+\.\d+\.\d+\/schema\.json/g;
 
 let failed = false;
 const fail = (msg) => { failed = true; console.error(`✗ ${msg}`); };
 
-const schemaPath = path.join(root, 'json-schema', expected, 'schema.json');
+const schemaPath = path.join(root, 'json-schema', `v${version}`, 'schema.json');
 if (!fs.existsSync(schemaPath)) {
-  fail(`json-schema/${expected}/schema.json not found (package.json version is ${version})`);
+  fail(`json-schema/v${version}/schema.json not found (package.json version is ${version})`);
 }
 
 const files = [
@@ -38,12 +42,12 @@ for (const file of files) {
   const rel = path.relative(repo, file);
   const text = fs.readFileSync(file, 'utf8');
   for (const match of text.matchAll(pattern)) {
-    if (match[1] !== expected) {
+    if (match[0] !== canonical) {
       const line = text.slice(0, match.index).split('\n').length;
-      fail(`${rel}:${line} references ${match[1]}, expected ${expected}`);
+      fail(`${rel}:${line} references ${match[0]}, expected ${canonical}`);
     }
   }
 }
 
-if (!failed) console.log(`✓ all Portolan schema URI references match ${expected}`);
+if (!failed) console.log(`✓ all Portolan schema URI references match ${canonical}`);
 process.exit(failed ? 1 : 0);


### PR DESCRIPTION
The schema URL never resolved (Pages disabled, no release, and the repo mixed two hosts: `portolan-sdi.org` in spec text vs `portolan-sdi.github.io` in the schema). Per discussion with Chris, the canonical URI is now `https://schema.portolan-sdi.org/v<version>/schema.json`, served from this repo's GitHub Pages.

- Point all references (schema `$id`/`const`, examples, npm scripts, READMEs, `core.md`) at the canonical URI.
- `check-version` now pins the full URI, host included — host drift fails CI.
- Publish workflow: deploy versions at site root, emit `CNAME`, add `workflow_dispatch` to publish before the v0.1.0 release (~2 weeks).

Outside this PR: repo Pages settings done (source: GitHub Actions, custom domain set); pending DNS CNAME `schema` → `portolan-sdi.github.io` (Chris). Follow-up: align reis's expected schema URI.