### PR TITLE
fix(examples): drop source assets for live-endpoint upstreams

### DIFF
--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -76,10 +76,12 @@ Mirrors get a `via` link, and any Collection with `provenance.canonical` gets a
 
 ## Pipeline per kind
 
-Every path downloads the source once into `.cache`, produces a cloud-native
-canonical `data` Asset, and also emits a `source`-role Asset that points at the
-upstream URL with the real `file:size` and multihash `file:checksum` of the
-fetched file.
+Every path downloads the source once into `.cache` and produces a cloud-native
+canonical `data` Asset. When the manifest marks the source `stable: true`, it
+also emits a `source`-role Asset that points at the upstream URL with the real
+`file:size` and multihash `file:checksum` of the fetched file. A `stable: false`
+source (a live endpoint) is referenced by URL in the sidecars only, because
+pinned checksums on bytes the catalog does not control are guaranteed to rot.
 
 - `vector`. `to_geoparquet` normalizes to EPSG:4326 with ogr2ogr into a GeoPackage, computes the bbox and count from it, then writes the canonical asset as a web-optimized GeoParquet 2.0 file with geoparquet-io's web profile (native geometry type, per row group GeospatialStatistics, a retained covering bbox column for page-level pruning, a Parquet page index, Hilbert ordering, and byte-targeted fetch-sized row groups). Derivatives read the normalized GeoPackage, not the 2.0 output. Optional PMTiles come from ogr2ogr GeoJSONSeq into tippecanoe, with a web-map-links `pmtiles` link. Optional MapLibre styles are authored by `author_styles` from the real field values and read the PMTiles. The GeoParquet `data` asset also carries `table:columns` from a DuckDB `DESCRIBE`, geometry column included, and `proj:code` `EPSG:4326`, declaring the table and projection extensions.
 - `raster`. `to_cog` builds a COG with embedded statistics. Band statistics go in STAC 1.1 core `bands`, and `proj:code` carries the CRS through the projection extension.
@@ -116,7 +118,7 @@ GeoPackage, `_rasterize` burns features from the collection `style` block, and
 - `gdal_rasterize` writes only band 1 by default. Pass `-b 1 -b 2 -b 3` to fill an RGB canvas.
 - Zip sources are extracted before reading, because GDAL `/vsizip` keys off a `.zip` suffix that the cached filename does not have.
 - The raster extension v2.0.0 is not declared, its schema conflicts with Collection-level assets (spec issues #52 and #41). Statistics still ship in core `bands`.
-- The Boston, San Francisco, and Eurostat sources are live endpoints, so their `source` checksums are point-in-time and each README says so.
+- The Boston, San Francisco, and Eurostat sources are live endpoints (`stable: false`), so they carry no `source`-role Asset and each README says so. Pinning a checksum on a live query URL guarantees a validator failure once upstream changes.
 
 ## Validation
 

--- a/examples/build.py
+++ b/examples/build.py
@@ -18,8 +18,10 @@ per-catalog values. For each collection it downloads the true original source
 once, converts it to a cloud-native canonical asset (GeoParquet for vector and
 tabular, COG for raster), builds derivatives (PMTiles, thumbnail, MapLibre
 styles), computes real file:size and sha2-256 multihash file:checksum for every
-asset, and also cites the original file as a source-role asset. It validates the
-output against the committed Portolan schema.
+asset, and also cites the original file as a source-role asset when the upstream
+is a stable download (a live endpoint is referenced by URL only, since pinned
+checksums on bytes the catalog does not control are guaranteed to rot). It
+validates the output against the committed Portolan schema.
 
 Prerequisites (FOSS, on PATH): GDAL 3.x (ogr2ogr, ogrinfo, gdal_translate,
 gdalinfo, gdal_rasterize, gdal_create, gdalwarp) with the Parquet and COG
@@ -827,7 +829,8 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
                                {"table:columns": cols, "table:primary_geometry": geom_col,
                                 "table:row_count": n, "proj:code": "EPSG:4326"})
         exts += [TABLE_EXT, PROJ_EXT]
-        assets["source"] = source_asset(local, src)
+        if src.get("stable", True):
+            assets["source"] = source_asset(local, src)
         if deriv.get("pmtiles"):
             pm = coll_dir / f"{stem}.pmtiles"
             make_pmtiles(norm, pm, layer_name)
