### PR TITLE
refactor: rename the validator from reis to rashid

### DIFF
--- a/.github/workflows/companion-pr.yaml
+++ b/.github/workflows/companion-pr.yaml
@@ -1,9 +1,9 @@
 name: Companion PR
 
-# The spec is ground truth and reis is its deterministic implementation, so
-# every normative change here must land with a matching reis change. This check
+# The spec is ground truth and rashid is its deterministic implementation, so
+# every normative change here must land with a matching rashid change. This check
 # enforces the pairing: a PR that touches normative content must either link
-# its reis companion PR in the body ("Companion-PR: portolan-sdi/reis#123") or
+# its rashid companion PR in the body ("Companion-PR: portolan-sdi/rashid#123") or
 # carry the "no-validator-change" label for edits with no conformance impact.
 #
 # The job runs on every PR and passes itself when no normative paths changed.
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require a reis companion PR for normative changes
+      - name: Require a rashid companion PR for normative changes
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -55,24 +55,24 @@ jobs:
             --json body --jq '.body')
 
           COMPANION=$(grep -oiE \
-            'Companion-PR:[[:space:]]*portolan-sdi/reis#[0-9]+' \
+            'Companion-PR:[[:space:]]*portolan-sdi/rashid#[0-9]+' \
             <<< "$BODY" | head -1 | grep -oE '[0-9]+$' || true)
 
           if [ -z "$COMPANION" ]; then
             echo "::error::This PR changes normative content (specs/ or stac/)" \
               "but names no companion validator PR. Add a line" \
-              "'Companion-PR: portolan-sdi/reis#<number>' to the PR body," \
+              "'Companion-PR: portolan-sdi/rashid#<number>' to the PR body," \
               "or apply the 'no-validator-change' label."
             exit 1
           fi
 
