### PR TITLE
Best practices: documentation, catalog philosophy, and the grader

### DIFF
--- a/specs/best-practices/README.md
+++ b/specs/best-practices/README.md
@@ -5,23 +5,14 @@ requirement — those live in [`specs/portolan/`](../portolan/). These are discu
 pieces and recommendations on how to build good Portolan catalogs, aimed at both
 the people who publish them and the agents that consume them.
 
-Over time this is also where the **catalog grader** will live — the criteria behind
-rating a catalog A+, B, C, and so on.
-
 ## Contents
 
+- [`documentation.md`](documentation.md) — what belongs in your `AGENTS.md` and
+  what makes a good `README.md`.
+- [`philosophy.md`](philosophy.md) — how to think about scoping, organizing, and
+  maintaining a Portolan catalog; pointers to exemplary catalogs.
+- [`grader.md`](grader.md) — the rubric for rating catalog quality, A+ through F.
 - [`styling.md`](styling.md) — making visualization styles that are clear and
   distinctive across a catalog.
 - [`conversion-defaults.md`](conversion-defaults.md) — the COG, partition, and
   thumbnail settings the Portolan CLI uses when converting source data.
-
-## Planned
-
-Stubs for guidance we intend to write (contributions welcome — open a PR):
-
-- **What belongs in your `AGENTS.md`** — how to write the agent-facing guide that
-  core requires, and what actually helps an agent use the data.
-- **What makes a good `README.md`** — the human-facing counterpart.
-- **Catalog philosophy** — how to think about scoping, organizing, and maintaining
-  a Portolan catalog; pointers to exemplary catalogs.
-- **The grader** — the rubric for rating catalog quality.

