### PR TITLE
feat(core): model raster scenes as items, single-COG as single-file

### DIFF
--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -142,6 +142,16 @@ is needed (see [Vector](formats.md#vector)). Alongside the `collection.json` and
 the `.parquet`, such a collection may optionally carry a `.pmtiles`, a
 `thumbnail.png`, and a `styles/` directory.
 
+### Raster Collections
+
+A collection holding multiple raster scenes MUST model each scene as an item
+carrying its COG as an item-level asset; scene COGs MUST NOT be listed as
+collection-level assets. Per-scene items are what let each scene carry its own
+footprint and acquisition time, which a flat asset list cannot express. A
+collection holding a single COG follows the single-file rule above: it MUST
+expose that COG as a collection-level asset with no item directory (see
+[Raster](formats.md#raster)).
+
 ## Nested Catalogs, Flat Collections
 
 Portolan organizes hierarchy with nested catalogs, not nested collections:

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -114,6 +114,9 @@ This is the baseline that
 rasterio treat as a COG.
 (Formats such as GeoZarr are candidates for future support once default tooling can
 render and consume them.)
+How a raster collection is structured — one item per scene, with a single-COG
+collection handled as a single-file collection — is defined under [Raster
+Collections](core.md#raster-collections).
 
 **Optimized GeoTIFF conformance.** Beyond that baseline, a COG MUST conform to OGC
 21-026's [Optimized GeoTIFF requirements

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -160,6 +160,24 @@ requirements:
       that data MUST be represented as a collection-level asset — no item
       directory or item JSON is needed (see [Vector](formats.md#vector)).
 
+  - id: PORTO-CORE-071
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/core.md
+    quote: >-
+      A collection holding multiple raster scenes MUST model each scene as an
+      item carrying its COG as an item-level asset; scene COGs MUST NOT be
+      listed as collection-level assets.
+
+  - id: PORTO-CORE-072
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/core.md
+    quote: >-
+      A collection holding a single COG follows the single-file rule above: it
+      MUST expose that COG as a collection-level asset with no item directory
+      (see [Raster](formats.md#raster)).
+
   - id: PORTO-CORE-018
     severity: MUST
     enforcement: validator


### PR DESCRIPTION
Settles #73: a collection holding multiple raster scenes MUST model each scene as an item carrying its COG as an item-level asset, and a single-COG collection MUST follow the single-file rule (collection-level asset, no item directory). New "Raster Collections" subsection in core.md, with a cross-reference from formats.md's Raster section.

The Planet Venezuela earthquake catalog (https://source.coop/planet/venezuela-earthquake-2026-06-24) is a working example of the default: each pre/post-event scene is an item.

Manifest: PORTO-CORE-071 and PORTO-CORE-072 (both MUST, validator-enforced); checker green at 111 anchored requirements.

Closes #73.

Companion-PR: portolan-sdi/reis#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)