### PR TITLE
Define a valid COG and require internal overviews

### DIFF
--- a/specs/best-practices/README.md
+++ b/specs/best-practices/README.md
@@ -12,6 +12,8 @@ rating a catalog A+, B, C, and so on.
 
 - [`styling.md`](styling.md) — making visualization styles that are clear and
   distinctive across a catalog.
+- [`conversion-defaults.md`](conversion-defaults.md) — the COG, partition, and
+  thumbnail settings the Portolan CLI uses when converting source data.
 
 ## Planned
 

--- a/specs/best-practices/conversion-defaults.md
+++ b/specs/best-practices/conversion-defaults.md
@@ -21,8 +21,11 @@ these defaults.
   (horizontal differencing) shrinks integer rasters, and predictor `3` suits
   floating-point data. Skip the predictor for RGB byte imagery and already-compressed
   inputs, where it adds nothing.
-- **Internal tiles: 512×512.** This is the tile size the overview requirement keys
-  off, so a raster wider or taller than 512 pixels needs overviews.
+- **Internal tiles: 512×512.**
+  [OGC 21-026](https://docs.ogc.org/is/21-026/21-026.html#optimized_geotiff-requirements-class)
+  asks for square tiles no larger than a screen viewport and recommends a power of
+  two: 256, 512, or 1024. 512 sits in the middle and is the tile size the overview
+  requirement keys off, so a raster wider or taller than 512 pixels needs overviews.
 - **Overview resampling: nearest for categorical, averaging for continuous.**
   `nearest` preserves exact class values and is the CLI default. For continuous
   imagery, `average` or `bilinear` produce smoother zoomed-out views. Choose by what

--- a/specs/best-practices/conversion-defaults.md
+++ b/specs/best-practices/conversion-defaults.md
@@ -1,0 +1,45 @@
+# Conversion Defaults
+
+This is guidance, not conformance. What a Portolan catalog must contain lives in
+[`specs/portolan/`](../portolan/); this page records the settings the Portolan CLI
+reaches for when it converts source data into cloud-native form. Most are borrowed
+from [rio-cogeo](https://cogeotiff.github.io/rio-cogeo/) and GDAL. A file produced
+with different settings still conforms as long as it meets the requirements in the
+spec, so treat these as sensible starting points rather than rules.
+
+## Raster (COG)
+
+The [Raster section](../portolan/formats.md#raster) requires a valid COG with
+internal overviews and embedded statistics. Within that envelope, the CLI picks
+these defaults.
+
+- **Compression: DEFLATE.** Lossless and readable everywhere, a safe default across
+  data types. `zstd` and `LZW` are fine alternatives where the reader supports them.
+  Reach for lossy `JPEG` or `WEBP` only for visual imagery where some pixel loss is
+  acceptable, never for measured or categorical data.
+- **Predictor: horizontal for integer, floating-point for float.** Predictor `2`
+  (horizontal differencing) shrinks integer rasters, and predictor `3` suits
+  floating-point data. Skip the predictor for RGB byte imagery and already-compressed
+  inputs, where it adds nothing.
+- **Internal tiles: 512×512.** This is the tile size the overview requirement keys
+  off, so a raster wider or taller than 512 pixels needs overviews.
+- **Overview resampling: nearest for categorical, averaging for continuous.**
+  `nearest` preserves exact class values and is the CLI default. For continuous
+  imagery, `average` or `bilinear` produce smoother zoomed-out views. Choose by what
+  the pixels mean.
+
+## Partitioning
+
+When a file is large enough to partition, follow the sizing guidance already in the
+[Partitioned Collections section](../portolan/formats.md#partitioned-collections):
+consider partitioning past roughly 2 GB, target 200 MB to 1 GB per file, and keep
+row groups under 150,000 rows. Fewer, larger files read faster in DuckDB than many
+small ones.
+
+## Thumbnails
+
+Core requires a `thumbnail`-role asset on every Collection. The CLI renders it as a
+small PNG that reads as a real map: projected to Web Mercator at the data's true
+aspect ratio over a light basemap, rather than stretched into a square. A few hundred
+pixels on the long edge is plenty. The thumbnail is a preview to help someone
+recognize the data at a glance, not a substitute for opening it.

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -107,19 +107,35 @@ range-request access without full download. A COG here means a valid COG per the
 [OGC Cloud Optimized GeoTIFF standard](https://docs.ogc.org/is/21-026/21-026.html)
 (OGC 21-026): an internally tiled GeoTIFF carrying georeferencing keys, with a
 header ordered so a reader can find the data it needs in an early range request.
-This is the baseline that `rio cogeo validate` and rasterio treat as a COG.
+This is the baseline that
+[`rio cogeo validate`](https://cogeotiff.github.io/rio-cogeo/CLI/#validate) and
+rasterio treat as a COG.
 (Formats such as GeoZarr are candidates for future support once default tooling can
 render and consume them.)
 
-**Internal overviews.** A raster larger than a single internal tile (512×512 by
-default) MUST carry internal reduced-resolution overviews, so a reader can display it
-zoomed out without fetching full-resolution pixels. The overview pyramid MUST extend
-until its smallest level fits within a single tile. This matches OGC 21-026's
-Optimized GeoTIFF conformance class (`/req/optimized_geotiff`, requirement
-`/req/optimized_geotiff/number`). A raster that already fits within one tile is
-exempt, since it is its own overview. Base COG validators, including
-`rio cogeo validate`, treat missing overviews as a warning rather than a failure;
-Portolan raises this to a requirement, matching the Optimized conformance class.
+**Optimized GeoTIFF conformance.** Beyond that baseline, a COG MUST conform to OGC
+21-026's [Optimized GeoTIFF requirements
+class](https://docs.ogc.org/is/21-026/21-026.html#optimized_geotiff-requirements-class)
+(`/req/optimized_geotiff`), which adds three requirements:
+
+- [Small tiles](https://docs.ogc.org/is/21-026/21-026.html#_requirement_small_tiles)
+  (`/req/optimized_geotiff/small-sizes`): square internal tiles, sized no larger than
+  a common screen viewport. 512×512 is the usual choice.
+- [Reduced-resolution subfiles
+  number](https://docs.ogc.org/is/21-026/21-026.html#_requirement_reduced_resolution_subfiles_number)
+  (`/req/optimized_geotiff/number`): internal overviews, each reducing resolution by a
+  factor between 2 and 10, extending until the coarsest level spans one tile across or
+  down.
+- [GeoTIFF
+  keys](https://docs.ogc.org/is/21-026/21-026.html#_requirement_geotiff_2)
+  (`/req/optimized_geotiff/geotiff`): georeferencing on the full-resolution IFD.
+
+The overview requirement is the one that bites in practice. A raster larger than a
+single internal tile needs internal overviews so a reader can display it zoomed out
+without fetching full-resolution pixels; one that already fits within a tile is exempt,
+since it is its own overview. Base COG validators, including `rio cogeo validate`,
+treat missing overviews as a warning rather than a failure. Portolan raises this to a
+requirement.
 
 **Raster statistics.** COGs MUST carry pixel statistics for rendering. Every band
 MUST carry an embedded minimum, maximum, mean, and standard deviation so a renderer

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -103,8 +103,23 @@ prescriptive; tune to your data and access patterns.
 ## Raster
 
 Raster data MUST be provided as Cloud Optimized GeoTIFF (COG) for efficient
-range-request access without full download. (Formats such as GeoZarr are candidates
-for future support once default tooling can render and consume them.)
+range-request access without full download. A COG here means a valid COG per the
+[OGC Cloud Optimized GeoTIFF standard](https://docs.ogc.org/is/21-026/21-026.html)
+(OGC 21-026): an internally tiled GeoTIFF carrying georeferencing keys, with a
+header ordered so a reader can find the data it needs in an early range request.
+This is the baseline that `rio cogeo validate` and rasterio treat as a COG.
+(Formats such as GeoZarr are candidates for future support once default tooling can
+render and consume them.)
+
+**Internal overviews.** A raster larger than a single internal tile (512×512 by
+default) MUST carry internal reduced-resolution overviews, so a reader can display it
+zoomed out without fetching full-resolution pixels. The overview pyramid MUST extend
+until its smallest level fits within a single tile. This matches OGC 21-026's
+Optimized GeoTIFF conformance class (`/req/optimized_geotiff`, requirement
+`/req/optimized_geotiff/number`). A raster that already fits within one tile is
+exempt, since it is its own overview. Base COG validators, including
+`rio cogeo validate`, treat missing overviews as a warning rather than a failure;
+Portolan raises this to a requirement, matching the Optimized conformance class.
 
 **Raster statistics.** COGs MUST carry pixel statistics for rendering. Every band
 MUST carry an embedded minimum, maximum, mean, and standard deviation so a renderer

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Raster internal overviews: a COG larger than a single internal tile (512×512 by
+  default) must carry internal reduced-resolution overviews, with the pyramid
+  extending until its smallest level fits within one tile. This follows OGC
+  21-026's Optimized GeoTIFF conformance class (`/req/optimized_geotiff`). The
+  Raster section now also defines a valid COG by reference to OGC 21-026, the
+  baseline `rio cogeo validate` and rasterio enforce.
 - Partition binding: a collection carrying any `partition:*` field, or declaring
   the partition extension, must declare
   `https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json` in

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Raster internal overviews: a COG larger than a single internal tile (512×512 by
-  default) must carry internal reduced-resolution overviews, with the pyramid
-  extending until its smallest level fits within one tile. This follows OGC
-  21-026's Optimized GeoTIFF conformance class (`/req/optimized_geotiff`). The
-  Raster section now also defines a valid COG by reference to OGC 21-026, the
-  baseline `rio cogeo validate` and rasterio enforce.
+- Optimized GeoTIFF conformance for rasters: a COG must meet OGC 21-026's
+  Optimized GeoTIFF requirements class (`/req/optimized_geotiff`), covering square
+  viewport-sized internal tiles, internal reduced-resolution overviews reducing by
+  a factor of 2 to 10 until the coarsest level spans one tile, and GeoTIFF keys on
+  the full-resolution IFD. The Raster section now also defines a valid COG by
+  reference to OGC 21-026, the baseline `rio cogeo validate` and rasterio enforce.
 - Partition binding: a collection carrying any `partition:*` field, or declaring
   the partition extension, must declare
   `https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json` in


### PR DESCRIPTION
## What

Portolan said raster data "MUST be a COG" but never said what a valid COG *is*, and it treated every COG creation setting as either invisible or implicitly required. This splits that gap in two: a structural requirement in the normative spec, and tuning defaults in best practices.

### Normative (`specs/portolan/formats.md`)

- Define a valid COG by reference to [OGC 21-026](https://docs.ogc.org/is/21-026/21-026.html): an internally tiled GeoTIFF with georeferencing keys and a range-read-friendly header ordering, the baseline `rio cogeo validate` and rasterio enforce.
- Require **internal overviews** on any raster larger than a single 512×512 tile, with the pyramid extending until its smallest level fits one tile. This matches OGC 21-026's Optimized GeoTIFF conformance class (`/req/optimized_geotiff/number`). Rasters that already fit one tile are exempt.

Base COG validators (`cog_validate`) only *warn* on missing overviews, which is why PTL-DAT-004 never caught this. Portolan raises it to a requirement, aligning with Cayetano's new `reis` rule PTL-DAT-011. The existing valid-percent row already covers PTL-DAT-010, so it is unchanged.

### Non-normative (`specs/best-practices/conversion-defaults.md`)

Records the CLI's conversion defaults (COG compression, predictor, tile size, overview resampling; partition sizing; thumbnail encoding) as guidance, so a file produced with different settings still conforms. No RFC 2119 keywords. **Closes #74.**

## Versioning

The overviews requirement is normative and breaking (pre-1.0 → targets 0.2.0). It is staged under CHANGELOG `Unreleased`, following the partition-binding pattern. The schema URI is not bumped here: overviews are a binary-content check, not schema-checkable, and the URI bump is a coordinated release step. Say the word if you want the bump in this PR.

## Verification

- Reference `sample-cog.tif` (791×718) already carries a 395×359 overview, so it conforms under the new rule. No generator change.
- New best-practices doc is free of MUST/SHOULD/MAY.

## Note

PR #77 also edits `specs/best-practices/README.md`; whichever merges second resolves a one-line Contents conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)