### PR TITLE
feat(examples): declare table:primary_geometry and table:row_count

### DIFF
--- a/examples/build.py
+++ b/examples/build.py
@@ -821,9 +821,11 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
         data_name = data_pq.name
         bbox, n, norm = to_geoparquet(local, src, data_pq)
         cols = table_columns(data_pq)
+        geom_col = next((c["name"] for c in cols if c["type"] == "geometry"), "geom")
         assets["data"] = asset(data_pq, MEDIA["geoparquet"], ["data"],
                                f"{spec['title']} (GeoParquet)",
-                               {"table:columns": cols, "proj:code": "EPSG:4326"})
+                               {"table:columns": cols, "table:primary_geometry": geom_col,
+                                "table:row_count": n, "proj:code": "EPSG:4326"})
         exts += [TABLE_EXT, PROJ_EXT]
         assets["source"] = source_asset(local, src)
         if deriv.get("pmtiles"):
@@ -876,7 +878,8 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
         n = feature_count(data_pq)
         bbox = None
         assets["data"] = asset(data_pq, MEDIA["parquet"], ["data"],
-                               f"{spec['title']} (Parquet)", {"table:columns": cols})
+                               f"{spec['title']} (Parquet)",
+                               {"table:columns": cols, "table:row_count": n})
         assets["source"] = source_asset(local, src)
         exts.append(TABLE_EXT)
         extra_readme = [f"Rows, {n}.", f"Columns, {len(cols)}.",

--- a/examples/catalog/reference/boundaries/boston-open-space/collection.json
+++ b/examples/catalog/reference/boundaries/boston-open-space/collection.json
@@ -146,6 +146,8 @@
           "type": "struct(xmin double, ymin double, xmax double, ymax double)"
         }
       ],
+      "table:primary_geometry": "geom",
+      "table:row_count": 1012,
       "proj:code": "EPSG:4326"
     },
     "source": {

--- a/examples/catalog/reference/boundaries/netherlands-provinces/collection.json
+++ b/examples/catalog/reference/boundaries/netherlands-provinces/collection.json
@@ -109,6 +109,8 @@
           "type": "struct(xmin double, ymin double, xmax double, ymax double)"
         }
       ],
+      "table:primary_geometry": "geom",
+      "table:row_count": 12,
       "proj:code": "EPSG:4326"
     },
     "source": {

--- a/examples/catalog/reference/boundaries/us-counties/collection.json
+++ b/examples/catalog/reference/boundaries/us-counties/collection.json
@@ -129,6 +129,8 @@
           "type": "struct(xmin double, ymin double, xmax double, ymax double)"
         }
       ],
+      "table:primary_geometry": "geom",
+      "table:row_count": 3235,
       "proj:code": "EPSG:4326"
     },
     "source": {

--- a/examples/catalog/reference/mirror/san-francisco-addresses/collection.json
+++ b/examples/catalog/reference/mirror/san-francisco-addresses/collection.json
@@ -204,6 +204,8 @@
           "type": "struct(xmin double, ymin double, xmax double, ymax double)"
         }
       ],
+      "table:primary_geometry": "geom",
+      "table:row_count": 5000,
       "proj:code": "EPSG:4326"
     },
     "source": {

--- a/examples/catalog/reference/reference/natural-earth-countries/collection.json
+++ b/examples/catalog/reference/reference/natural-earth-countries/collection.json
@@ -752,6 +752,8 @@
           "type": "struct(xmin double, ymin double, xmax double, ymax double)"
         }
       ],
+      "table:primary_geometry": "geom",
+      "table:row_count": 177,
       "proj:code": "EPSG:4326"
     },
     "source": {

--- a/examples/catalog/reference/reference/natural-earth-populated-places/collection.json
+++ b/examples/catalog/reference/reference/natural-earth-populated-places/collection.json
@@ -628,6 +628,8 @@
           "type": "struct(xmin double, ymin double, xmax double, ymax double)"
         }
       ],
+      "table:primary_geometry": "geom",
+      "table:row_count": 1251,
       "proj:code": "EPSG:4326"
     },
     "source": {

--- a/examples/catalog/reference/tabular/eurostat-electricity-prices/collection.json
+++ b/examples/catalog/reference/tabular/eurostat-electricity-prices/collection.json
@@ -112,7 +112,8 @@
           "name": "CONF_STATUS",
           "type": "varchar"
         }
-      ]
+      ],
+      "table:row_count": 65412
     },
     "source": {
       "href": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false",


### PR DESCRIPTION
Follow-up to #68.

The `table` extension we use is on the latest release (v1.2.0), but the data assets carried only `table:columns`. Two fields were missing.

- **`table:primary_geometry`** names the geometry column on every GeoParquet asset. The projection extension is declared on the same asset, and the spec defines `proj:code`, `proj:bbox` and friends relative to the primary geometry, so without it a reader cannot tell which column the CRS applies to. Libraries like geopandas and sf also use it to pick the active geometry.
- **`table:row_count`** records the feature or row count on both the GeoParquet and the plain Parquet assets, a value the generator already computes.

The geometry column is detected from the described column types rather than hardcoded. The change is purely additive, no asset checksums move, and the full build re-validates clean against `stac/json-schema/v0.1.0/schema.json`.