-          STATE=$(gh pr view "$COMPANION" --repo portolan-sdi/reis \
+          STATE=$(gh pr view "$COMPANION" --repo portolan-sdi/rashid \
             --json state --jq '.state' 2>/dev/null || echo MISSING)
 
           if [ "$STATE" = "MISSING" ]; then
-            echo "::error::Companion PR portolan-sdi/reis#${COMPANION}" \
+            echo "::error::Companion PR portolan-sdi/rashid#${COMPANION}" \
               "does not exist."
             exit 1
           fi
 
-          echo "Companion PR portolan-sdi/reis#${COMPANION} found (${STATE})."
+          echo "Companion PR portolan-sdi/rashid#${COMPANION} found (${STATE})."

--- a/.github/workflows/requirements-manifest.yaml
+++ b/.github/workflows/requirements-manifest.yaml
@@ -1,7 +1,7 @@
 name: Requirements Manifest
 
 # Keeps specs/portolan/requirements.yaml and the spec prose in lockstep.
-# The manifest anchors a stable ID to every normative sentence; reis keys
+# The manifest anchors a stable ID to every normative sentence; rashid keys
 # its coverage gate to those IDs. See scripts/check_requirements.py.
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,12 +64,12 @@ versioned standard. A catalog declares this version by carrying
 - **Reference catalogs** ([`examples/`](examples/)) with the generator that builds
   them, converting vector data through DuckDB and rasters through rasterio and
   rio-cogeo, rendering thumbnails and PMTiles without a GDAL CLI, and validating
-  every build with [reis](https://github.com/portolan-sdi/reis).
+  every build with [rashid](https://github.com/portolan-sdi/rashid).
 - **Schema publishing** at `schemas.portolan-sdi.org`, deployed from the tracked
   schema versions on each release, with portolan-sdi extension schemas pinned in
   `stac/portolan-extensions.json` and fetched from their source repositories at
   build time.
-- **CI gates**: every PR touching normative content names its companion reis PR or
+- **CI gates**: every PR touching normative content names its companion rashid PR or
   carries the `no-validator-change` label; the requirements manifest check anchors
   prose to IDs; the profile test suite lints markdown, pins the canonical schema URI,
   and validates the examples.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ data on any S3-compatible bucket, described by structured
 others:
 
 - **The standard** defines what a great catalog looks like. It lives here.
-- **[reis](https://github.com/portolan-sdi/reis)**, the validator, proves a
+- **[rashid](https://github.com/portolan-sdi/rashid)**, the validator, proves a
   catalog meets the standard.
 - **[portolan-cli](https://github.com/portolan-sdi/portolan-cli)** makes catalogs
   easy to build.
@@ -79,10 +79,10 @@ GeoParquet were built for long-term stability. Portolan sits on top of them and
 moves faster. Each version states what the community currently believes a great
 catalog looks like, so a requirement that is aspirational today may relax or
 tighten as the ecosystem catches up. Conformance means passing the
-[validator](https://github.com/portolan-sdi/reis), not claiming to conform. Every
-normative statement carries a stable ID in
-[`requirements.yaml`](specs/portolan/requirements.yaml), and CI proves that reis
-enforces each one.
+[validator](https://github.com/portolan-sdi/rashid), not claiming to conform.
+Every normative statement carries a stable ID in
+[`requirements.yaml`](specs/portolan/requirements.yaml), and CI proves that
+rashid enforces each one.
 
 Where the current landscape has gaps, Portolan will incubate new standards or
 write down practices that until now have been informal. Usually that means
@@ -167,15 +167,15 @@ When a change is normative, bump the spec version per the
 
 ### Companion validator PRs
 
-The spec is ground truth and [reis](https://github.com/portolan-sdi/reis) is its
-deterministic implementation. A catalog conforms to the spec exactly when it
-passes reis, so the two must never diverge.
+The spec is ground truth and [rashid](https://github.com/portolan-sdi/rashid) is
+its deterministic implementation. A catalog conforms to the spec exactly when it
+passes rashid, so the two must never diverge.
 
 Every PR that touches normative content (`specs/` or `stac/`) must name the
-matching reis PR in its body:
+matching rashid PR in its body:
 
 ```
-Companion-PR: portolan-sdi/reis#123
+Companion-PR: portolan-sdi/rashid#123
 ```
 
 CI verifies the reference. Editorial changes with no conformance impact (typos,

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ and raster conversion and thumbnails alike, runs on DuckDB spatial, rasterio,
 and rio-cogeo, not the GDAL CLI, so no GDAL command-line install is needed.
 The generator downloads each source once into a git-ignored cache, converts
 it, computes real checksums, writes the STAC tree with `AGENTS.md` and
-`README.md` beside every node, and validates the result with reis, the
+`README.md` beside every node, and validates the result with rashid, the
 canonical Portolan validator.
 
 Thumbnails are drawn in Web Mercator at the data's true aspect ratio over a CARTO

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -24,7 +24,7 @@ bootstraps `sys.path` with its own directory so they import as flat names.
 | `thumbnails.py` | Web Mercator preview rendering over the tile basemap fetched by `tiles.py` |
 | `tiles.py` | XYZ basemap tile fetch and mosaic for thumbnails |
 | `stacio.py` | STAC assembly, manifest, providers, assets, links, sidecars, catalog builders |
-| `validate.py` | Thin adapter over reis, the canonical validator. Runs its metadata, structural, schema, and data passes over the built catalog |
+| `validate.py` | Thin adapter over rashid, the canonical validator. Runs its metadata, structural, schema, and data passes over the built catalog |
 | `tests/` | Standalone `uv run` checks, `check_compliance.py`, `check_web_output.py`, `check_validate.py`, `check_tiles.py`, `check_thumb_geoms.py`, `check_thumbnails.py`, `check_cog.py`, `check_fetch.py`, and `check_styles.py` |
 
 Inputs and outputs live under `examples/`, not here.
@@ -135,7 +135,7 @@ because pinned checksums on bytes the catalog does not control are guaranteed to
 rot. `add_source_asset` is the single gate.
 
 - `vector`. `to_geoparquet` converts with DuckDB spatial, preserving the source CRS or the manifest `output_crs`, and also builds a WGS84 GeoPackage for the bbox, the PMTiles feed, the thumbnail, and style sampling. It then writes the canonical asset as a web-optimized GeoParquet 2.0 file with geoparquet-io's web profile (native geometry type, per row group GeospatialStatistics, a retained covering bbox column for page-level pruning, a Parquet page index, Hilbert ordering, and byte-targeted fetch-sized row groups). Derivatives read the WGS84 GeoPackage, not the 2.0 output. Optional PMTiles come from a DuckDB GeoJSONSeq export into tippecanoe, with a web-map-links `pmtiles` link. Optional MapLibre styles are authored by `author_styles` from the real field values and read the PMTiles. The GeoParquet `data` asset also carries `table:columns` from a DuckDB `DESCRIBE`, geometry column included, and `proj:code` derived from the real output CRS, declaring the table and projection extensions.
-- `raster`. `to_cog` builds the COG with rasterio, preserving the source CRS or warping to the manifest `output_crs`. Band statistics come from rasterio and numpy and go in STAC 1.1 core `bands`, minimum, maximum, mean, stddev, and valid percent, and `proj:code` carries the real output CRS through the projection extension. The same values are embedded as GDAL `STATISTICS_*` band tags, which is where reis reads them. Overview depth is left to rio-cogeo rather than pinned, see the gotcha below.
+- `raster`. `to_cog` builds the COG with rasterio, preserving the source CRS or warping to the manifest `output_crs`. Band statistics come from rasterio and numpy and go in STAC 1.1 core `bands`, minimum, maximum, mean, stddev, and valid percent, and `proj:code` carries the real output CRS through the projection extension. The same values are embedded as GDAL `STATISTICS_*` band tags, which is where rashid reads them. Overview depth is left to rio-cogeo rather than pinned, see the gotcha below.
 - `tabular`. `to_table_parquet` reads the CSV with DuckDB and writes Parquet. Columns are described with the table extension. No geometry, the spatial extent is the whole world and spatial rules are relaxed.
 
 A Collection whose manifest sets `attribution` declares the attribution extension and carries a top-level `attribution` field.
@@ -168,18 +168,18 @@ onto the canvas with `rasterio.features`. Rasters are warped on top with
 - GeoJSON is always WGS84 and silently drops any target SRS. The thumbnail path reads the WGS84 GeoPackage intermediate and reprojects it to EPSG:3857 with DuckDB spatial in `_mercator_geoms`, so the Mercator projection survives.
 - Zip sources are extracted before reading, because GDAL `/vsizip` keys off a `.zip` suffix that the cached filename does not have.
 - The raster extension v2.0.0 is not declared, its schema conflicts with Collection-level assets (spec issues #52 and #41). Statistics still ship in core `bands`.
-- COG overview depth is never pinned. `to_cog` omits `overview_level` so rio-cogeo derives it from the raster size and the 512px output blocksize, halving until the coarsest level fits inside one tile. That is OGC 21-026's `/req/optimized_geotiff/number`, which formats.md raises to a MUST and reis enforces as PTL-DAT-011. A fixed level, which this used to carry, under-builds overviews on a large raster and builds pointless ones on a raster smaller than a tile. Note the requirement reads "one tile across or down", so the bar is the shorter side, which is what rio-cogeo measures.
-- A MapLibre style's PMTiles url is relative to the `styles/` directory the file sits in, so it is `../name.pmtiles`, never `./name.pmtiles`. The `./` form resolves to `styles/name.pmtiles`, which does not exist, and the style then loads no tiles and renders an empty map. Nothing else catches this, reis does not read style bodies and the STAC validators skip style files for having no `stac_version`, so `check_styles.py` asserts every url resolves to a real file. The source key and every `layers[].source` are `data` per formats.md, while `source-layer` stays the tippecanoe layer name.
+- COG overview depth is never pinned. `to_cog` omits `overview_level` so rio-cogeo derives it from the raster size and the 512px output blocksize, halving until the coarsest level fits inside one tile. That is OGC 21-026's `/req/optimized_geotiff/number`, which formats.md raises to a MUST and rashid enforces as PTL-DAT-011. A fixed level, which this used to carry, under-builds overviews on a large raster and builds pointless ones on a raster smaller than a tile. Note the requirement reads "one tile across or down", so the bar is the shorter side, which is what rio-cogeo measures.
+- A MapLibre style's PMTiles url is relative to the `styles/` directory the file sits in, so it is `../name.pmtiles`, never `./name.pmtiles`. The `./` form resolves to `styles/name.pmtiles`, which does not exist, and the style then loads no tiles and renders an empty map. Nothing else catches this, rashid does not read style bodies and the STAC validators skip style files for having no `stac_version`, so `check_styles.py` asserts every url resolves to a real file. The source key and every `layers[].source` are `data` per formats.md, while `source-layer` stays the tippecanoe layer name.
 - The thumbnail is painted from the DEFAULT style, meaning the variant listed first in `style.variants`, because core.md requires exactly that and core.md also says the default is listed first. `stacio` passes `default_variant` into the thumbnail context and `thumbnails.py` only reaches for the category palette when that variant is in `CATEGORICAL_VARIANTS`. So a Collection that wants a category-coloured preview leads with `categorical`, it does not keep a flat `default` in front of it. Previously the thumbnail branched on `category_field` alone and three Collections shipped previews with zero pixels in common with their own default style.
 - tippecanoe records both `--name` and the verbatim command line in the archive metadata, so it runs with `cwd` set to the Collection directory and bare filenames. Passing absolute paths ships the builder's home directory inside every published `.pmtiles`.
-- A nested Collection's STAC `id` is its full POSIX path from the catalog root, `boundaries/us-counties`, not the leaf segment. Filenames still use the leaf, a slash cannot appear in one. Nothing validates this, reis has no id rules and the profile schema has no id constraint, so it is easy to regress.
+- A nested Collection's STAC `id` is its full POSIX path from the catalog root, `boundaries/us-counties`, not the leaf segment. Filenames still use the leaf, a slash cannot appear in one. Nothing validates this, rashid has no id rules and the profile schema has no id constraint, so it is easy to regress.
 - The `source` asset does not carry the `data` role. core.md scopes `data` to the primary GeoParquet, COG, or Parquet and says the cloud-native asset is primary while the rest are alternates, so rolling a zipped Shapefile `data` leaves a client filtering on that role unable to tell which asset is canonical.
 - The Boston, San Francisco, and Eurostat sources are live endpoints (`stable: false`), so they carry no `source`-role Asset and each README says so. Pinning a checksum on a live query URL guarantees a validator failure once upstream changes, and formats.md scopes the rule to an original that is directly downloadable rather than an API. `fetch` still refetches them instead of reusing the cache, because the canonical Asset is converted from those bytes and a stale cached copy would publish a `data` Asset that no longer matches upstream. That is how spec issue #80 happened, and the build's own validator cannot catch it, since the local-only reader skips remote assets. The DataSF URL also carries `$order=:id` so the 5k window does not reshuffle between fetches.
 
 ## Validation
 
 `validate` runs after each catalog unless `--only` or `--no-validate` is set. It
-calls reis, the canonical Portolan validator, and fails the build on any error
+calls rashid, the canonical Portolan validator, and fails the build on any error
 finding. Warnings and infos print without failing.
 
 Four passes run. The metadata pass checks the Portolan rules. The structural
@@ -193,12 +193,12 @@ statistics, and row-group size, through a local-only reader that skips remote
 source assets so the build stays offline.
 
 Because the build skips remote assets, the remote `source` checksums are only
-proven by running reis directly, without the adapter. Do that before publishing a
+proven by running rashid directly, without the adapter. Do that before publishing a
 rebuild.
 
 ```bash
-uv run --with "reis[data] @ git+https://github.com/portolan-sdi/reis.git" \
-  reis check --data examples/catalog/reference
+uv run --with "rashid[data] @ git+https://github.com/portolan-sdi/rashid.git" \
+  rashid check --data examples/catalog/reference
 ```
 
 The build is clean apart from eight infos, which are expected and terminal. Do
@@ -208,28 +208,28 @@ not try to make the output silent.
   makes `canonical` a conditional MUST, owed only when the upstream publishes its
   own STAC catalog. None of these eight upstreams does, checked directly and
   against all of STAC Index, so the condition never triggers and there is no URL
-  to point at. reis scores it info precisely because metadata cannot settle the
+  to point at. rashid scores it info precisely because metadata cannot settle the
   question. Inventing a link would be worse than the finding.
 
 A ninth finding used to be terminal and no longer is. `PTL-DAT-005` warned on
-`netherlands-provinces` because reis derived its comparison bbox by reprojecting
+`netherlands-provinces` because rashid derived its comparison bbox by reprojecting
 only the four corners of the asset's native EPSG:28992 bbox, which is not a bound
-under a non-affine projection. Filed as portolan-sdi/reis#26 and fixed in
-portolan-sdi/reis#28, which brackets the reprojected extent between a densified
+under a non-affine projection. Filed as portolan-sdi/rashid#26 and fixed in
+portolan-sdi/rashid#28, which brackets the reprojected extent between a densified
 outer bound and an inner bound instead. Collections that preserve a projected
-source CRS validate cleanly from reis
+source CRS validate cleanly from rashid
 `7bb322961dc7fa4d49744604ee227346561f7f64` onward.
 
-reis's live-hosting pass (`--live`, PTL-LIV) is deliberately not wired in. It
+rashid's live-hosting pass (`--live`, PTL-LIV) is deliberately not wired in. It
 probes the servers behind absolute `https` asset hrefs. The catalog does have
 eight of those, one `source` asset per Collection, so the pass would find
-targets. It skips them anyway, because `reis/src/reis/live.py` exempts any
+targets. It skips them anyway, because `rashid/src/rashid/live.py` exempts any
 `source` or `alternate` asset on the grounds that the publisher does not run
 that server. So the pass has nothing left to probe until the catalog is
 published at a real base URL and its own relative hrefs become absolute.
 Revisit then.
 
-Worth knowing that the exemption is reis's own invention. core.md's Data Storage
+Worth knowing that the exemption is rashid's own invention. core.md's Data Storage
 section says "Servers MUST support range requests" and requires CORS with
 `Access-Control-Expose-Headers`, unqualified, with no carve-out for upstream
 servers. Measured against the eight upstream sources, two ignore `Range`
@@ -237,10 +237,10 @@ entirely, four send no CORS header, and none sends
 `Access-Control-Expose-Headers`. Nothing the generator can fix, those are third
 party servers. The spec should scope those MUSTs to assets the publisher hosts.
 
-reis is a pinned git dependency in `build.py`'s PEP 723 header. Bumping the
-Portolan schema is a coordinated change across this repo and reis, update the
-local schema, regenerate the reference catalog, re-vendor fixtures into reis,
-then bump the reis pin here.
+rashid is a pinned git dependency in `build.py`'s PEP 723 header. Bumping the
+Portolan schema is a coordinated change across this repo and rashid, update the
+local schema, regenerate the reference catalog, re-vendor fixtures into rashid,
+then bump the rashid pin here.
 
 ## Conventions
 

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -7,7 +7,7 @@
 #   "pyarrow>=25",
 #   "geoparquet-io @ git+https://github.com/yharby/geoparquet-io.git@f27e53108910f19bd74a9ff4be5c7d97b104753c",
 #   "rasterio>=1.5",
-#   "reis[data] @ git+https://github.com/portolan-sdi/reis.git@7bb322961dc7fa4d49744604ee227346561f7f64",
+#   "rashid[data] @ git+https://github.com/portolan-sdi/rashid.git@4302f169374a17265f219824486e217591195aad",
 #   "rio-cogeo>=5.3",
 #   "Pillow>=11",
 # ]

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -123,7 +123,7 @@ def add_source_asset(assets: dict, local: Path, spec_source: dict) -> None:
     is referenced by URL in the sidecars instead. Two reasons. A live query URL is
     an API rather than a download, and `file:size` and `file:checksum` pinned to
     bytes this catalog does not control are guaranteed to rot the moment upstream
-    changes, which is exactly the validator failure reis caught on the Socrata
+    changes, which is exactly the validator failure rashid caught on the Socrata
     mirror.
     """
     if spec_source.get("stable", True):

--- a/examples/tools/tests/check_cog.py
+++ b/examples/tools/tests/check_cog.py
@@ -12,12 +12,12 @@
 Covers the two rules formats.md raises to MUSTs on top of a valid COG, per OGC
 21-026's Optimized GeoTIFF requirements class.
 
-Overviews (`/req/optimized_geotiff/number`), which reis enforces as PTL-DAT-011.
+Overviews (`/req/optimized_geotiff/number`), which rashid enforces as PTL-DAT-011.
 A raster wider or taller than one 512px tile MUST carry internal overviews,
 halving until the coarsest level fits inside a tile. A raster already smaller
 than a tile is exempt, since it is its own overview.
 
-Band statistics, which reis enforces as PTL-DAT-009 and PTL-DAT-010. Every band
+Band statistics, which rashid enforces as PTL-DAT-009 and PTL-DAT-010. Every band
 carries embedded STATISTICS_* tags, and valid percent is a MUST once the band has
 a nodata value.
 

--- a/examples/tools/tests/check_styles.py
+++ b/examples/tools/tests/check_styles.py
@@ -13,7 +13,7 @@ typically `../filename.pmtiles`, with `layers[].source` set to `data`.
 
 A style file that points at `./x.pmtiles` resolves to `styles/x.pmtiles`, which
 does not exist, so the style loads no tiles and renders nothing. Nothing else in
-the toolchain catches that, reis does not read style bodies and the STAC
+the toolchain catches that, rashid does not read style bodies and the STAC
 validators skip them for having no stac_version, so it is asserted here.
 
 core.md also requires the thumbnail to be generated from default styling, where

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -5,7 +5,7 @@
 #   "reis[data] @ git+https://github.com/portolan-sdi/reis.git@45207def50768cdb03eaa28f02215fabfdacacda",
 # ]
 # ///
-"""Standalone checks for the reis validation adapter.
+"""Standalone checks for the rashid validation adapter.
 
 Run:
     uv run examples/tools/tests/check_validate.py
@@ -29,7 +29,7 @@ from validate import validate  # noqa: E402
 
 
 def check_reference_catalog_passes() -> None:
-    # Raises SystemExit if reis reports any error finding.
+    # Raises SystemExit if rashid reports any error finding.
     validate(REFERENCE, SCHEMA)
 
 

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "jsonschema>=4.26.0",
-#   "reis[data] @ git+https://github.com/portolan-sdi/reis.git@45207def50768cdb03eaa28f02215fabfdacacda",
+#   "rashid[data] @ git+https://github.com/portolan-sdi/rashid.git@4302f169374a17265f219824486e217591195aad",
 # ]
 # ///
 """Standalone checks for the rashid validation adapter.

--- a/examples/tools/validate.py
+++ b/examples/tools/validate.py
@@ -1,9 +1,9 @@
-"""Validate a built Portolan catalog with reis, the canonical validator.
+"""Validate a built Portolan catalog with rashid, the canonical validator.
 
-reis defines Portolan conformance. This module is a thin adapter. It runs reis's
-metadata, structural, schema, and data passes over a built catalog, feeds the
-schema pass the repo's working-copy schema under stac/, restricts the data pass
-to local assets, and fails the build on any error finding.
+rashid defines Portolan conformance. This module is a thin adapter. It runs
+rashid's metadata, structural, schema, and data passes over a built catalog,
+feeds the schema pass the repo's working-copy schema under stac/, restricts the
+data pass to local assets, and fails the build on any error finding.
 """
 from __future__ import annotations
 
@@ -15,17 +15,17 @@ from typing import TYPE_CHECKING, Callable
 import jsonschema
 
 if TYPE_CHECKING:
-    from reis.catalog import Node
-    from reis.data import DataDefect
-    from reis.data.reader import AssetReader, Locator
+    from rashid.catalog import Node
+    from rashid.data import DataDefect
+    from rashid.data.reader import AssetReader, Locator
 
 
 def _local_schema_validator(schema_path: Path) -> Callable[[dict], list[str]]:
-    """A reis schema-pass validator bound to the working-copy schema.
+    """A rashid schema-pass validator bound to the working-copy schema.
 
-    Reis's schema pass fetches the published profile schema. Here we point it at
-    the committed schema under stac/ so the build tests the working copy, which
-    is what the old validator did. Returns the jsonschema messages for one
+    Rashid's schema pass fetches the published profile schema. Here we point it
+    at the committed schema under stac/ so the build tests the working copy,
+    which is what the old validator did. Returns the jsonschema messages for one
     object, empty when it satisfies the schema.
     """
     schema = json.loads(schema_path.read_text())
@@ -60,8 +60,8 @@ class _LocalOnlyReader:
 
 
 def _local_only_data_validator() -> "Callable[[Node, AssetReader], list[DataDefect]]":
-    """Wrap reis's byte checker so it reads through a local-only reader."""
-    from reis.data import checks
+    """Wrap rashid's byte checker so it reads through a local-only reader."""
+    from rashid.data import checks
 
     def validate_node(node: "Node", reader: "AssetReader") -> "list[DataDefect]":
         return checks.check_node(node, _LocalOnlyReader(reader))
@@ -70,15 +70,15 @@ def _local_only_data_validator() -> "Callable[[Node, AssetReader], list[DataDefe
 
 
 def validate(out: Path, schema_path: Path) -> None:
-    """Validate the built catalog at out with reis and fail on any error.
+    """Validate the built catalog at out with rashid and fail on any error.
 
     Runs the metadata pass (always), the STAC 1.1.0 structural pass, the schema
     pass against the working-copy schema, and the data pass over local assets.
-    Prints every finding and raises SystemExit when reis reports an error.
+    Prints every finding and raises SystemExit when rashid reports an error.
     """
-    from reis import validate as reis_validate
+    from rashid import validate as rashid_validate
 
-    report = reis_validate(
+    report = rashid_validate(
         out,
         structural=True,
         schema=True,

--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -19,7 +19,7 @@ sentence it governs, so the check needs no markup inside the markdown:
 Exclusions cover uppercase keyword mentions that are not requirements (for
 example, prose explaining the RFC 2119 conventions themselves).
 
-Downstream, the reis validator vendors this manifest and enforces that every
+Downstream, the rashid validator vendors this manifest and enforces that every
 MUST and SHOULD ID maps to at least one rule and one test.
 
 Usage::

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -7,7 +7,7 @@
 # REQUIRED -> MUST, RECOMMENDED -> SHOULD, OPTIONAL / NOT REQUIRED -> MAY).
 #
 # enforcement is one of:
-#   validator - the reis validator must cite this ID from at least one check.
+#   validator - the rashid validator must cite this ID from at least one check.
 #   process   - not machine-checkable from the catalog or its bytes
 #               (publish-time behavior, upstream knowledge, guidance).
 #


### PR DESCRIPTION
Companion-PR: portolan-sdi/rashid#34

The validator repository moved from `portolan-sdi/reis` to
`portolan-sdi/rashid`. The distribution name, the import package, and the
console script follow the repository name, so every reference in this repo has
to move with it. This is one of five coordinated PRs across the org.

## What changed

`.github/workflows/companion-pr.yaml` is the tightest coupling. It greps PR
bodies for a `Companion-PR: portolan-sdi/reis#123` header and then calls
`gh pr view --repo portolan-sdi/reis` to confirm the referenced PR exists. Both
the pattern and the API call now name `rashid`. The header convention
documented in `README.md` changes in lockstep; leaving either side behind would
have contributors writing a header the workflow no longer matches.

`examples/tools/validate.py` imports the validator directly. `reis.catalog`,
`reis.data`, `reis.data.reader`, and the `reis_validate` alias all become
`rashid`.

The rest is prose: `README.md`, `CHANGELOG.md`, `examples/README.md`,
`examples/tools/CLAUDE.md`, the requirement-manifest comments in
`specs/portolan/requirements.yaml` and `scripts/check_requirements.py`, and the
explanatory docstrings in the example tools. The copy-paste `uv run` commands in
`examples/tools/CLAUDE.md` now use the `rashid` console-script name.

Rule IDs (`PTL-*`), degradation codes, schema URIs under
`schemas.portolan-sdi.org`, and the `validator` requirement key are unchanged.
Only the prose describing the validator moved.

## The two SHA pins are deliberately stale

`examples/tools/build.py:10` and `examples/tools/tests/check_validate.py:5` are
PEP 723 headers pinning the validator by commit SHA. Both SHAs predate the
rename, so those commits still install a distribution literally named `reis`.
Re-pinning them requires the validator's own rename to reach its main branch
first. Both lines are left exactly as they are and will be re-pinned in a
follow-up.

Because those pins are stale, `examples/tools/validate.py` will not run green on
this branch. That is expected.

## Checks

`scripts/check_requirements.py` passes, reporting 115 requirements anchored. The
`stac/` profile suite passes: schema-URI version check, `stac-node-validator`
over all four examples, and the Portolan profile check. All touched YAML parses
and all touched Python compiles.

The example build and validate path could not run, for the reason above.
