### PR TITLE
spec(formats): ratify items.parquet as a raster SHOULD

### DIFF
--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -14,4 +14,4 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
-| [`stac-geoparquet.md`](stac-geoparquet.md) | Maturing convention — may become required |
+| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item rollups are normative; other rollups still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -14,4 +14,4 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
-| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item rollups are normative; other rollups still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |
+| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; mirroring collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/stac-geoparquet.md
+++ b/specs/incubating/stac-geoparquet.md
@@ -2,32 +2,29 @@
 
 **Status: maturing convention, may become required.**
 
-The item rollup for raster collections is ratified. See [Raster § Item
-rollup](../portolan/formats.md#raster). It graduated first because
+The item mirror for raster collections is ratified. See [Raster § Item
+mirror](../portolan/formats.md#raster). It graduated first because
 [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) tooling already
 writes and reads `items.parquet`, and because scene collections are where
 per-item JSON fetches hurt most.
 
-Three extensions of the idea are still open.
+Two extensions of the idea are still open.
 
-## Rollups for other collection types
+## Mirroring collections themselves
 
-Vector and point-cloud collections can carry an `items.parquet` on the same
-terms. Portolan does not ask for one yet. A partitioned vector collection often
-has no items at all, since `partition:glob` is the access path, and point cloud
-support is itself unimplemented.
+One construct should cover every collection a catalog holds, whatever the data
+underneath — COGs, vector, point clouds. A Parquet mirror of the collections
+would let a client search across a catalog in one read, as `items.parquet` does
+within one collection, and would carry the same terms to collection types that
+today publish no mirror at all.
 
-## A catalog-wide collections.parquet
-
-A rollup of every collection in a catalog would let a client search across
-collections in one read, as `items.parquet` does within one collection. The
-encoding is unsettled. Collection extents are ranges rather than footprints,
+The encoding is unsettled. Collection extents are ranges rather than footprints,
 summaries vary in shape, and no tooling reads such a file today.
 
 ## A whole STAC catalog in Parquet
 
-Beyond either rollup, the longer-term goal is a Parquet representation complete
-enough to reconstruct a catalog: catalogs, collections, items, and links in one
-queryable set of files. That work belongs upstream in `stac-geoparquet` first.
-Portolan should adopt the convention once it exists there, rather than invent a
-parallel one.
+Beyond mirroring items or collections, the longer-term goal is a Parquet
+representation complete enough to reconstruct a catalog: catalogs, collections,
+items, and links in one queryable set of files. That work belongs upstream in
+`stac-geoparquet` first. Portolan should adopt the convention once it exists
+there, rather than invent a parallel one.

--- a/specs/incubating/stac-geoparquet.md
+++ b/specs/incubating/stac-geoparquet.md
@@ -1,12 +1,33 @@
-# Incubating — STAC-GeoParquet
+# Incubating — STAC-GeoParquet Beyond Raster Items
 
 **Status: maturing convention, may become required.**
 
-For catalogs with many items (e.g. more than 100), include a
-[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) file alongside
-`collection.json` to enable search and filtering without a STAC API server.
+The item rollup for raster collections is ratified. See [Raster § Item
+rollup](../portolan/formats.md#raster). It graduated first because
+[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) tooling already
+writes and reads `items.parquet`, and because scene collections are where
+per-item JSON fetches hurt most.
 
-This is a best practice while tooling matures and may become a requirement in a
-later Portolan version. It is incubating rather than normative so that catalogs are
-not held to it before the tooling and conventions (file location, naming, and how
-it is linked from the collection) are settled.
+Three extensions of the idea are still open.
+
+## Rollups for other collection types
+
+Vector and point-cloud collections can carry an `items.parquet` on the same
+terms. Portolan does not ask for one yet. A partitioned vector collection often
+has no items at all, since `partition:glob` is the access path, and point cloud
+support is itself unimplemented.
+
+## A catalog-wide collections.parquet
+
+A rollup of every collection in a catalog would let a client search across
+collections in one read, as `items.parquet` does within one collection. The
+encoding is unsettled. Collection extents are ranges rather than footprints,
+summaries vary in shape, and no tooling reads such a file today.
+
+## A whole STAC catalog in Parquet
+
+Beyond either rollup, the longer-term goal is a Parquet representation complete
+enough to reconstruct a catalog: catalogs, collections, items, and links in one
+queryable set of files. That work belongs upstream in `stac-geoparquet` first.
+Portolan should adopt the convention once it exists there, rather than invent a
+parallel one.

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -162,32 +162,33 @@ The exact on-disk encoding (the TIFF `GDAL_METADATA` tag and its XML layout, and
 [`specs/incubating/geotiff-stats-headers.md`](../incubating/geotiff-stats-headers.md).
 Compliance is defined by the tag contents, not by use of GDAL.
 
-**Item rollup.** A raster collection that models scenes as items SHOULD also publish a
-[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) rollup at `items.parquet`
-in the collection root. One range request then returns the whole collection's item
-metadata, in place of one HTTP fetch per scene. Clients can search a large scene collection,
-or assemble it into a data cube, without a STAC API server.
+**Item mirror.** A raster collection that models scenes as items SHOULD also publish a
+[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) mirror of those items at
+`items.parquet` in the collection root. One range request then returns the whole
+collection's item metadata, in place of one HTTP fetch per scene. Clients can search a large
+scene collection, or assemble it into a data cube, without a STAC API server.
 
-No item-count threshold applies. Tooling generates the rollup from the item JSON, and the
+No item-count threshold applies. Tooling generates the mirror from the item JSON, and the
 saved fetches add up at any size.
 
-A published rollup MUST be registered twice on the collection: as an asset under the key
-`geoparquet-items` with role `["stac-items"]`, and as a `rel: "items"` link. Both carry
-media type `application/vnd.apache.parquet`. Asset-reading clients find the first
-registration, link-walking clients the second.
+A published mirror MUST be registered as a collection-level asset carrying media type
+`application/vnd.apache.parquet` and the role `collection-mirror`, per [Referencing STAC
+Geoparquet Collections in STAC Collection
+JSON](https://radiantearth.github.io/stac-geoparquet-spec/latest/#referencing-a-stac-geoparquet-collections-in-a-stac-collection-json).
+That single registration is the whole requirement; no `rel: "items"` link is needed.
 
-The item JSON stays normative and the rollup derives from it, so rollup rows MUST match the
-collection's items at publish time. A rollup that lags its items answers queries wrongly,
-and the client reading it cannot tell.
+The item JSON stays normative and the Parquet mirrors it, so the file MUST reproduce the
+collection's items exactly at publish time — one row per item, each row carrying that
+item's fields. A mirror that lags its items answers queries wrongly, and the client reading
+it cannot tell.
 
-A rollup carries item metadata, not data. The GeoParquet requirements above bind data
-assets, and a validator MUST NOT hold a rollup to them. Spatial ordering, per-row-group
-spatial statistics, and the row-group ceiling describe a dataset queried by extent, not an
-item index.
+The GeoParquet requirements above bind the mirror as they bind vector data: rows MUST be
+spatially ordered, the file MUST carry per-row-group spatial statistics, and row groups
+MUST hold no more than 150,000 rows. An item index is queried by extent like any other
+spatial table, and readers prune it the same way.
 
-A collection holding a single COG has no items and publishes no rollup. Rollups for vector
-and point-cloud collections remain incubating, as does a catalog-wide
-`collections.parquet`. See
+A collection holding a single COG has no items and publishes no mirror. Mirroring other
+collection types, and mirroring a whole catalog's collections, remain incubating. See
 [`specs/incubating/stac-geoparquet.md`](../incubating/stac-geoparquet.md).
 
 Raster styling (colormaps, legends, continuous vs. categorical vs. multiband) is

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -162,6 +162,34 @@ The exact on-disk encoding (the TIFF `GDAL_METADATA` tag and its XML layout, and
 [`specs/incubating/geotiff-stats-headers.md`](../incubating/geotiff-stats-headers.md).
 Compliance is defined by the tag contents, not by use of GDAL.
 
+**Item rollup.** A raster collection that models scenes as items SHOULD also publish a
+[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) rollup at `items.parquet`
+in the collection root. One range request then returns the whole collection's item
+metadata, in place of one HTTP fetch per scene. Clients can search a large scene collection,
+or assemble it into a data cube, without a STAC API server.
+
+No item-count threshold applies. Tooling generates the rollup from the item JSON, and the
+saved fetches add up at any size.
+
+A published rollup MUST be registered twice on the collection: as an asset under the key
+`geoparquet-items` with role `["stac-items"]`, and as a `rel: "items"` link. Both carry
+media type `application/vnd.apache.parquet`. Asset-reading clients find the first
+registration, link-walking clients the second.
+
+The item JSON stays normative and the rollup derives from it, so rollup rows MUST match the
+collection's items at publish time. A rollup that lags its items answers queries wrongly,
+and the client reading it cannot tell.
+
+A rollup carries item metadata, not data. The GeoParquet requirements above bind data
+assets, and a validator MUST NOT hold a rollup to them. Spatial ordering, per-row-group
+spatial statistics, and the row-group ceiling describe a dataset queried by extent, not an
+item index.
+
+A collection holding a single COG has no items and publishes no rollup. Rollups for vector
+and point-cloud collections remain incubating, as does a catalog-wide
+`collections.parquet`. See
+[`specs/incubating/stac-geoparquet.md`](../incubating/stac-geoparquet.md).
+
 Raster styling (colormaps, legends, continuous vs. categorical vs. multiband) is
 still under discussion — see
 [`specs/incubating/raster-styling.md`](../incubating/raster-styling.md).

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -1020,6 +1020,41 @@ requirements:
       Point cloud support is not yet implemented; when complete, data MUST be
       provided as Cloud-Optimized Point Cloud (COPC).
 
+  - id: PORTO-FMT-040
+    severity: SHOULD
+    enforcement: validator
+    file: specs/portolan/formats.md
+    quote: >-
+      A raster collection that models scenes as items SHOULD also publish a
+      [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) rollup
+      at `items.parquet` in the collection root.
+
+  - id: PORTO-FMT-041
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/formats.md
+    quote: >-
+      A published rollup MUST be registered twice on the collection: as an
+      asset under the key `geoparquet-items` with role `["stac-items"]`, and
+      as a `rel: "items"` link. Both carry media type
+      `application/vnd.apache.parquet`.
+
+  - id: PORTO-FMT-042
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/formats.md
+    quote: >-
+      The item JSON stays normative and the rollup derives from it, so rollup
+      rows MUST match the collection's items at publish time.
+
+  - id: PORTO-FMT-043
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/formats.md
+    quote: >-
+      The GeoParquet requirements above bind data assets, and a validator MUST
+      NOT hold a rollup to them.
+
 exclusions:
   # RFC 2119 preamble: keyword mentions, not requirements.
   - file: specs/portolan/core.md

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -1026,34 +1026,34 @@ requirements:
     file: specs/portolan/formats.md
     quote: >-
       A raster collection that models scenes as items SHOULD also publish a
-      [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) rollup
-      at `items.parquet` in the collection root.
+      [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) mirror
+      of those items at `items.parquet` in the collection root.
 
   - id: PORTO-FMT-041
     severity: MUST
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      A published rollup MUST be registered twice on the collection: as an
-      asset under the key `geoparquet-items` with role `["stac-items"]`, and
-      as a `rel: "items"` link. Both carry media type
-      `application/vnd.apache.parquet`.
+      A published mirror MUST be registered as a collection-level asset
+      carrying media type `application/vnd.apache.parquet` and the role
+      `collection-mirror`
 
   - id: PORTO-FMT-042
     severity: MUST
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      The item JSON stays normative and the rollup derives from it, so rollup
-      rows MUST match the collection's items at publish time.
+      the file MUST reproduce the collection's items exactly at publish time —
+      one row per item, each row carrying that item's fields.
 
   - id: PORTO-FMT-043
     severity: MUST
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      The GeoParquet requirements above bind data assets, and a validator MUST
-      NOT hold a rollup to them.
+      The GeoParquet requirements above bind the mirror as they bind vector
+      data: rows MUST be spatially ordered, the file MUST carry per-row-group
+      spatial statistics, and row groups MUST hold no more than 150,000 rows.
 
 exclusions:
   # RFC 2119 preamble: keyword mentions, not requirements.


### PR DESCRIPTION
Closes #72. Implements the decision from that thread: `items.parquet` becomes a
SHOULD for collections of COGs, not a MUST, and not deferred to v0.3.

Companion-PR: portolan-sdi/reis#32

## What lands in formats.md

A raster collection that models scenes as items SHOULD publish a stac-geoparquet
rollup at `items.parquet` in the collection root. One range request then returns
the whole collection's item metadata, in place of one fetch per scene, so a large
scene collection can be searched and assembled into a data cube without a STAC
API server.

The registration shape is a conditional MUST, following the PMTiles pattern of a
SHOULD to provide paired with a MUST on how it is declared. The asset key is
`geoparquet-items` with role `["stac-items"]`, alongside a `rel: "items"` link,
both typed `application/vnd.apache.parquet`. That is what portolan-cli already
writes (ADR-0049 and ADR-0031), so no producer has to change output to comply.

Rollup rows MUST match the collection's items at publish time. A rollup that
lags reports items that no longer exist, or omits items that do, and the client
reading it cannot tell.

## Two decisions worth reviewing

**No item-count threshold.** ADR-0049 set 100 items for the best practice and
1000 for the requirement. Both numbers date from when tooling was scarcer, and a
threshold mainly hands producers a boundary to argue about. Single-COG
collections have no items, so they fall out of scope by construction rather than
by a count.

**Rollups are exempt from the GeoParquet data requirements.** Spatial ordering,
per-row-group spatial statistics, and the 150,000-row ceiling describe a dataset
queried by extent. An item index is not one. Without the carve-out, following the
new SHOULD would fail the data pass on `PORTO-FMT-006`, `007`, and `009`, and a
rollup would also be asked for the tabular `table:columns`. The exemption is
written as a MUST NOT on validators so the two passes cannot drift apart.

## Manifest and validator

Four new entries: `PORTO-FMT-040` (SHOULD, publish), `041` (MUST, registration),
`042` (MUST, rows match items), `043` (MUST NOT, no GeoParquet rules on rollups).
All four are `enforcement: validator`; reis#32 adds `PTL-ROL-001`, `PTL-ROL-002`,
and `PTL-DAT-016` to cover them. `scripts/check_requirements.py` reports 115
requirements anchored.

## What stays incubating

`specs/incubating/stac-geoparquet.md` now covers only what is unsettled: rollups
for vector and point-cloud collections, a catalog-wide `collections.parquet`, and
a Parquet representation of an entire catalog. The last of those is the upstream
work @yharby, @cayetanobv, and I discussed, and it belongs in `stac-geoparquet`
before Portolan adopts a convention for it.

## Not in this PR

The reference catalog has no multi-scene raster collection, so it gains no
rollup. Adding one means new COG scene assets and a manifest entry to generate
them, which is example work rather than spec work. Worth a follow-up issue if we
want the SHOULD demonstrated in the reference tree.