--- a/specs/best-practices/documentation.md
+++ b/specs/best-practices/documentation.md
@@ -1,0 +1,104 @@
+# Best Practices — Documentation
+
+Every catalog and collection carries two documentation files: an
+[`AGENTS.md`](../portolan/core.md#agentsmd) for agents and a
+[`README.md`](../portolan/core.md#readmemd) for humans. Core requires both files
+and sets a content minimum for the README. This page covers what to put in
+them, drawn from the catalogs whose documentation agents use most successfully
+today.
+
+## Two files, two audiences
+
+Write the README for a person deciding whether to trust and use the data. Write
+the AGENTS.md for an agent that has already committed to using it and now needs
+to get queries right on the first try. The files share a subject but not a job,
+so resist copying one into the other. A README schema table orients a reader;
+an AGENTS.md that names the join key saves an agent a failed query.
+
+## What belongs in AGENTS.md
+
+The strongest agent guides published so far, such as the per-collection guides
+in [Portolan NL](https://source.coop/cholmes/portolan-nl), share a recognizable
+shape. In rough priority order:
+
+- **What the data is, and how it connects.** Two or three sentences of context,
+  then the identifiers that matter: which column is the stable key, and which
+  codes join to other datasets. Portolan NL's administrative-areas guide points
+  out that its CBS municipality codes are the join key used across all Dutch
+  government data. That one sentence unlocks every cross-dataset query.
+
+- **Runnable access patterns.** Show the exact DuckDB or GeoPandas invocation
+  against the published URL, not a placeholder. For partitioned collections,
+  include the glob pattern that reads every partition in one query. Note when
+  remote reads stream over HTTP range requests, so agents query in place
+  instead of downloading.
+
+- **Quirks and caveats.** The highest-value section, because it holds what no
+  schema can express. Real examples from Portolan NL: parcel ids are re-issued
+  each year, so cross-year identity needs a spatial join; the RGB and infrared
+  bands were flown in different seasons; black tile edges are unmasked nodata;
+  one category exists in the data only from 2023 onward. Each sentence of this
+  kind prevents a silently wrong answer.
+
+- **The coordinate system, with consequences.** Name the CRS and say what
+  follows from it. "EPSG:28992 is in metres, so `ST_Area` returns square
+  metres. Divide by 10,000 for hectares" teaches more than the code alone.
+
+- **Schema semantics.** Types and names live in `table:columns`; meaning lives
+  here. Decode cryptic column names and code systems, state units, and when a
+  collection ships several data files, document the schema of each file
+  separately.
+
+- **Query recipes worth stealing.** A handful of queries an analyst would run:
+  an aggregation, a point-in-polygon lookup, a join into a related collection.
+  Write recipes by running them, so they double as tests of the documentation.
+
+- **Related collections and provenance.** Point at sibling collections that
+  join well. Record how the data was produced, ideally as the exact command.
+  Portolan NL's crop-parcels guide includes the full `ogr2ogr` invocation,
+  flags and all, plus the geometry fix it needed.
+
+Leave out what the machine metadata already says. Restating extents, licenses,
+and row counts from `collection.json` pads the file without helping. Agents
+read the JSON too, and duplicated facts drift.
+
+## What makes a good README.md
+
+Core requires a title, description, license, and provenance. Treat that as a
+floor.
+
+- **Numbers build trust.** State feature counts, coverage, and the vintage of
+  the data in the opening paragraph. "All 63,073 nationally listed monuments"
+  tells a reader more than "monument locations".
+
+- **A schema table with described columns.** A column table with a description
+  per field is the single most useful section for a human evaluating fit.
+  Those descriptions belong in `table:columns` as well. Write them once in a
+  manifest and generate both.
+
+- **One runnable Quick Start.** A few lines of GeoPandas or DuckDB against the
+  published URL. One tested snippet beats four aspirational ones.
+
+- **Catalog-level READMEs are tables of contents.** At the root and at each
+  sub-catalog, a collections table (title, feature count, geometry, one-line
+  description) plus a short section on where the data comes from gives a
+  reader the whole shape of the catalog in one screen.
+
+- **Cross-reference the agent guide.** A one-line callout near the top,
+  pointing agents at the AGENTS.md, routes each audience to its file.
+
+## Keep the documentation honest
+
+Drift between prose and metadata is the most common defect in otherwise strong
+catalogs: a README that lists a collection the catalog no longer contains,
+feature counts that disagree between pages, a Quick Start URL that returns 404
+after a layout change, a guide claiming public domain while the metadata says
+otherwise. Three habits prevent it:
+
+- Generate documentation from the STAC metadata on every publish, so tables
+  and counts cannot diverge from the catalog they describe.
+- Run every example before publishing. A broken Quick Start costs more trust
+  than no Quick Start.
+- When a description exists only in prose, propagate it into the metadata.
+  Hand-written schema tables that never reach `table:columns` help humans and
+  strand agents.

--- a/specs/best-practices/documentation.md
+++ b/specs/best-practices/documentation.md
@@ -7,6 +7,17 @@ and sets a content minimum for the README. This page covers what to put in
 them, drawn from the catalogs whose documentation agents use most successfully
 today.
 
+The goal of all of it, borrowed from the
+[Candid Core Framework](https://lettersfromthreadedfoundry.substack.com/p/candid-core-framework)
+(Trochim & Roy, 2025, [doi:10.5281/zenodo.15227664](https://doi.org/10.5281/zenodo.15227664)),
+is to help users "swiftly, accurately, and confidently assess a dataset's
+practical value". Discovery is the solved half of the problem: a well-formed
+STAC catalog can be found and crawled. What documentation adds is
+evaluability. In the framework's words, effective metadata must transparently
+communicate "articulated data quality, explicitly acknowledged biases, candid
+limitations, recommended use cases informed by real-world insights, and
+collective community knowledge shared transparently."
+
 ## Two files, two audiences
 
 Write the README for a person deciding whether to trust and use the data. Write
@@ -14,6 +25,54 @@ the AGENTS.md for an agent that has already committed to using it and now needs
 to get queries right on the first try. The files share a subject but not a job,
 so resist copying one into the other. A README schema table orients a reader;
 an AGENTS.md that names the join key saves an agent a failed query.
+
+The STAC `description` field is a third surface, and it overlaps the README by
+design. They are two interfaces to the same facts: the description serves
+browsers, search results, and item lists; the README serves a person who has
+already clicked through. Duplication between them is fine. Drift is not, so
+generate both from one source where you can, and when you hand-edit one,
+update the other.
+
+## Evaluate the data, not just describe it
+
+A schema table and an extent tell a user what the data is. The documentation
+that earns trust also tells them what it is *for*, and what it is not for.
+Future versions of this guidance may make these required sections; today they
+separate complete documentation from excellent documentation.
+
+- **Suggested uses.** Name what the data has actually supported: the analysis
+  in the source paper, the operational program it feeds, the question a known
+  user answered with it. Attributed, real uses beat abstract claims of
+  suitability. Keep them informative rather than restrictive; a list of
+  proven uses invites reuse, a fence around "intended use" forecloses it.
+
+- **Application limitations and inappropriate uses.** Say when *not* to use
+  the data, in plain terms. The [FTW global
+  catalog](https://source.coop/ftw/global-data) does this well: a field
+  polygon "is a *remote-sensing field unit*, **not** a cadastral/legal parcel.
+  This is not a land-tenure product." One sentence like that prevents a whole
+  category of misuse that no accuracy figure would catch.
+
+- **Accuracy and uncertainty, quantified.** Report the validation numbers,
+  and where confidence varies, ship it as data: a per-record confidence
+  column or an uncertainty layer, with the derivation and a recommended
+  threshold documented. An honest 85% with a map of where it is weak serves
+  users better than an unqualified 95%.
+
+- **Known biases.** State where the data is weaker, by region, season, or
+  class, and why. FTW again: the confidence layer "is conservative outside
+  the training distribution (e.g. smallholder systems)", with the suggested
+  mitigation alongside. Naming a bias is what lets a user work around it.
+
+- **Definitions.** When the data asserts a category — forest, urban, field,
+  building — state the threshold and cite the definition used. Published
+  forest datasets disagree by millions of square kilometres on definitional
+  grounds alone. The category boundary is metadata, not a footnote.
+
+Put these caveats where they will be seen. A warning buried in prose is easily
+missed once the data itself looks clean and continuous, so state limitations
+in the README *and* carry what you can in structured metadata: confidence as a
+column, quality masks as assets, definitions in column descriptions.
 
 ## What belongs in AGENTS.md
 
@@ -65,19 +124,42 @@ read the JSON too, and duplicated facts drift.
 ## What makes a good README.md
 
 Core requires a title, description, license, and provenance. Treat that as a
-floor.
+floor. The README is the landing page: for most users, human or agent, it is
+the first and often only thing read before deciding to use the data or move
+on. Write it as a narrative that carries a reader from "what is this" to
+"how do I get it", not as a checklist of fields.
 
 - **Numbers build trust.** State feature counts, coverage, and the vintage of
   the data in the opening paragraph. "All 63,073 nationally listed monuments"
   tells a reader more than "monument locations".
+
+- **Links carry the context.** Link the paper that describes the methods, the
+  agency page the data comes from, the program that funded collection, and
+  the datasets it derives from, in flowing sentences where each source is
+  introduced, not as a bare reference list at the bottom. The [Planet
+  Venezuela earthquake
+  catalog](https://source.coop/planet/venezuela-earthquake-2026-06-24) quotes
+  its source program's own description and links every location name to the
+  scenes it describes; a reader leaves its README knowing the event, the
+  sensors, and the program, without having opened another tab first.
 
 - **A schema table with described columns.** A column table with a description
   per field is the single most useful section for a human evaluating fit.
   Those descriptions belong in `table:columns` as well. Write them once in a
   manifest and generate both.
 
-- **One runnable Quick Start.** A few lines of GeoPandas or DuckDB against the
-  published URL. One tested snippet beats four aspirational ones.
+- **One runnable Quick Start.** The exact invocation that gets the data, near
+  the top, against the published URL. One tested snippet that answers "this
+  is how you get it" beats four aspirational ones.
+
+- **Escalate to the interesting access pattern.** Past the Quick Start, skip
+  the third and fourth basic query; show the pattern a reader would not have
+  guessed. For a raster collection, that is treating the whole collection as
+  one dataset: the Venezuela catalog turns its scene collection into a single
+  xarray cube with `odc.stac.load`, and into one GDAL VRT from its
+  STAC-GeoParquet index. For vectors, it is the glob query across every
+  partition. One advanced, runnable pattern teaches what the catalog is
+  capable of.
 
 - **Catalog-level READMEs are tables of contents.** At the root and at each
   sub-catalog, a collections table (title, feature count, geometry, one-line
@@ -93,7 +175,10 @@ Drift between prose and metadata is the most common defect in otherwise strong
 catalogs: a README that lists a collection the catalog no longer contains,
 feature counts that disagree between pages, a Quick Start URL that returns 404
 after a layout change, a guide claiming public domain while the metadata says
-otherwise. Three habits prevent it:
+otherwise. An agent guide is especially prone to surviving a refactor intact,
+still describing a structure the catalog no longer has, complete with example
+queries that filter on values that can no longer match. Three habits prevent
+it:
 
 - Generate documentation from the STAC metadata on every publish, so tables
   and counts cannot diverge from the catalog they describe.

--- a/specs/best-practices/grader.md
+++ b/specs/best-practices/grader.md
@@ -1,31 +1,64 @@
 # Best Practices — The Grader
 
 Conformance is pass/fail: a catalog passes the validator or it does not. Above
-that floor, quality is a scale, and this rubric grades it from A+ to F. Every
-criterion below is checkable by inspection — a file resolves or 404s, a field
-is present or absent, a count matches or disagrees — so two reviewers reach
-the same grade.
+that floor, quality is a scale, and this rubric grades it from A+ to F.
+Compliance alone does not make data good — "you can have perfectly FAIR,
+utterly useless data" ([Sundwall,
+2025](https://radiant.earth/blog/2025/11/great-data-products/)) — so the
+rubric measures two different things. Grades up through A rest on criteria
+checkable by inspection: a file resolves or 404s, a field is present or
+absent, a count matches or disagrees, so two reviewers reach the same grade.
+The A+ is a judgment call about whether the catalog is genuinely excellent to
+use, and it is assessed qualitatively.
 
 One principle drives the weighting: **grade the machine contract as hard as
 the visible surface.** The two decouple in practice. A catalog can ship
-resolving thumbnails, thematic styles, and excellent prose while carrying no
-checksums, empty provider lists, and no agent links. Humans notice the first
-set. Agents and validators depend on the second. A rubric that rewards only
-what a browser shows will certify catalogs that fail every machine that reads
-them.
+resolving thumbnails, thematic styles, and excellent prose while carrying
+empty provider lists and no agent links. Humans notice the first set. Agents
+and validators depend on the second. A rubric that rewards only what a
+browser shows will certify catalogs that fail every machine that reads them.
+
+## The ladder
+
+The grades anchor to the spec, so a publisher always knows what a given level
+of effort earns:
+
+- **F** — Not a validating STAC catalog. Malformed JSON, a missing or
+  unreachable root, or structural links broken at scale. There is nothing
+  here for a STAC client to consume.
+- **D** — A real attempt, decently broken. The catalog validates as STAC but
+  misses Portolan requirements in ways that block a class of consumers: a
+  required file class absent throughout, no renderable assets, documentation
+  that contradicts the metadata.
+- **C** — Portolan-compliant, and nothing more. Every MUST in
+  [core](../portolan/core.md) is met: the required files exist and link, the
+  schema URI is declared, primaries are cloud-native. Conformance is the
+  entry ticket, not the destination.
+- **B** — Compliant plus the SHOULDs, executed with minor defects. Thumbnails
+  and styles resolve, agent guides exist at every level, providers and
+  licenses are in order.
+- **A** — Everything checkable, done well. The catalog sits at the top tier
+  of every dimension below: dataset-specific agent guides, multiple
+  purposeful visualizations, a default view that renders, prose that agrees
+  with metadata everywhere.
+- **A+** — Beyond anything the spec names. The judgment-call grade, described
+  in [its own section](#the-a-judgment): candid evaluation of limitations
+  and biases, a narrative that gives real context, an experience that
+  renders instantly and reads beautifully, and contribution back to the
+  shared network. When a user shows up at this catalog, it is an incredible
+  experience.
 
 ## How to read the tiers
 
-Each dimension below anchors three tiers. **A+** is the ceiling worth aiming
-at. **B** is solid: complete with minor defects. **D** is broken in a way that
+Each dimension below anchors three tiers. **A** is the checkable ceiling.
+**B** is solid: complete with minor defects. **D** is broken in a way that
 blocks a class of consumers. Grades between the anchors interpolate: a C is a
-mix of B and D findings, an A meets every B criterion and most of A+. **F** is
-reserved for a catalog missing a required file class outright or whose
-structural links are broken at scale.
+mix of B and D findings. A catalog's checkable grade is capped by these
+dimensions; the A+ sits above them all.
 
 ## 1. Required files and links
 
-- **A+** — `catalog.json`, `AGENTS.md`, and `README.md` exist and resolve at
+- **A** — `catalog.json`, `AGENTS.md`, and `README.md` exist and resolve at
   the root, every sub-catalog, and every collection. Each `AGENTS.md` is
   linked with `rel: "agents"` and each `README.md` with `rel: "describedby"`,
   both typed `text/markdown` and pointing at the raw file. Every catalog and
@@ -40,19 +73,21 @@ structural links are broken at scale.
 
 ## 2. Metadata integrity
 
-- **A+** — Every asset carries `file:checksum` and `file:size` with the
-  registered media type for its format. Every collection lists a producer and
-  exactly one host provider, the host reachable by URL or email. Licenses are
-  valid SPDX identifiers, and mirrors carry `updated`.
-- **B** — Providers, licenses, and media types are in order, but checksums are
-  missing on some assets or `updated` has gone stale.
-- **D** — Checksum coverage is zero, provider lists are empty (so the catalog
-  has no owner and no contact), a forbidden license value like `proprietary`
-  appears, or most data assets carry an unregistered media type.
+- **A** — Every asset carries the registered media type for its format and
+  `file:size`. Every collection lists a producer and exactly one host
+  provider, the host reachable by URL or email. Licenses are valid SPDX
+  identifiers, and mirrors carry `updated`. Checksums (`file:checksum`) are
+  credited when present, and they are cheap to generate, but their absence
+  does not cost a grade.
+- **B** — Providers, licenses, and media types are in order, but `file:size`
+  is missing on some assets or `updated` has gone stale.
+- **D** — Provider lists are empty (so the catalog has no owner and no
+  contact), a forbidden license value like `proprietary` appears, or most
+  data assets carry an unregistered media type.
 
 ## 3. Cloud-native assets
 
-- **A+** — The primary data asset of every collection is cloud-native
+- **A** — The primary data asset of every collection is cloud-native
   (GeoParquet, COG, PMTiles, COPC) with the correct media type, a visual
   derivative exists wherever the source is not self-rendering, legacy formats
   appear only as clearly-roled alternates, and each file is registered exactly
@@ -65,7 +100,7 @@ structural links are broken at scale.
 
 ## 4. Agent documentation
 
-- **A+** — Every `AGENTS.md` is dataset-specific: it names join keys, shows
+- **A** — Every `AGENTS.md` is dataset-specific: it names join keys, shows
   runnable remote queries against published URLs, states the CRS with its
   practical consequences, documents quirks the schema cannot express, offers
   non-trivial query recipes, and points at related collections.
@@ -76,18 +111,43 @@ structural links are broken at scale.
 
 ## 5. Visualization
 
-- **A+** — Every geospatial collection has a thumbnail that resolves and was
+- **A** — Every geospatial collection has a thumbnail that resolves and was
   rendered from its default style, plus at least one style asset per render
-  path with the default listed first. Rich collections offer thematic
-  variants, per the [styling guidance](styling.md).
+  path with the default listed first. The catalog as a whole offers three or
+  more visualizations that express genuinely different aspects of the data —
+  a categorical theme, a confidence surface, a density view — not three
+  renderings of the same picture. The only exception is data that is truly
+  just a geometry with an attribute or two that do not visualize; per the
+  [styling guidance](styling.md).
 - **B** — A resolving thumbnail and a single default style on every
   collection, nothing more.
 - **D** — Geospatial collections missing a thumbnail or a style entirely, or
   thumbnail links that 404.
 
-## 6. Maintenance signals
+## 6. Performance and first render
 
-- **A+** — `updated` is set and recent on every synced object, mirrors carry
+A catalog is judged at its front door: paste the root URL into a STAC
+browser, open a collection, and see whether data appears before the user
+gives up.
+
+- **A** — The default view of every collection renders visible data
+  immediately at its natural full extent. Tiled visual assets carry content
+  from zoom 0 (or the collection's full-extent zoom): sub-pixel features get
+  generalized low-zoom overviews — dissolved coverage, density fills, or
+  representative points — rather than relying on the tiler to drop what does
+  not fit. Visual assets live in the same repository as the catalog that
+  references them.
+- **B** — Everything renders, but slowly or partially: heavyweight
+  thumbnails, low-zoom tiles that are technically present but visually
+  near-empty, a first paint that takes long enough to doubt.
+- **D** — The default view is blank. A tileset whose minimum zoom starts
+  levels below the full extent, with no fallback layer or extent hint, shows
+  a user nothing until they already know where to look — the worst possible
+  first impression, and indistinguishable from a broken catalog.
+
+## 7. Maintenance signals
+
+- **A** — `updated` is set and recent on every synced object, mirrors carry
   `via` and (where upstream publishes STAC) `canonical` links to specific
   upstream endpoints, the host is contactable, and prose agrees with metadata
   everywhere: counts, licenses, and links say the same thing in the README,
@@ -99,9 +159,42 @@ structural links are broken at scale.
   that 404, counts that disagree between levels, a guide claiming one license
   while the JSON declares another.
 
+## The A+ judgment
+
+Everything above can be verified by inspection, and an honest A is a catalog
+anyone can rely on. The A+ asks a different kind of question, drawn from the
+[Candid Core Framework](https://lettersfromthreadedfoundry.substack.com/p/candid-core-framework):
+does this catalog candidly outline known limitations, potential biases, and
+inappropriate use cases to promote responsible data application? Not "is the
+metadata complete", but is the dataset aware of its own blind spots — what
+does it preserve, what does it erase, and does it say so? The grader assesses
+this qualitatively, reading the catalog the way a prospective user would.
+
+Marks of an A+ catalog:
+
+- **Candid evaluation.** Suggested uses grounded in real applications;
+  explicit inappropriate uses ("this is not a land-tenure product");
+  quantified accuracy with uncertainty shipped as data, not just a headline
+  number; named biases with mitigations; definitions stated and cited.
+- **Narrative and context.** The README reads as a story with the links woven
+  in — the source paper, the producing agency, the program behind the data —
+  so a user leaves understanding not just the schema but the world the data
+  describes.
+- **An experience, not just an artifact.** Renders instantly, styled with
+  care, escalating access examples that are runnable and genuinely
+  interesting, documentation scoped correctly at every level of the tree.
+- **Network participation.** The catalog is registered on the Portolan
+  registry. A team can use excellent data internally and earn an A; the A+
+  is reserved for catalogs contributing to the shared network.
+- **Feedback loops.** The code that built the catalog is published, and a
+  user who finds a mistake can file an issue or open a pull request against
+  it. This practice is young and not yet expected, which is exactly why it
+  distinguishes.
+
 ## The overall grade
 
-A catalog's overall grade is its weakest dimension, raised by at most one step
-when most other dimensions sit at A or better. The floor rule is the point:
+A catalog's checkable grade is its weakest dimension, raised by at most one
+step when most other dimensions sit at A. The floor rule is the point:
 excellence in visible dimensions cannot buy back a broken machine contract,
-because the consumers who depend on that contract never see the polish.
+because the consumers who depend on that contract never see the polish. The
+A+ is then awarded, or not, on top of a clean A.

--- a/specs/best-practices/grader.md
+++ b/specs/best-practices/grader.md
@@ -1,0 +1,107 @@
+# Best Practices — The Grader
+
+Conformance is pass/fail: a catalog passes the validator or it does not. Above
+that floor, quality is a scale, and this rubric grades it from A+ to F. Every
+criterion below is checkable by inspection — a file resolves or 404s, a field
+is present or absent, a count matches or disagrees — so two reviewers reach
+the same grade.
+
+One principle drives the weighting: **grade the machine contract as hard as
+the visible surface.** The two decouple in practice. A catalog can ship
+resolving thumbnails, thematic styles, and excellent prose while carrying no
+checksums, empty provider lists, and no agent links. Humans notice the first
+set. Agents and validators depend on the second. A rubric that rewards only
+what a browser shows will certify catalogs that fail every machine that reads
+them.
+
+## How to read the tiers
+
+Each dimension below anchors three tiers. **A+** is the ceiling worth aiming
+at. **B** is solid: complete with minor defects. **D** is broken in a way that
+blocks a class of consumers. Grades between the anchors interpolate: a C is a
+mix of B and D findings, an A meets every B criterion and most of A+. **F** is
+reserved for a catalog missing a required file class outright or whose
+structural links are broken at scale.
+
+## 1. Required files and links
+
+- **A+** — `catalog.json`, `AGENTS.md`, and `README.md` exist and resolve at
+  the root, every sub-catalog, and every collection. Each `AGENTS.md` is
+  linked with `rel: "agents"` and each `README.md` with `rel: "describedby"`,
+  both typed `text/markdown` and pointing at the raw file. Every catalog and
+  collection declares the Portolan schema URI. Structural links are relative;
+  no object carries a `self` link.
+- **B** — All files exist and resolve, with scattered defects: a wrong media
+  type on a `describedby` link, a missing schema URI on some objects, a stray
+  `self` link.
+- **D** — A file class is absent across the catalog (every `AGENTS.md` 404s,
+  or the links to them are missing), the schema URI appears nowhere, or
+  hardcoded `self` links pin every object to one deployment URL.
+
+## 2. Metadata integrity
+
+- **A+** — Every asset carries `file:checksum` and `file:size` with the
+  registered media type for its format. Every collection lists a producer and
+  exactly one host provider, the host reachable by URL or email. Licenses are
+  valid SPDX identifiers, and mirrors carry `updated`.
+- **B** — Providers, licenses, and media types are in order, but checksums are
+  missing on some assets or `updated` has gone stale.
+- **D** — Checksum coverage is zero, provider lists are empty (so the catalog
+  has no owner and no contact), a forbidden license value like `proprietary`
+  appears, or most data assets carry an unregistered media type.
+
+## 3. Cloud-native assets
+
+- **A+** — The primary data asset of every collection is cloud-native
+  (GeoParquet, COG, PMTiles, COPC) with the correct media type, a visual
+  derivative exists wherever the source is not self-rendering, legacy formats
+  appear only as clearly-roled alternates, and each file is registered exactly
+  once.
+- **B** — Cloud-native primaries and visuals throughout, with a mislabeled
+  media type or a legacy file registered as a plain extra asset.
+- **D** — Primaries typed `application/octet-stream` or in server-dependent
+  formats, duplicate asset keys pointing at one file with conflicting roles,
+  or a geospatial collection with no renderable asset at all.
+
+## 4. Agent documentation
+
+- **A+** — Every `AGENTS.md` is dataset-specific: it names join keys, shows
+  runnable remote queries against published URLs, states the CRS with its
+  practical consequences, documents quirks the schema cannot express, offers
+  non-trivial query recipes, and points at related collections.
+- **B** — Present and linked at every level, but thin: access snippets and a
+  schema restatement without quirks, recipes, or cross-references.
+- **D** — Boilerplate repeated across collections, or content that contradicts
+  the machine metadata it describes.
+
+## 5. Visualization
+
+- **A+** — Every geospatial collection has a thumbnail that resolves and was
+  rendered from its default style, plus at least one style asset per render
+  path with the default listed first. Rich collections offer thematic
+  variants, per the [styling guidance](styling.md).
+- **B** — A resolving thumbnail and a single default style on every
+  collection, nothing more.
+- **D** — Geospatial collections missing a thumbnail or a style entirely, or
+  thumbnail links that 404.
+
+## 6. Maintenance signals
+
+- **A+** — `updated` is set and recent on every synced object, mirrors carry
+  `via` and (where upstream publishes STAC) `canonical` links to specific
+  upstream endpoints, the host is contactable, and prose agrees with metadata
+  everywhere: counts, licenses, and links say the same thing in the README,
+  the AGENTS.md, and the JSON.
+- **B** — Provenance links are specific and honest, but `updated` lags or
+  appears only at some levels.
+- **D** — `updated` is null across a mirror, no contact route exists, or the
+  documentation contradicts the metadata: a README table listing collections
+  that 404, counts that disagree between levels, a guide claiming one license
+  while the JSON declares another.
+
+## The overall grade
+
+A catalog's overall grade is its weakest dimension, raised by at most one step
+when most other dimensions sit at A or better. The floor rule is the point:
+excellence in visible dimensions cannot buy back a broken machine contract,
+because the consumers who depend on that contract never see the polish.

--- a/specs/best-practices/philosophy.md
+++ b/specs/best-practices/philosophy.md
@@ -6,6 +6,19 @@ Core defines the shape of a catalog: the required
 page covers the judgment calls the spec leaves open: what one catalog should
 contain, how to organize it, and what maintaining it actually involves.
 
+## Design for the person who shows up
+
+A catalog is a data product, and the measure of a data product is what a
+user can do with it ([Sundwall,
+2025](https://radiant.earth/blog/2025/11/great-data-products/)). Every choice
+below — scope, depth, naming, maintenance — serves one scenario: someone
+arrives at your catalog knowing nothing, and within minutes they understand
+what the data is, whether it fits their problem, and how to get it. The
+README is that first landing point; the structure is what makes the second
+minute as smooth as the first. Optimize for the visitor's experience, not
+the publisher's convenience, and most of the judgment calls resolve
+themselves.
+
 ## Scope by steward, not by theme
 
 The most durable catalog boundaries follow data stewardship.
@@ -16,11 +29,12 @@ sub-catalog inherits one upstream, one license posture, and one contact point
 from its institution, so provenance stays coherent without per-collection
 bookkeeping. Themes shift with fashion. Stewardship rarely moves.
 
-Within a steward's catalog, give each published dataset one collection. Keep
-several data files inside a single collection when they share provenance and a
-schema family. Portolan NL's administrative areas hold municipal, provincial,
-and national boundaries as three GeoParquet assets in one collection rather
-than three collections, because they are one dataset at three levels.
+Within a steward's catalog, give each published dataset one collection. When
+related datasets accumulate — boundaries at several administrative levels, a
+product family with shared provenance — group their collections under a
+sub-catalog rather than packing multiple datasets into one collection as
+sibling assets. A collection whose assets are really three datasets makes
+every consumer disambiguate them; a sub-catalog makes the grouping navigable.
 
 ## Shallow and uniform beats deep and clever
 
@@ -36,13 +50,14 @@ feels tidy.
 ## Names outlive everything
 
 Collection ids become URLs, join targets, and lines in other people's scripts,
-so choose them as contracts. Keep the source's own name for the id, lowercased,
-and let the title carry the translation: Portolan NL uses Dutch ids like
-`bestuurlijke_gebieden` under the English title "Administrative Areas
-(Bestuurlijke Gebieden)", which keeps ids stable against upstream while titles
-serve discovery. Keep tooling artifacts out of ids. An export prefix that
-leaks from an ETL pipeline into a collection id is a temporary detail made
-permanent.
+so choose them as contracts. Keep ids short, lowercase, and snake_case, and
+let the title do the describing: an id like `administrative_areas` under the
+title "Administrative Areas of the Netherlands (municipal, provincial,
+national)" gives scripts a stable handle while the title serves discovery and
+translation. Keep tooling artifacts out of ids. An export prefix that leaks
+from an ETL pipeline into a collection id is a temporary detail made
+permanent, and so is a pipeline stage name like `alpha/` baked into a
+published path.
 
 ## Maintenance is the product
 
@@ -53,10 +68,10 @@ on from one they route around is everything that happens after:
   pages drift: collection tables that link to renamed collections, feature
   counts that disagree between levels, examples that 404 after a layout
   change. Generated pages cannot.
-- **Tend the invisible contract.** Checksums, providers, media types, the
-  schema URI, and `updated` timestamps on mirrors are invisible in a browser
-  and load-bearing for agents and validators. A catalog can look polished,
-  with resolving thumbnails and rich prose, while failing every machine that
+- **Tend the invisible contract.** Providers, media types, the schema URI,
+  and `updated` timestamps on mirrors are invisible in a browser and
+  load-bearing for agents and validators. A catalog can look polished, with
+  resolving thumbnails and rich prose, while failing every machine that
   reads it. Budget maintenance for both surfaces.
 - **Record syncs.** A mirror that never updates `updated` gives consumers no
   way to judge freshness, which reads as abandonment even when the data is
@@ -64,8 +79,36 @@ on from one they route around is everything that happens after:
 
 ## Catalogs worth studying
 
+Different data, different organizations, different concerns — browse them to
+see the patterns before reading about them:
+
 - [Portolan NL](https://browser.portolan-sdi.org/#/external/data.source.coop/cholmes/portolan-nl/catalog.json)
   — an institution-scoped national mirror with exceptional per-collection
   agent guides and thematic style variants.
+- [Planet — Venezuela earthquake](https://source.coop/planet/venezuela-earthquake-2026-06-24)
+  — an event-response imagery catalog: narrative README with the event story
+  up front, escalating access recipes from a browser link to a
+  whole-collection data cube, and pre-merged convenience mosaics so users
+  need not juggle forty tiles.
+- [Fields of the World — Global](https://source.coop/ftw/global-data)
+  — a global ML-derived dataset: candid caveats ("not a land-tenure
+  product"), per-polygon confidence with the derivation documented, quality
+  layers shipped as sibling data, and the build code linked from the catalog
+  itself.
 - The [reference catalog](../../examples/) in this repo — small, fully
   conformant, and regenerated end-to-end from manifests.
+
+This list should grow toward a handful of exemplars across data types and
+publisher types. If you have built a catalog that teaches a pattern these do
+not, propose it.
+
+## This is a discussion
+
+Nothing on this page is definitive. It is a working community's current best
+understanding of how to make great data products, extracted from a small
+number of real catalogs, and it will change as more people publish and
+report back. If your experience contradicts a recommendation here, or your
+catalog solved a problem this page does not cover, open an issue or a pull
+request on the
+[spec repository](https://github.com/portolan-sdi/portolan-spec) — the
+guidance improves the same way the catalogs do.

--- a/specs/best-practices/philosophy.md
+++ b/specs/best-practices/philosophy.md
@@ -1,0 +1,71 @@
+# Best Practices — Catalog Philosophy
+
+Core defines the shape of a catalog: the required
+[structure](../portolan/core.md#core-structure) and the
+[nesting rules](../portolan/core.md#nested-catalogs-flat-collections). This
+page covers the judgment calls the spec leaves open: what one catalog should
+contain, how to organize it, and what maintaining it actually involves.
+
+## Scope by steward, not by theme
+
+The most durable catalog boundaries follow data stewardship.
+[Portolan NL](https://source.coop/cholmes/portolan-nl), a cloud-native mirror
+of Dutch national geodata, organizes 21 collections as one sub-catalog per
+producing institution: Kadaster, Rijkswaterstaat, CBS, and so on. Each
+sub-catalog inherits one upstream, one license posture, and one contact point
+from its institution, so provenance stays coherent without per-collection
+bookkeeping. Themes shift with fashion. Stewardship rarely moves.
+
+Within a steward's catalog, give each published dataset one collection. Keep
+several data files inside a single collection when they share provenance and a
+schema family. Portolan NL's administrative areas hold municipal, provincial,
+and national boundaries as three GeoParquet assets in one collection rather
+than three collections, because they are one dataset at three levels.
+
+## Shallow and uniform beats deep and clever
+
+Portolan NL keeps every path the same length: root, institution, collection.
+No collection sits deeper than another, so traversal is predictable and an
+agent that has walked one branch has learned the whole catalog. Thematic
+groupings ("water infrastructure", "boundaries") appear as tables in the
+README, not as directory levels. Prose reorganizes for free. Directories are
+forever. Add an intermediate catalog when a steward publishes enough
+collections that a flat list stops being readable, not because a taxonomy
+feels tidy.
+
+## Names outlive everything
+
+Collection ids become URLs, join targets, and lines in other people's scripts,
+so choose them as contracts. Keep the source's own name for the id, lowercased,
+and let the title carry the translation: Portolan NL uses Dutch ids like
+`bestuurlijke_gebieden` under the English title "Administrative Areas
+(Bestuurlijke Gebieden)", which keeps ids stable against upstream while titles
+serve discovery. Keep tooling artifacts out of ids. An export prefix that
+leaks from an ETL pipeline into a collection id is a temporary detail made
+permanent.
+
+## Maintenance is the product
+
+Publishing a catalog is the cheap part. What separates a catalog people build
+on from one they route around is everything that happens after:
+
+- **Regenerate documentation from metadata on every publish.** Hand-edited
+  pages drift: collection tables that link to renamed collections, feature
+  counts that disagree between levels, examples that 404 after a layout
+  change. Generated pages cannot.
+- **Tend the invisible contract.** Checksums, providers, media types, the
+  schema URI, and `updated` timestamps on mirrors are invisible in a browser
+  and load-bearing for agents and validators. A catalog can look polished,
+  with resolving thumbnails and rich prose, while failing every machine that
+  reads it. Budget maintenance for both surfaces.
+- **Record syncs.** A mirror that never updates `updated` gives consumers no
+  way to judge freshness, which reads as abandonment even when the data is
+  current.
+
+## Catalogs worth studying
+
+- [Portolan NL](https://browser.portolan-sdi.org/#/external/data.source.coop/cholmes/portolan-nl/catalog.json)
+  — an institution-scoped national mirror with exceptional per-collection
+  agent guides and thematic style variants.
+- The [reference catalog](../../examples/) in this repo — small, fully
+  conformant, and regenerated end-to-end from manifests.


### PR DESCRIPTION
This writes the three remaining pieces from the best-practices Planned list: guidance on `AGENTS.md` and `README.md`, catalog philosophy, and the grader rubric. All three are guidance, not conformance. No normative text changes, so no version bump.

The content is grounded in a survey of Chris Holmes's [Portolan NL](https://browser.portolan-sdi.org/#/external/data.source.coop/cholmes/portolan-nl/catalog.json) catalog, the closest thing we have to a working model of these practices: the root, all six institution catalogs, and 21 collections, checked file by file. The reference catalog in `examples/` served as the second data point.

**`documentation.md`** splits the two files by audience: the README for a person deciding whether to trust the data, the AGENTS.md for an agent that needs its first query to succeed. The AGENTS.md guidance distills the shape of Portolan NL's per-collection agent guides, which predate the `AGENTS.md` convention but are the best agent documentation published against real data so far: join keys, runnable remote queries, quirks no schema can express, and the CRS with its practical consequences. A closing section addresses drift between prose and metadata, the most common defect the survey found. One README in the survey listed a collection that 404s, and one guide claimed public domain while its metadata declared another license.

**`philosophy.md`** recommends scoping by data steward rather than theme, one collection per dataset, shallow uniform hierarchy with thematic groupings in prose, and ids treated as contracts. It closes with the maintenance argument: the machine contract (checksums, providers, media types, `updated`) is invisible in a browser and load-bearing for agents, so a catalog can look polished while failing every machine that reads it.

**`grader.md`** defines six dimensions (required files and links, metadata integrity, cloud-native assets, agent documentation, visualization, maintenance signals) with A+, B, and D anchors per dimension. Every criterion is checkable by inspection rather than taste. The overall grade is the weakest dimension, raised at most one step, so visible polish cannot buy back a broken machine contract. The survey demonstrated why this floor rule matters: Portolan NL grades around B on the visible surface (every sampled thumbnail resolves, styles ship thematic variants) and D on the machine contract (zero checksums across ~178 assets, empty provider lists on 20 of 21 collections).

`specs/best-practices/README.md` moves the three items from Planned to Contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)