### PR TITLE
feat: bind partition extension into spec and profile

### DIFF
--- a/.github/workflows/publish-schema.yaml
+++ b/.github/workflows/publish-schema.yaml
@@ -18,53 +18,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build site from tracked schema versions
+      - name: Build site from tracked and pinned schema versions
         env:
           EVENT_NAME: ${{ github.event_name }}
           VERSION: ${{ github.ref_name }}
         run: |
-          # Every schema version is tracked in the repo under
-          # stac/json-schema/v<semver>/; the site is rebuilt from that tree,
-          # never from what is currently deployed. schemas.portolan-sdi.org
-          # hosts one path segment per schema; this profile lives under
-          # /portolan/, so versions deploy at /portolan/v<semver>/.
+          set -euo pipefail
+
+          # schemas.portolan-sdi.org hosts one path segment per schema. The
+          # Portolan profile lives under /portolan/, rebuilt from the versions
+          # tracked in this repo under stac/json-schema/v<semver>/. The
+          # portolan-sdi extension schemas live in their own repositories and
+          # are pinned in stac/portolan-extensions.json; each pinned version is
+          # fetched from its source repo at build time and served under
+          # /<name>/<version>/. The site is never rebuilt from what is
+          # currently deployed.
           if [ "$EVENT_NAME" = "release" ] && [ ! -f "stac/json-schema/${VERSION}/schema.json" ]; then
             echo "::error::stac/json-schema/${VERSION}/schema.json not found for release ${VERSION}"
             exit 1
           fi
 
-          mkdir -p _site/portolan
-          for dir in stac/json-schema/v*/; do
-            ver=$(basename "$dir")
-            mkdir -p "_site/portolan/${ver}"
-            cp "${dir}schema.json" "_site/portolan/${ver}/"
-          done
+          MANIFEST=stac/portolan-extensions.json
 
