### PR TITLE
Namespace schema publishing under schemas.portolan-sdi.org

### DIFF
--- a/.github/workflows/publish-schema.yaml
+++ b/.github/workflows/publish-schema.yaml
@@ -25,27 +25,42 @@ jobs:
         run: |
           # Every schema version is tracked in the repo under
           # stac/json-schema/v<semver>/; the site is rebuilt from that tree,
-          # never from what is currently deployed. The site is served at the
-          # root of schema.portolan-sdi.org, so versions deploy at /v<semver>/.
+          # never from what is currently deployed. schemas.portolan-sdi.org
+          # hosts one path segment per schema; this profile lives under
+          # /portolan/, so versions deploy at /portolan/v<semver>/.
           if [ "$EVENT_NAME" = "release" ] && [ ! -f "stac/json-schema/${VERSION}/schema.json" ]; then
             echo "::error::stac/json-schema/${VERSION}/schema.json not found for release ${VERSION}"
             exit 1
           fi
 
-          mkdir -p _site
+          mkdir -p _site/portolan
           for dir in stac/json-schema/v*/; do
             ver=$(basename "$dir")
-            mkdir -p "_site/${ver}"
-            cp "${dir}schema.json" "_site/${ver}/"
+            mkdir -p "_site/portolan/${ver}"
+            cp "${dir}schema.json" "_site/portolan/${ver}/"
           done
 
-          ls -d stac/json-schema/v*/ | xargs -n1 basename | jq -R . | jq -s . > _site/versions.json
+          ls -d stac/json-schema/v*/ | xargs -n1 basename | jq -R . | jq -s . > _site/portolan/versions.json
 
           # Serve the custom domain on GitHub Pages
-          echo "schema.portolan-sdi.org" > _site/CNAME
+          echo "schemas.portolan-sdi.org" > _site/CNAME
 
-          # Create index page listing all versions
+          # Root index redirects to the profile schema listing
           cat > _site/index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="refresh" content="0; url=portolan/">