@@ -857,7 +860,8 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
         n = 0
         assets["data"] = asset(cog, MEDIA["cog"], ["data"], f"{spec['title']} (COG)",
                                {"bands": bands, "proj:code": code})
-        assets["source"] = source_asset(local, src)
+        if src.get("stable", True):
+            assets["source"] = source_asset(local, src)
         # Band statistics live in STAC 1.1 core `bands`. The raster extension v2.0.0
         # schema conflicts with collection-level assets (spec issues #52 / #41), so
         # it is not declared here, projection carries the CRS.
@@ -880,7 +884,8 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
         assets["data"] = asset(data_pq, MEDIA["parquet"], ["data"],
                                f"{spec['title']} (Parquet)",
                                {"table:columns": cols, "table:row_count": n})
-        assets["source"] = source_asset(local, src)
+        if src.get("stable", True):
+            assets["source"] = source_asset(local, src)
         exts.append(TABLE_EXT)
         extra_readme = [f"Rows, {n}.", f"Columns, {len(cols)}.",
                         "Non-geospatial table, spatial requirements relaxed."]
@@ -943,8 +948,8 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
         f"Original source, {src['url']} .",
     ] + extra_readme
     if not src.get("stable", True):
-        readme_extra.append("Note, the upstream source is a live endpoint, so the source "
-                            "checksum reflects the copy fetched at build time.")
+        readme_extra.append("Note, the upstream source is a live endpoint, so it is "
+                            "referenced by URL only and not archived as a source asset.")
     readme_extra += [""] + open_lines
     agents = [
         f"This collection holds {spec['title']}.",
@@ -953,7 +958,9 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
          if assets.get("visual") else "For a quick preview use the thumbnail asset."),
         f"License is {spec['license']}."
         + (f" Attribute as {attribution}." if attribution else ""),
-        f"The original upstream source is {src['url']} , tagged on the source-role asset.",
+        f"The original upstream source is {src['url']} , "
+        + ("tagged on the source-role asset."
+           if src.get("stable", True) else "a live endpoint referenced by URL only."),
     ]
     write_sidecars(coll_dir, spec["title"], spec["description"].strip(), readme_extra, agents)
 

--- a/examples/catalog/reference/boundaries/boston-open-space/AGENTS.md
+++ b/examples/catalog/reference/boundaries/boston-open-space/AGENTS.md
@@ -4,4 +4,4 @@ This collection holds Boston Open Space.
 Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("boston-open-space.parquet").
 For rendering use the visual PMTiles asset or the thumbnail.
 License is PDDL-1.0.
-The original upstream source is https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326 , tagged on the source-role asset.
+The original upstream source is https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326 , a live endpoint referenced by URL only.

--- a/examples/catalog/reference/boundaries/boston-open-space/README.md
+++ b/examples/catalog/reference/boundaries/boston-open-space/README.md
@@ -7,7 +7,7 @@ Providers, City of Boston (producer, licensor, host).
 Original source, https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326 .
 Features, 1012.
 Cloud-native asset, boston-open-space.parquet (GeoParquet).
-Note, the upstream source is a live endpoint, so the source checksum reflects the copy fetched at build time.
+Note, the upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.
 
 ## Open the data
 

--- a/examples/catalog/reference/boundaries/boston-open-space/collection.json
+++ b/examples/catalog/reference/boundaries/boston-open-space/collection.json
@@ -150,17 +150,6 @@
       "table:row_count": 1012,
       "proj:code": "EPSG:4326"
     },