-          ls -d stac/json-schema/v*/ | xargs -n1 basename | jq -R . | jq -s . > _site/portolan/versions.json
-
-          # Serve the custom domain on GitHub Pages
-          echo "schemas.portolan-sdi.org" > _site/CNAME
-
-          # Root index redirects to the profile schema listing
-          cat > _site/index.html << 'HTMLEOF'
+          # Per-family index page: title $1, source repo $2, output path $3.
+          family_index() {
+            sed "s/__TITLE__/$1/g; s|__REPO__|$2|g" > "$3" << 'HTMLEOF'
           <!DOCTYPE html>
           <html>
           <head>
-            <meta http-equiv="refresh" content="0; url=portolan/">
-            <title>Portolan schemas</title>
-          </head>
-          <body>
-            <a href="portolan/">Portolan schemas</a>
-          </body>
-          </html>
-          HTMLEOF
-
-          # Create index page listing all versions of the profile schema
-          cat > _site/portolan/index.html << 'HTMLEOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>Portolan STAC Profile</title>
+            <title>__TITLE__</title>
             <style>
               body { font-family: system-ui, sans-serif; max-width: 600px; margin: 2rem auto; padding: 0 1rem; }
               h1 { color: #333; }
@@ -74,8 +56,8 @@ jobs:
             </style>
           </head>
           <body>
-            <h1>Portolan STAC Profile</h1>
-            <p>JSON Schema for the <a href="https://github.com/portolan-sdi/portolan-spec">Portolan STAC profile</a>.</p>
+            <h1>__TITLE__</h1>
+            <p>JSON Schema for <a href="https://github.com/__REPO__">__REPO__</a>.</p>
             <h2>Available Versions</h2>
             <ul id="versions"></ul>
             <script>
@@ -93,6 +75,69 @@ jobs:
           </body>
           </html>
           HTMLEOF
+          }
+
+          # Portolan profile: tracked schema versions.
+          mkdir -p _site/portolan
+          for dir in stac/json-schema/v*/; do
+            ver=$(basename "$dir")
+            mkdir -p "_site/portolan/${ver}"
+            cp "${dir}schema.json" "_site/portolan/${ver}/"
+          done
+          ls -d stac/json-schema/v*/ | xargs -n1 basename | jq -R . | jq -s . > _site/portolan/versions.json
+          family_index "Portolan STAC Profile" "portolan-sdi/portolan-spec" _site/portolan/index.html
+
+          # Extension schemas: pinned versions fetched from their source repos.
+          for name in $(jq -r 'keys[] | select(startswith("$") | not)' "$MANIFEST"); do
+            repo=$(jq -r --arg n "$name" '.[$n].repo' "$MANIFEST")
+            file=$(jq -r --arg n "$name" '.[$n].path' "$MANIFEST")
+            title=$(jq -r --arg n "$name" '.[$n].title' "$MANIFEST")
+            for ver in $(jq -r --arg n "$name" '.[$n].versions | keys[]' "$MANIFEST"); do
+              ref=$(jq -r --arg n "$name" --arg v "$ver" '.[$n].versions[$v]' "$MANIFEST")
+              mkdir -p "_site/${name}/${ver}"
+              if ! curl -sfL "https://raw.githubusercontent.com/${repo}/${ref}/${file}" \
+                  -o "_site/${name}/${ver}/schema.json"; then
+                echo "::error::failed to fetch ${name} ${ver} from ${repo}@${ref}"
+                exit 1
+              fi
+            done
+            jq --arg n "$name" '.[$n].versions | keys' "$MANIFEST" > "_site/${name}/versions.json"
+            family_index "$title" "$repo" "_site/${name}/index.html"
+          done
+
+          # Serve the custom domain on GitHub Pages
+          echo "schemas.portolan-sdi.org" > _site/CNAME
+
+          # Root index lists every schema family.
+          {
+            cat << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>Portolan schemas</title>
+            <style>
+              body { font-family: system-ui, sans-serif; max-width: 600px; margin: 2rem auto; padding: 0 1rem; }
+              h1 { color: #333; }
+              ul { list-style: none; padding: 0; }
+              li { margin: 0.5rem 0; }
+              a { color: #0066cc; }
+            </style>
+          </head>
+          <body>
+            <h1>Portolan schemas</h1>
+            <ul>
+              <li><a href="portolan/">Portolan STAC Profile</a></li>
+          HTMLEOF
+            for name in $(jq -r 'keys[] | select(startswith("$") | not)' "$MANIFEST"); do
+              title=$(jq -r --arg n "$name" '.[$n].title' "$MANIFEST")
+              echo "      <li><a href=\"${name}/\">${title}</a></li>"
+            done
+            cat << 'HTMLEOF'
+            </ul>
+          </body>
+          </html>
+          HTMLEOF
+          } > _site/index.html
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -75,9 +75,10 @@ PMTiles file (typically `../filename.pmtiles`), and `layers[].source` to `"data"
 
 Large files MAY be partitioned. Partitioning MUST be described per the
 [partition extension](https://github.com/portolan-sdi/stac-partition-extension)
-(v1.0.0), with its schema declared in `stac_extensions`; field definitions and
-requirement levels live in the extension and are not restated here. Portolan adds
-the requirements the extension does not cover:
+(v1.0.0), with its schema declared in `stac_extensions` and its required fields
+carried — `partition:scheme`, `partition:keys`, and `partition:glob`. Field
+definitions live in the extension and are not restated here. Portolan adds the
+requirements the extension does not cover:
 
 - The scheme's path structure MUST reflect spatial extent so readers can prune
   files without reading metadata.

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -73,14 +73,27 @@ PMTiles file (typically `../filename.pmtiles`), and `layers[].source` to `"data"
 
 ### Partitioned Collections
 
-Large files MAY be partitioned. When partitioned, the scheme's path structure MUST
-reflect spatial extent so readers can prune files without reading metadata.
+Large files MAY be partitioned. Partitioning MUST be described per the
+[partition extension](https://github.com/portolan-sdi/stac-partition-extension)
+(v1.0.0), with its schema declared in `stac_extensions`; field definitions and
+requirement levels live in the extension and are not restated here. Portolan adds
+the requirements the extension does not cover:
+
+- The scheme's path structure MUST reflect spatial extent so readers can prune
+  files without reading metadata.
+- `partition:glob` is the normative bulk-access path; the collection description
+  SHOULD also mention the glob for human readers, but validators read only the
+  field. The https-only rule for absolute asset hrefs does not extend to the
+  glob: globs are consumed by partition-aware readers rather than browsers, and
+  bucket-native schemes (`s3://`, `gs://`) MAY be used where those readers need
+  them (glob expansion requires listing, which plain https does not provide).
+- Every partition file MUST share a single Parquet schema — the same columns,
+  names, and types — so the glob can be queried as one table. This is validated
+  by tooling reading file footers, not by JSON schema.
+
 Partition files MAY be represented as items when partitions are user-meaningful
 units (countries, regions); for opaque schemes (hilbert, s2, h3) or hundreds of
-partitions, items SHOULD NOT be created — the glob pattern is the access path. The
-collection description MUST include a glob pattern for accessing all partitions at
-once (for example `s3://bucket/buildings/*.parquet`), since most users want a
-single URL rather than enumerating items.
+partitions, items SHOULD NOT be created — the glob pattern is the access path.
 
 As a rough guide, consider partitioning files over ~2 GB, targeting 200 MB–1 GB per
 file — fewer, larger files outperform many small ones for DuckDB. This is not

--- a/stac/.gitignore
+++ b/stac/.gitignore
@@ -1,2 +1,3 @@
 /package-lock.json
 /node_modules
+/.schema-cache

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Partition binding: a collection carrying any `partition:*` field, or declaring
   the partition extension, must declare
-  `https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json` in
+  `https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json` in
   `stac_extensions` and carry `partition:scheme`, `partition:keys`, and
   `partition:glob`. `partition:glob` is the normative bulk-access path.
 - `portolan-extensions.json`: pins which portolan-sdi extension schema versions

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Partition binding: a collection carrying any `partition:*` field, or declaring
+  the partition extension, must declare
+  `https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json` in
+  `stac_extensions` and carry `partition:scheme`, `partition:keys`, and
+  `partition:glob`. `partition:glob` is the normative bulk-access path.
+- `portolan-extensions.json`: pins which portolan-sdi extension schema versions
+  are published under `schemas.portolan-sdi.org/<name>/<version>/`. The publish
+  workflow fetches pinned versions from their source repos at build time; the
+  test suite fetches them into `.schema-cache/` and applies them to examples
+  that declare them.
+
 - Initial version of the Portolan STAC profile, moved from the
   `stac-portolan-extension` repository into `stac/`.
 - JSON Schema covering the specification's schema-checkable structural

--- a/stac/README.md
+++ b/stac/README.md
@@ -48,7 +48,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |
 | [Raster][] | `https://stac-extensions.github.io/raster/v2.0.0/schema.json`               | **MUST**    | When band-level detail is provided |
 | [Vector][] | `https://stac-extensions.github.io/vector/v0.1.0/schema.json`               | **MUST**    | When layer-level detail is provided |
-| [Partition][] | `https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json`              | **MUST**    | Partitioned collections: `partition:scheme`, `partition:keys`, `partition:glob` (spec: Partitioned Collections) |
+| [Partition][] | `https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json`              | **MUST**    | Partitioned collections: `partition:scheme`, `partition:keys`, `partition:glob` (spec: Partitioned Collections) |
 | [Table][] | `https://stac-extensions.github.io/table/v1.2.0/schema.json`                | SHOULD      | Tabular collections: document columns with `table:columns` |
 | [Alternate Assets][] | `https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json`     | SHOULD      | Expose `s3://` alternates for absolute `https` asset hrefs |
 | [Render][] | `https://stac-extensions.github.io/render/v2.0.0/schema.json`               | SHOULD      | Continuous rasters rendering from source (draw-time colorization) |

--- a/stac/README.md
+++ b/stac/README.md
@@ -48,6 +48,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |
 | [Raster][] | `https://stac-extensions.github.io/raster/v2.0.0/schema.json`               | **MUST**    | When band-level detail is provided |
 | [Vector][] | `https://stac-extensions.github.io/vector/v0.1.0/schema.json`               | **MUST**    | When layer-level detail is provided |
+| [Partition][] | `https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json`              | **MUST**    | Partitioned collections: `partition:scheme`, `partition:keys`, `partition:glob` (spec: Partitioned Collections) |
 | [Table][] | `https://stac-extensions.github.io/table/v1.2.0/schema.json`                | SHOULD      | Tabular collections: document columns with `table:columns` |
 | [Alternate Assets][] | `https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json`     | SHOULD      | Expose `s3://` alternates for absolute `https` asset hrefs |
 | [Render][] | `https://stac-extensions.github.io/render/v2.0.0/schema.json`               | SHOULD      | Continuous rasters rendering from source (draw-time colorization) |
@@ -67,6 +68,7 @@ As the profile grows, per-format requirement sets (vector, raster, tabular) may 
 [Version]: https://github.com/stac-extensions/version
 [Raster]: https://github.com/stac-extensions/raster
 [Vector]: https://github.com/stac-extensions/vector
+[Partition]: https://github.com/portolan-sdi/stac-partition-extension
 [Table]: https://github.com/stac-extensions/table
 [Projection]: https://github.com/stac-extensions/projection
 [Alternate Assets]: https://github.com/stac-extensions/alternate-assets
@@ -145,7 +147,7 @@ The files are stored flat in `examples/` for convenience, but their relative hre
 
 ## Building and Testing
 
-Every published schema version is tracked in this repository under `json-schema/v<version>/schema.json`; the `version` field in `package.json` names the current one and is the single source of truth. The publish workflow deploys the site from that tree.
+Every published schema version is tracked in this repository under `json-schema/v<version>/schema.json`; the `version` field in `package.json` names the current one and is the single source of truth. The portolan-sdi extension schemas (currently [partition](https://github.com/portolan-sdi/stac-partition-extension)) live in their own repositories; [`portolan-extensions.json`](portolan-extensions.json) pins which versions are published under `schemas.portolan-sdi.org/<name>/<version>/`, so bumping a pin — like binding the profile to a new extension version — is a change to this repository. The publish workflow deploys the site from the tracked tree plus the pinned extension schemas fetched from their source repos.
 
 From `stac/`:
 
@@ -154,12 +156,12 @@ npm install
 npm test
 ```
 
-`npm test` runs:
+`npm test` runs (after a `pretest` step that fetches the pinned extension schemas into the gitignored `.schema-cache/`):
 
 - **check-markdown** — remark lint over the profile documents.
 - **check-version** — every versioned Portolan schema URI reference (schema `$id`, READMEs, examples, spec documents) matches the `package.json` version, and the matching `json-schema/v<version>/` directory exists.
 - **check-examples** — [stac-node-validator](https://github.com/stac-utils/stac-node-validator) validates the examples, applying the schema where `stac_extensions` declares it.
-- **check-portolan** — validates every example directly against the schema with ajv, the way the Portolan validator does. This is what exercises the schema's item rules — items never declare the schema URI, so `check-examples` alone would never apply it to them. It also verifies the examples' `file:checksum` values are well-formed sha2-256 multihashes, which the schema deliberately delegates to tooling.
+- **check-portolan** — validates every example directly against the schema with ajv, the way the Portolan validator does. This is what exercises the schema's item rules — items never declare the schema URI, so `check-examples` alone would never apply it to them. It also applies the pinned extension schemas to every example that declares them, and verifies the examples' `file:checksum` values are well-formed sha2-256 multihashes, which the schema deliberately delegates to tooling.
 
 ## Contributing
 

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -3,7 +3,7 @@
   "stac_version": "1.1.0",
   "stac_extensions": [
     "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
-    "https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json",
+    "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -3,6 +3,7 @@
   "stac_version": "1.1.0",
   "stac_extensions": [
     "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],
@@ -17,6 +18,17 @@
     "cadastre",
     "andalusia"
   ],
+  "partition:scheme": "directory",
+  "partition:strategy": "attribute",
+  "partition:keys": [
+    {
+      "name": "province",
+      "type": "string",
+      "description": "Province of Andalusia, one GeoParquet file per province"
+    }
+  ],
+  "partition:file_count": 8,
+  "partition:glob": "https://data.example.org/andalusia/buildings/*/*.parquet",
   "providers": [
     {
       "name": "Dirección General del Catastro",

--- a/stac/json-schema/v0.1.0/schema.json
+++ b/stac/json-schema/v0.1.0/schema.json
@@ -70,6 +70,9 @@
           "$ref": "#/definitions/providers_conformant"
         },
         {
+          "$ref": "#/definitions/partition_conformant"
+        },
+        {
           "properties": {
             "extent": {
               "type": "object",
@@ -377,6 +380,51 @@
                 "type": "string",
                 "minLength": 1
               }
+            }
+          }
+        }
+      }
+    },
+    "partition_conformant": {
+      "$comment": "A partitioned collection declares the partition extension and carries its required fields (spec: Partitioned Collections). Any partition:* field without the declared extension, or a declaration missing a required field, fails. Field shapes are validated by the partition extension schema itself, which Portolan validators apply alongside this profile; cross-partition Parquet schema consistency is checked by tooling reading file footers.",
+      "type": "object",
+      "if": {
+        "anyOf": [
+          {
+            "required": ["partition:scheme"]
+          },
+          {
+            "required": ["partition:keys"]
+          },
+          {
+            "required": ["partition:strategy"]
+          },
+          {
+            "required": ["partition:file_count"]
+          },
+          {
+            "required": ["partition:glob"]
+          },
+          {
+            "required": ["stac_extensions"],
+            "properties": {
+              "stac_extensions": {
+                "type": "array",
+                "contains": {
+                  "const": "https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "required": ["partition:scheme", "partition:keys", "partition:glob", "stac_extensions"],
+        "properties": {
+          "stac_extensions": {
+            "type": "array",
+            "contains": {
+              "const": "https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json"
             }
           }
         }

--- a/stac/json-schema/v0.1.0/schema.json
+++ b/stac/json-schema/v0.1.0/schema.json
@@ -411,7 +411,7 @@
               "stac_extensions": {
                 "type": "array",
                 "contains": {
-                  "const": "https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json"
+                  "const": "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json"
                 }
               }
             }
@@ -424,7 +424,7 @@
           "stac_extensions": {
             "type": "array",
             "contains": {
-              "const": "https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json"
+              "const": "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json"
             }
           }
         }

--- a/stac/package.json
+++ b/stac/package.json
@@ -8,9 +8,9 @@
     "fetch-extension-schemas": "node scripts/fetch-extension-schemas.js",
     "check-markdown": "remark . --frail",
     "check-version": "node scripts/check-version.js",
-    "check-examples": "stac-node-validator examples/*.json --schemaMap \"https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json;https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json=./.schema-cache/partition/v1.0.0/schema.json\"",
+    "check-examples": "stac-node-validator examples/*.json --schemaMap \"https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json;https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json=./.schema-cache/incubating/partition/v1.0.0/schema.json\"",
     "check-portolan": "node scripts/check-portolan.js",
-    "format-examples": "stac-node-validator examples/*.json --schemaMap \"https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json;https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json=./.schema-cache/partition/v1.0.0/schema.json\" --format"
+    "format-examples": "stac-node-validator examples/*.json --schemaMap \"https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json;https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json=./.schema-cache/incubating/partition/v1.0.0/schema.json\" --format"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/stac/package.json
+++ b/stac/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "description": "Portolan STAC profile — JSON Schema for the schema-checkable requirements plus a profile over reused STAC extensions",
   "scripts": {
+    "pretest": "node scripts/fetch-extension-schemas.js",
     "test": "npm run check-markdown && npm run check-version && npm run check-examples && npm run check-portolan",
+    "fetch-extension-schemas": "node scripts/fetch-extension-schemas.js",
     "check-markdown": "remark . --frail",
     "check-version": "node scripts/check-version.js",
-    "check-examples": "stac-node-validator examples/*.json --schemaMap https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json",
+    "check-examples": "stac-node-validator examples/*.json --schemaMap \"https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json;https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json=./.schema-cache/partition/v1.0.0/schema.json\"",
     "check-portolan": "node scripts/check-portolan.js",
-    "format-examples": "stac-node-validator examples/*.json --schemaMap https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json --format"
+    "format-examples": "stac-node-validator examples/*.json --schemaMap \"https://schemas.portolan-sdi.org/portolan/v$npm_package_version/schema.json=./json-schema/v$npm_package_version/schema.json;https://schemas.portolan-sdi.org/partition/v1.0.0/schema.json=./.schema-cache/partition/v1.0.0/schema.json\" --format"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/stac/portolan-extensions.json
+++ b/stac/portolan-extensions.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Registry of the portolan-sdi org's own STAC extensions published under schemas.portolan-sdi.org. Each schema lives in its source repository; this file pins which versions are published, mapping each version to the git ref to fetch it from. The publish workflow serves these at https://schemas.portolan-sdi.org/<name>/<version>/schema.json and the test suite fetches them into .schema-cache/, so bumping a pin is a spec-repo change and profile bindings move together with published schemas. PIN NOTE: partition temporarily pins the commit of the canonical-URI PR branch; repoint to ref v1.0.0 once that release is tagged.",
+  "partition": {
+    "title": "STAC Partition Extension",
+    "repo": "portolan-sdi/stac-partition-extension",
+    "path": "json-schema/schema.json",
+    "versions": {
+      "v1.0.0": "638370d62d879d34e420d58acd87ccebd7cfadc5"
+    }
+  }
+}

--- a/stac/portolan-extensions.json
+++ b/stac/portolan-extensions.json
@@ -1,11 +1,11 @@
 {
-  "$comment": "Registry of the portolan-sdi org's own STAC extensions published under schemas.portolan-sdi.org. Each schema lives in its source repository; this file pins which versions are published, mapping each version to the git ref to fetch it from. The publish workflow serves these at https://schemas.portolan-sdi.org/<name>/<version>/schema.json and the test suite fetches them into .schema-cache/, so bumping a pin is a spec-repo change and profile bindings move together with published schemas. PIN NOTE: partition temporarily pins the commit of the canonical-URI PR branch; repoint to ref v1.0.0 once that release is tagged.",
-  "partition": {
+  "$comment": "Registry of the portolan-sdi org's own STAC extensions published under schemas.portolan-sdi.org. Each schema lives in its source repository; this file pins which versions are published, mapping each version to the git ref to fetch it from. The publish workflow serves these at https://schemas.portolan-sdi.org/<name>/<version>/schema.json and the test suite fetches them into .schema-cache/, so bumping a pin is a spec-repo change and profile bindings move together with published schemas. Extensions incubating toward stac-extensions publish under incubating/<name>. PIN NOTE: partition temporarily pins the commit of the canonical-URI PR branch; repoint to ref v1.0.0 once that release is tagged.",
+  "incubating/partition": {
     "title": "STAC Partition Extension",
     "repo": "portolan-sdi/stac-partition-extension",
     "path": "json-schema/schema.json",
     "versions": {
-      "v1.0.0": "638370d62d879d34e420d58acd87ccebd7cfadc5"
+      "v1.0.0": "c4269be16e287435e10e9ee07dfc0970f0ff58bd"
     }
   }
 }

--- a/stac/scripts/check-portolan.js
+++ b/stac/scripts/check-portolan.js
@@ -4,6 +4,9 @@
 // their collection), so stac-node-validator's schemaMap never applies the
 // schema's item branch to them — this script applies the schema to every
 // example regardless of declaration, the way the Portolan validator does.
+// It also applies the pinned portolan-sdi extension schemas (fetched into
+// .schema-cache/ by fetch-extension-schemas.js) to every example that
+// declares them.
 'use strict';
 
 const fs = require('fs');
@@ -17,6 +20,24 @@ const examplesDir = path.join(__dirname, '..', 'examples');
 const ajv = new Ajv({ allErrors: true, strict: false });
 const validate = ajv.compile(JSON.parse(fs.readFileSync(schemaPath, 'utf8')));
 
+const extensions = require('../portolan-extensions.json');
+const extValidators = {};
+for (const [name, ext] of Object.entries(extensions)) {
+  if (name.startsWith('$')) continue;
+  for (const ver of Object.keys(ext.versions)) {
+    const uri = `https://schemas.portolan-sdi.org/${name}/${ver}/schema.json`;
+    const cached = path.join(__dirname, '..', '.schema-cache', name, ver, 'schema.json');
+    if (!fs.existsSync(cached)) {
+      console.error(`✗ ${name} ${ver}: schema not cached — run \`node scripts/fetch-extension-schemas.js\``);
+      process.exit(1);
+    }
+    extValidators[uri] = {
+      label: `${name} ${ver}`,
+      validate: ajv.compile(JSON.parse(fs.readFileSync(cached, 'utf8'))),
+    };
+  }
+}
+
 let failed = false;
 
 const names = fs.readdirSync(examplesDir).filter((f) => f.endsWith('.json')).sort();
@@ -26,6 +47,13 @@ for (const name of names) {
 
   if (!validate(doc)) {
     errors.push(...validate.errors.map((e) => `${e.instancePath || '/'} ${e.message}`));
+  }
+
+  for (const uri of doc.stac_extensions || []) {
+    const ext = extValidators[uri];
+    if (ext && !ext.validate(doc)) {
+      errors.push(...ext.validate.errors.map((e) => `[${ext.label}] ${e.instancePath || '/'} ${e.message}`));
+    }
   }
 
   // The schema deliberately delegates multihash validity to tooling; the

--- a/stac/scripts/check-version.js
+++ b/stac/scripts/check-version.js
@@ -16,8 +16,20 @@ const version = require('../package.json').version;
 const canonical = `https://schemas.portolan-sdi.org/portolan/v${version}/schema.json`;
 // Any URL that mentions portolan and ends in a versioned schema.json is a
 // Portolan schema URI candidate — this catches stale hosts (github.io, the
-// apex domain) as well as stale versions.
+// apex domain) as well as stale versions. Extension schema URIs pinned in
+// portolan-extensions.json also match (schemas.portolan-sdi.org contains
+// "portolan"), so the pinned canonical URIs are exempted; anything else —
+// a stale extension version or host — still fails.
 const pattern = /https:\/\/[^\s"'`<>()\[\]]*portolan[^\s"'`<>()\[\]]*\/v\d+\.\d+\.\d+\/schema\.json/g;
+
+const extensions = require('../portolan-extensions.json');
+const pinned = new Set();
+for (const [name, ext] of Object.entries(extensions)) {
+  if (name.startsWith('$')) continue;
+  for (const ver of Object.keys(ext.versions)) {
+    pinned.add(`https://schemas.portolan-sdi.org/${name}/${ver}/schema.json`);
+  }
+}
 
 let failed = false;
 const fail = (msg) => { failed = true; console.error(`✗ ${msg}`); };
@@ -32,6 +44,7 @@ const files = [
   path.join(root, 'README.md'),
   path.join(repo, 'README.md'),
   path.join(repo, 'specs', 'portolan', 'core.md'),
+  path.join(repo, 'specs', 'portolan', 'formats.md'),
   ...fs.readdirSync(path.join(root, 'examples'))
     .filter((f) => f.endsWith('.json'))
     .map((f) => path.join(root, 'examples', f)),
@@ -42,6 +55,7 @@ for (const file of files) {
   const rel = path.relative(repo, file);
   const text = fs.readFileSync(file, 'utf8');
   for (const match of text.matchAll(pattern)) {
+    if (pinned.has(match[0])) continue;
     if (match[0] !== canonical) {
       const line = text.slice(0, match.index).split('\n').length;
       fail(`${rel}:${line} references ${match[0]}, expected ${canonical}`);

--- a/stac/scripts/fetch-extension-schemas.js
+++ b/stac/scripts/fetch-extension-schemas.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Fetches the pinned portolan-sdi extension schemas listed in
+// portolan-extensions.json into .schema-cache/ so the test suite can apply
+// them without the published site being live. Each fetched schema's $id must
+// match its canonical https://schemas.portolan-sdi.org/<name>/<version>/schema.json
+// URI. Pins are immutable refs, so an existing cache entry is reused; pass
+// --force to refetch.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const root = path.join(__dirname, '..');
+const manifest = require('../portolan-extensions.json');
+const force = process.argv.includes('--force');
+
+function get(url, redirects = 5) {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location && redirects > 0) {
+        res.resume();
+        return resolve(get(res.headers.location, redirects - 1));
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+      }
+      let body = '';
+      res.on('data', (d) => { body += d; });
+      res.on('end', () => resolve(body));
+    }).on('error', reject);
+  });
+}
+
+(async () => {
+  for (const [name, ext] of Object.entries(manifest)) {
+    if (name.startsWith('$')) continue;
+    for (const [version, ref] of Object.entries(ext.versions)) {
+      const dest = path.join(root, '.schema-cache', name, version, 'schema.json');
+      if (fs.existsSync(dest) && !force) {
+        console.log(`✓ ${name} ${version} (cached)`);
+        continue;
+      }
+      const url = `https://raw.githubusercontent.com/${ext.repo}/${ref}/${ext.path}`;
+      const body = await get(url);
+      const schema = JSON.parse(body);
+      const canonical = `https://schemas.portolan-sdi.org/${name}/${version}/schema.json`;
+      const id = String(schema.$id || '').replace(/#$/, '');
+      if (id !== canonical) {
+        throw new Error(`${name} ${version}: fetched $id ${schema.$id} does not match ${canonical}`);
+      }
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, body);
+      console.log(`✓ ${name} ${version} fetched from ${ext.repo}@${ref}`);
+    }
+  }
+})().catch((e) => {
+  console.error(`✗ ${e.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #70.

- `formats.md`: the partition extension is the normative partition mechanism — partitioned collections declare it in `stac_extensions`; field definitions and requirement levels live in the extension. Portolan adds what it doesn't cover: path structure reflects spatial extent, `partition:glob` is the normative bulk-access path (description mention is a SHOULD), one Parquet schema across all partition files.
- Profile schema: any `partition:*` field or extension declaration requires the declaration plus `partition:scheme`, `partition:keys`, `partition:glob`.
- `portolan-extensions.json` pins extension schema versions published under `schemas.portolan-sdi.org/<name>/<version>/`; the publish workflow fetches pins at build time, tests cache and apply them.

Note: the partition pin points at the head of portolan-sdi/stac-partition-extension#3; flip it to `v1.0.0` once that PR merges and the tag is cut.