+            <title>Portolan schemas</title>
+          </head>
+          <body>
+            <a href="portolan/">Portolan schemas</a>
+          </body>
+          </html>
+          HTMLEOF
+
+          # Create index page listing all versions of the profile schema
+          cat > _site/portolan/index.html << 'HTMLEOF'
           <!DOCTYPE html>
           <html>
           <head>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ defined in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
 The specification is versioned with [SemVer](https://semver.org/), starting pre-1.0.
 A catalog declares the version it was authored against through the **Portolan STAC
 profile schema URI** in its `stac_extensions` array, e.g.
-`https://schema.portolan-sdi.org/v0.1.0/schema.json`. That schema URI is the
+`https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json`. That schema URI is the
 single signal of specification version; there is no separate version file (see
 [Conformance and Versioning](specs/portolan/core.md#conformance-and-versioning)).
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -78,7 +78,7 @@ versioned schema URI carries the specification version the object was authored
 against.
 
 Every catalog and collection MUST declare the versioned Portolan schema URI (e.g.
-`https://schema.portolan-sdi.org/v0.1.0/schema.json`) in its `stac_extensions`
+`https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json`) in its `stac_extensions`
 array. The schema URI is the single signal of specification version; no separate
 version property is defined. Declaration happens at the catalog and collection
 level only, since assets cannot carry `stac_extensions`, and items inherit
@@ -107,7 +107,7 @@ Validation runs in separable passes:
 The metadata passes MUST be executable without reading asset data; the data pass
 MAY be run independently.
 
-Portolan schemas are published at `schema.portolan-sdi.org`. `versions.json` is a tooling
+Portolan schemas are published at `schemas.portolan-sdi.org`. `versions.json` is a tooling
 artifact and is NOT REQUIRED in a catalog for v0.1.
 
 ## Recommended STAC Extensions

--- a/stac/README.md
+++ b/stac/README.md
@@ -3,7 +3,7 @@
 > **Work in Progress** — This profile is under active development. Requirement levels and the schema URL may change before the first stable release.
 
 - **Title:** Portolan
-- **Identifier:** <https://schema.portolan-sdi.org/v0.1.0/schema.json>
+- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json>
 - **Field Name Prefix:** portolan (reserved; no fields defined in v0.1)
 - **Scope:** Catalog, Collection — Items inherit conformance from their collection
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
@@ -42,7 +42,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
-| [Portolan][] | `https://schema.portolan-sdi.org/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
+| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
 | [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | Every object with assets: `file:size` + `file:checksum` (multihash) on each asset |
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schema.portolan-sdi.org/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
   ],
   "id": "andalusia-open-geodata",
   "title": "Andalusia Open Geodata",

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schema.portolan-sdi.org/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schema.portolan-sdi.org/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],

--- a/stac/json-schema/v0.1.0/schema.json
+++ b/stac/json-schema/v0.1.0/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schema.portolan-sdi.org/v0.1.0/schema.json#",
+  "$id": "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json#",
   "title": "Portolan STAC Profile",
   "description": "The schema-checkable structural requirements of the Portolan specification. The versioned schema URI declared in stac_extensions is the single signal of specification version; no portolan-prefixed fields are defined. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
   "oneOf": [
@@ -127,7 +127,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://schema.portolan-sdi.org/v0.1.0/schema.json"
+            "const": "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
           }
         }
       }

--- a/stac/package.json
+++ b/stac/package.json
@@ -6,9 +6,9 @@
     "test": "npm run check-markdown && npm run check-version && npm run check-examples && npm run check-portolan",
     "check-markdown": "remark . --frail",
     "check-version": "node scripts/check-version.js",
-    "check-examples": "stac-node-validator examples/*.json --schemaMap https://schema.portolan-sdi.org/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json",
+    "check-examples": "stac-node-validator examples/*.json --schemaMap https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json",
     "check-portolan": "node scripts/check-portolan.js",
-    "format-examples": "stac-node-validator examples/*.json --schemaMap https://schema.portolan-sdi.org/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json --format"
+    "format-examples": "stac-node-validator examples/*.json --schemaMap https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json --format"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/stac/scripts/check-version.js
+++ b/stac/scripts/check-version.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // The package.json version is the single source of truth for the profile
-// version, and https://schema.portolan-sdi.org/v<version>/schema.json is the
+// version, and https://schemas.portolan-sdi.org/portolan/v<version>/schema.json is the
 // single canonical schema URI. The schema for the current version must exist
 // under json-schema/, and every Portolan schema URI — in the schema itself,
 // the profile README, the examples, and the spec documents — must match the
@@ -13,7 +13,7 @@ const path = require('path');
 const root = path.join(__dirname, '..');
 const repo = path.join(root, '..');
 const version = require('../package.json').version;
-const canonical = `https://schema.portolan-sdi.org/v${version}/schema.json`;
+const canonical = `https://schemas.portolan-sdi.org/portolan/v${version}/schema.json`;
 // Any URL that mentions portolan and ends in a versioned schema.json is a
 // Portolan schema URI candidate — this catches stale hosts (github.io, the
 // apex domain) as well as stale versions.


### PR DESCRIPTION
Per Chris's suggestion: more than one Portolan schema is plausible (per-format subprofiles, the incubating raster-styling extension), so the host becomes plural and each schema gets a path segment. New canonical URI:

```
https://schemas.portolan-sdi.org/portolan/v<version>/schema.json
```

- All references (schema `$id`/`const`, examples, npm scripts, READMEs, `core.md`) point at the namespaced URI.
- Publish workflow deploys the profile under `/portolan/` (own `versions.json` + index, root redirects there); `CNAME` file updated.
- `check-version` pins the new canonical URI; the previous one now fails CI.

Outside this PR: DNS CNAME `schemas` → `portolan-sdi.github.io` is already live (Chris); Pages custom domain must be switched to `schemas.portolan-sdi.org` (Cayetano) before the next publish run. reis PR #6's `SCHEMA_URI_PATTERN` should target `^https://schemas\.portolan-sdi\.org/portolan/v\d+\.\d+\.\d+/schema\.json$`.