-    "source": {
-      "href": "https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326",
-      "type": "application/zip",
-      "title": "City of Boston Open Space (zipped Shapefile export)",
-      "roles": [
-        "data",
-        "source"
-      ],
-      "file:size": 1074835,
-      "file:checksum": "1220dae5eae812b5c298d1c29d80540797067672cc63281ae01f3c4784ff7285efaa"
-    },
     "visual": {
       "href": "./boston-open-space.pmtiles",
       "type": "application/vnd.pmtiles",

--- a/examples/catalog/reference/mirror/san-francisco-addresses/AGENTS.md
+++ b/examples/catalog/reference/mirror/san-francisco-addresses/AGENTS.md
@@ -4,4 +4,4 @@ This collection holds San Francisco Addresses (EAS).
 Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("san-francisco-addresses.parquet").
 For rendering use the visual PMTiles asset or the thumbnail.
 License is PDDL-1.0.
-The original upstream source is https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000 , tagged on the source-role asset.
+The original upstream source is https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000 , a live endpoint referenced by URL only.

--- a/examples/catalog/reference/mirror/san-francisco-addresses/README.md
+++ b/examples/catalog/reference/mirror/san-francisco-addresses/README.md
@@ -7,7 +7,7 @@ Providers, City and County of San Francisco (producer, licensor), DataSF (proces
 Original source, https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000 .
 Features, 5000.
 Cloud-native asset, san-francisco-addresses.parquet (GeoParquet).
-Note, the upstream source is a live endpoint, so the source checksum reflects the copy fetched at build time.
+Note, the upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.
 
 ## Open the data
 

--- a/examples/catalog/reference/mirror/san-francisco-addresses/collection.json
+++ b/examples/catalog/reference/mirror/san-francisco-addresses/collection.json
@@ -208,17 +208,6 @@
       "table:row_count": 5000,
       "proj:code": "EPSG:4326"
     },
-    "source": {
-      "href": "https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000",
-      "type": "application/geo+json",
-      "title": "DataSF San Francisco Addresses with Units (GeoJSON, 5k extract)",
-      "roles": [
-        "data",
-        "source"
-      ],
-      "file:size": 4326949,
-      "file:checksum": "12208d97b1357b40e063c8820e1ace051745886fa0b525e05d0da6a528660a2c670c"
-    },
     "visual": {
       "href": "./san-francisco-addresses.pmtiles",
       "type": "application/vnd.pmtiles",

--- a/examples/catalog/reference/tabular/eurostat-electricity-prices/AGENTS.md
+++ b/examples/catalog/reference/tabular/eurostat-electricity-prices/AGENTS.md
@@ -4,4 +4,4 @@ This collection holds Eurostat Electricity Prices for Household Consumers.
 Read the Parquet `data` asset with pandas, pd.read_parquet("eurostat-electricity-prices.parquet").
 For a quick preview use the thumbnail asset.
 License is CC-BY-4.0. Attribute as Source, Eurostat.
-The original upstream source is https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false , tagged on the source-role asset.
+The original upstream source is https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false , a live endpoint referenced by URL only.

--- a/examples/catalog/reference/tabular/eurostat-electricity-prices/README.md
+++ b/examples/catalog/reference/tabular/eurostat-electricity-prices/README.md
@@ -8,7 +8,7 @@ Original source, https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/n
 Rows, 65412.
 Columns, 13.
 Non-geospatial table, spatial requirements relaxed.
-Note, the upstream source is a live endpoint, so the source checksum reflects the copy fetched at build time.
+Note, the upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.
 
 ## Open the data
 

--- a/examples/catalog/reference/tabular/eurostat-electricity-prices/collection.json
+++ b/examples/catalog/reference/tabular/eurostat-electricity-prices/collection.json
@@ -114,17 +114,6 @@
         }
       ],
       "table:row_count": 65412
-    },
-    "source": {
-      "href": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false",
-      "type": "text/csv",
-      "title": "Eurostat nrg_pc_204 electricity prices (SDMX-CSV)",
-      "roles": [
-        "data",
-        "source"
-      ],
-      "file:size": 6241780,
-      "file:checksum": "1220d7347e2ac295fcf7fb55b986118134f66db5ff58f3837b3b26b7e6e66ca511b0"
     }
   },
   "links": [


### PR DESCRIPTION
Dogfooding reis (portolan-sdi/reis#27) against the reference catalog surfaced a checksum mismatch on the San Francisco mirror. Its `source` asset pins `file:size`/`file:checksum` on a live Socrata query URL, so the pins rotted when upstream changed — and Boston and Eurostat carry the same time bomb.

formats.md already draws the correct line: include the original as an asset "when it is directly downloadable (not just an API)". The manifests already mark these three sources `stable: false`. This PR makes `build.py` honor the flag: stable downloads keep their pinned source-role asset, live endpoints are referenced by URL in the sidecars only. The three affected collections and their sidecars are updated to match what the generator now emits.

Verification: `reis check --schema --data` over `examples/catalog/reference` reports 0 errors, 0 warnings, 2 by-design INFO nudges (Natural Earth publishes no upstream STAC).

The same dogfood run also caught a reis bug (PTL-DAT-015 ignored asset-level `table:columns`), fixed on portolan-sdi/reis#27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #80. That issue proposed regenerating the pinned checksum, but a regenerated pin on a live query URL rots again on the next upstream change; removing the pin per the manifest's existing `stable: false` flag removes the failure class.