### PR TITLE
docs: align schema-host prose with schema.portolan-sdi.org

### DIFF
--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -107,7 +107,7 @@ Validation runs in separable passes:
 The metadata passes MUST be executable without reading asset data; the data pass
 MAY be run independently.
 
-Portolan schemas are published at `portolan-sdi.org`. `versions.json` is a tooling
+Portolan schemas are published at `schema.portolan-sdi.org`. `versions.json` is a tooling
 artifact and is NOT REQUIRED in a catalog for v0.1.
 
 ## Recommended STAC Extensions


### PR DESCRIPTION
One-line prose fix, follow-up to #65.

#65 updated the schema URI **example** (core.md line 81) to the canonical
`https://schema.portolan-sdi.org/v0.1.0/schema.json`, but the prose sentence
below it still said *"Portolan schemas are published at `portolan-sdi.org`"*.
This points it at `schema.portolan-sdi.org`, where the schema is actually
served (DNS live, schema `$id` confirmed).

No behavioral change; documentation consistency only. Surfaced while syncing
the reis validator to the canonical host (portolan-sdi/reis#6).