### PR TITLE
ci: check the example catalogs, and pin rashid to 0.1.3

### DIFF
--- a/.github/workflows/catalog-upstream.yaml
+++ b/.github/workflows/catalog-upstream.yaml
@@ -1,0 +1,87 @@
+name: Catalog Upstream
+
+# Proves the upstream sources the example catalogs cite. rashid's data pass
+# refetches every stable source and checks the file:size and file:checksum
+# published for it. Spec issue #80 was an upstream drifting away from a
+# published checksum, and nothing else in CI catches that.
+#
+# This is deliberately not a pull-request gate. It depends on five third-party
+# servers, so a merge would be blocked by a source being briefly unreachable,
+# which says nothing about the PR. Weekly catches drift just as well. The
+# committed bytes are still checked on every PR, offline, by
+# examples-checks.yaml.
+#
+# A failure opens an issue rather than going unread in a scheduled run nobody
+# watches, and comments on the existing one instead of filing a duplicate.
+
+on:
+  schedule:
+    # Mondays, 06:17 UTC. Off the hour, since scheduled runs bunch up on it.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v9
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'examples/tools/**/*.py'
+
+      - name: Validate every catalog against its upstream sources
+        id: check
+        run: |
+          # pipefail is not on in the default runner shell, so without it the
+          # step would take tee's exit code and never fail.
+          set -o pipefail
+          uv run scripts/check_catalogs.py 2>&1 | tee findings.txt
+
+      - name: Report drift
+        if: failure() && steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          gh label create upstream-drift --force \
+            --color d93f0b --description "An example catalog stopped validating"
+
+          # findings.txt is this workflow's own output, not user input.
+          {
+            echo "\`scripts/check_catalogs.py\` failed on a scheduled run."
+            echo "An example catalog no longer validates against its upstream sources."
+            echo
+            echo "Run: ${RUN_URL}"
+            echo
+            echo '```'
+            tail -c 40000 findings.txt
+            echo '```'
+            echo
+            echo "Reproduce locally with \`uv run scripts/check_catalogs.py\`."
+            echo "If an upstream changed, rebuild with \`uv run examples/tools/build.py\`"
+            echo "and commit the result."
+          } > issue-body.md
+
+          EXISTING=$(gh issue list --label upstream-drift --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file issue-body.md
+          else
+            gh issue create --label upstream-drift \
+              --title "An example catalog no longer validates upstream" \
+              --body-file issue-body.md
+          fi

--- a/.github/workflows/catalog-upstream.yaml
+++ b/.github/workflows/catalog-upstream.yaml
@@ -35,7 +35,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v9
+      # Exact version, setup-uv has no floating v9 tag. See examples-checks.yaml.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: 'examples/tools/**/*.py'

--- a/.github/workflows/examples-checks.yaml
+++ b/.github/workflows/examples-checks.yaml
@@ -37,7 +37,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v9
+      # setup-uv stopped publishing floating major tags after v7, so this is
+      # pinned to an exact version while checkout above can float. It needs a
+      # Dependabot config to stay current, see the note in the PR.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           # Each check_*.py carries its own PEP 723 dependencies, so the cache

--- a/.github/workflows/examples-checks.yaml
+++ b/.github/workflows/examples-checks.yaml
@@ -1,0 +1,48 @@
+name: Examples
+
+# The generator under examples/tools/ ships nine checks and nothing ran them.
+# They cover catalog conformance, the committed COG and GeoParquet, the MapLibre
+# style URLs, the thumbnail geometry, and the fetch cache. Several of them catch
+# defects nothing else does, see examples/tools/CLAUDE.md.
+#
+# Every check is offline and deterministic, and the whole suite runs in about
+# twelve seconds. So this runs on every pull request with no path filter, which
+# keeps it eligible to be a required status check. A path-filtered workflow
+# cannot be required, it stays pending on the PRs it skips.
+#
+# The upstream sources are a different problem. Proving them means refetching
+# five third-party servers, which is slow and fails for reasons unrelated to any
+# PR, so that runs on a schedule in catalog-upstream.yaml instead.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Superseded PR runs are worth cancelling. Runs on main are not, a cancelled
+  # one leaves a gap in the record of what was green.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v9
+        with:
+          enable-cache: true
+          # Each check_*.py carries its own PEP 723 dependencies, so the cache
+          # key has to follow the scripts rather than a lockfile.
+          cache-dependency-glob: 'examples/tools/**/*.py'
+
+      - name: Run the generator checks
+        run: uv run examples/tools/tests/run_all.py

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -25,7 +25,7 @@ bootstraps `sys.path` with its own directory so they import as flat names.
 | `tiles.py` | XYZ basemap tile fetch and mosaic for thumbnails |
 | `stacio.py` | STAC assembly, manifest, providers, assets, links, sidecars, catalog builders |
 | `validate.py` | Thin adapter over rashid, the canonical validator. Runs its metadata, structural, schema, and data passes over the built catalog |
-| `tests/` | Standalone `uv run` checks, `check_compliance.py`, `check_web_output.py`, `check_validate.py`, `check_tiles.py`, `check_thumb_geoms.py`, `check_thumbnails.py`, `check_cog.py`, `check_fetch.py`, and `check_styles.py` |
+| `tests/` | Standalone `uv run` checks, `check_compliance.py`, `check_web_output.py`, `check_validate.py`, `check_tiles.py`, `check_thumb_geoms.py`, `check_thumbnails.py`, `check_cog.py`, `check_fetch.py`, and `check_styles.py`, plus `run_all.py` which runs the lot |
 
 Inputs and outputs live under `examples/`, not here.
 
@@ -49,10 +49,12 @@ geoparquet-io) on the fly. The whole generator, data path and thumbnails
 alike, runs on DuckDB spatial, rasterio, and rio-cogeo, none of it shells out
 to the GDAL CLI, so the only prerequisites on PATH are `tippecanoe` and `uv`.
 
-The test scripts run the same way.
+The test scripts run the same way, and `run_all.py` runs all of them, reporting
+every result rather than stopping at the first failure. That is what CI runs.
 
 ```bash
-uv run examples/tools/tests/check_compliance.py
+uv run examples/tools/tests/run_all.py           # all of them
+uv run examples/tools/tests/check_compliance.py  # or one at a time
 uv run examples/tools/tests/check_web_output.py
 uv run examples/tools/tests/check_validate.py
 uv run examples/tools/tests/check_tiles.py
@@ -197,8 +199,8 @@ proven by running rashid directly, without the adapter. Do that before publishin
 rebuild.
 
 ```bash
-uv run --with "rashid[data] @ git+https://github.com/portolan-sdi/rashid.git" \
-  rashid check --data examples/catalog/reference
+uv run --with "rashid[data]>=0.1.3,<0.2.0" \
+  rashid check --schema examples/catalog/reference
 ```
 
 The build is clean apart from eight infos, which are expected and terminal. Do
@@ -237,10 +239,45 @@ entirely, four send no CORS header, and none sends
 `Access-Control-Expose-Headers`. Nothing the generator can fix, those are third
 party servers. The spec should scope those MUSTs to assets the publisher hosts.
 
-rashid is a pinned git dependency in `build.py`'s PEP 723 header. Bumping the
-Portolan schema is a coordinated change across this repo and rashid, update the
-local schema, regenerate the reference catalog, re-vendor fixtures into rashid,
-then bump the rashid pin here.
+rashid comes from PyPI, pinned to a compatible range in `build.py`'s PEP 723
+header, currently `rashid[data]>=0.1.3,<0.2.0`. Bumping the Portolan schema is a
+coordinated change across this repo and rashid, update the local schema,
+regenerate the reference catalog, re-vendor fixtures into rashid, then bump the
+rashid range here.
+
+## What CI runs, and why it is split in two
+
+The committed catalogs used to be checked by nothing, so they could drift out of
+conformance between rebuilds unnoticed. Two workflows cover that now, split on
+whether the check needs the network.
+
+`.github/workflows/examples-checks.yaml` runs `tests/run_all.py` on every push
+and pull request, with no path filter. Every check in there is offline and
+deterministic and the suite takes about twelve seconds, so there is no reason to
+filter, and an unfiltered workflow is the only kind that can be a required
+status check. A path-filtered one stays pending on the PRs it skips.
+
+`.github/workflows/catalog-upstream.yaml` runs `scripts/check_catalogs.py`
+weekly and on demand. That is the one that refetches the upstream sources and
+proves their `file:size` and `file:checksum`. It is not a PR gate on purpose. It
+depends on five third-party servers, so gating merges on it would block work
+whenever one of them is briefly down, which says nothing about the PR. A failure
+opens an issue instead, or comments on the open one.
+
+`check_catalogs.py` reads the rashid requirement out of `build.py`'s PEP 723
+header with `tomllib`, so the validator that checks a catalog is the validator
+that built it and there is no second pin to drift. It is generic over every tree
+under `examples/catalog/`, so a new manifest is covered as soon as its output is
+committed. Its gate is errors and warnings, since rashid's own exit code fires
+on errors alone and a warning in a reference example is a real defect. The eight
+infos above are advisory and do not fail it.
+
+Two known gaps. `check_catalogs.py` validates against the profile schema bundled
+in the rashid wheel, while `validate.py` injects the working copy under `stac/`,
+so a change to `stac/json-schema/` is proven by the build rather than by CI. And
+`check_validate.py` is hardcoded to the `reference` tree, so a second catalog
+gets weekly coverage immediately but per-PR coverage only once that script is
+generalized.
 
 ## Conventions
 

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -7,7 +7,7 @@
 #   "pyarrow>=25",
 #   "geoparquet-io @ git+https://github.com/yharby/geoparquet-io.git@f27e53108910f19bd74a9ff4be5c7d97b104753c",
 #   "rasterio>=1.5",
-#   "rashid[data] @ git+https://github.com/portolan-sdi/rashid.git@4302f169374a17265f219824486e217591195aad",
+#   "rashid[data]>=0.1.3,<0.2.0",
 #   "rio-cogeo>=5.3",
 #   "Pillow>=11",
 # ]

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "jsonschema>=4.26.0",
-#   "rashid[data] @ git+https://github.com/portolan-sdi/rashid.git@4302f169374a17265f219824486e217591195aad",
+#   "rashid[data]>=0.1.3,<0.2.0",
 # ]
 # ///
 """Standalone checks for the rashid validation adapter.

--- a/examples/tools/tests/run_all.py
+++ b/examples/tools/tests/run_all.py
@@ -1,0 +1,89 @@
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Run every generator check in this directory and report them together.
+
+Each check_*.py is its own uv entrypoint with its own PEP 723 dependencies, so
+each runs in its own resolved environment. This runner shells out to `uv run`
+per script rather than importing them, which keeps that isolation and means the
+runner itself needs nothing but the standard library.
+
+Every check here is offline and deterministic. check_tiles.py fetches from a
+fake host, check_fetch.py runs against a local HTTP server, and check_validate.py
+reads the committed catalog through validate.py's local-only reader. Nothing
+reaches a third-party server, so this is safe to gate a pull request on. The
+upstream sources are proven separately by scripts/check_catalogs.py.
+
+Every check runs even after one fails, because a single failure should not hide
+the other eight.
+
+Usage::
+
+    uv run examples/tools/tests/run_all.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+# examples/tools/tests/run_all.py -> repo root is three levels up
+REPO = HERE.parent.parent.parent
+
+
+def _checks() -> list[Path]:
+    return sorted(HERE.glob("check_*.py"))
+
+
+def main() -> int:
+    checks = _checks()
+    if not checks:
+        print(f"no check_*.py found in {HERE}", file=sys.stderr)
+        return 1
+
+    results: list[tuple[str, bool, float]] = []
+    for script in checks:
+        print(f"::group::{script.name}", flush=True)
+        started = time.monotonic()
+        completed = subprocess.run(["uv", "run", str(script)], check=False)
+        elapsed = time.monotonic() - started
+        print("::endgroup::", flush=True)
+        results.append((script.name, completed.returncode == 0, elapsed))
+
+    print()
+    for name, ok, elapsed in results:
+        print(f"{'PASS' if ok else 'FAIL'}  {elapsed:5.1f}s  {name}")
+
+    failed = [name for name, ok, _ in results if not ok]
+    summary = (
+        f"{len(results) - len(failed)}/{len(results)} generator checks passed"
+        if not failed
+        else f"{len(failed)} of {len(results)} generator checks failed: "
+        + ", ".join(failed)
+    )
+    print(f"\n{summary}")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        lines = ["| Check | Result | Time |", "| --- | --- | --- |"]
+        lines += [
+            f"| `{name}` | {'pass' if ok else '**fail**'} | {elapsed:.1f}s |"
+            for name, ok, elapsed in results
+        ]
+        with open(step_summary, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+    if failed:
+        rel = HERE.relative_to(REPO)
+        for name in failed:
+            print(f"::error::{name} failed, rerun it with 'uv run {rel}/{name}'")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/tools/validate.py
+++ b/examples/tools/validate.py
@@ -12,29 +12,26 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
-import jsonschema
-
 if TYPE_CHECKING:
     from rashid.catalog import Node
     from rashid.data import DataDefect
     from rashid.data.reader import AssetReader, Locator
+    from rashid.schema import Validator
 
 
-def _local_schema_validator(schema_path: Path) -> Callable[[dict], list[str]]:
+def _local_schema_validator(schema_path: Path) -> "Validator":
     """A rashid schema-pass validator bound to the working-copy schema.
 
-    Rashid's schema pass fetches the published profile schema. Here we point it
-    at the committed schema under stac/ so the build tests the working copy,
-    which is what the old validator did. Returns the jsonschema messages for one
+    Rashid's schema pass resolves the published profile schema from the copies
+    bundled in its wheel. Here we point it at the committed schema under stac/
+    so the build tests the working copy. rashid's own `validator_from_schema`
+    builds it, which keeps the SchemaError contract and the oneOf error
+    narrowing rashid's reporting expects. Returns the schema errors for one
     object, empty when it satisfies the schema.
     """
-    schema = json.loads(schema_path.read_text())
-    validator = jsonschema.Draft7Validator(schema)
+    from rashid.schema import validator_from_schema
 
-    def validate_object(obj: dict) -> list[str]:
-        return [error.message for error in validator.iter_errors(obj)]
-
-    return validate_object
+    return validator_from_schema(json.loads(schema_path.read_text()))
 
 
 class _LocalOnlyReader:

--- a/scripts/check_catalogs.py
+++ b/scripts/check_catalogs.py
@@ -1,0 +1,175 @@
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Validate every committed example catalog with rashid, upstream sources included.
+
+examples/catalog/ holds the canonical examples of a conformant Portolan catalog,
+committed in full, Parquet and COG included. This runs rashid over each of them.
+
+The data pass is left on, which is what separates this check from the generator
+checks under examples/tools/tests/. Those read the committed bytes through a
+local-only reader and stay offline. This one refetches the stable upstream
+sources and proves the file:size and file:checksum published for each. Spec
+issue #80 was an upstream drifting away from a published checksum, and nothing
+else catches that.
+
+That makes this check depend on third-party servers, so it belongs on a schedule
+rather than on a pull request. A source being briefly unreachable is not a reason
+to block a merge, but it is a reason to look.
+
+The rashid version is read out of the PEP 723 header in examples/tools/build.py,
+so the validator that checks a catalog is the validator that built it. This
+script declares no dependencies of its own for that reason, and runs on the
+standard library alone.
+
+The gate is errors and warnings. rashid's own exit code fires on errors only, and
+a warning is a real defect in a reference example. Infos are advisory and do not
+fail the run. The reference catalog reports eight PTL-PRO-002 infos, which are
+expected and terminal, see examples/tools/CLAUDE.md.
+
+Usage::
+
+    uv run scripts/check_catalogs.py
+    uv run scripts/check_catalogs.py --catalog reference
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+# The reference regex from PEP 723 for locating an embedded metadata block.
+PEP_723_BLOCK = (
+    r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
+)
+
+
+def _repo_root() -> Path:
+    # scripts/check_catalogs.py -> repo root is two levels up
+    return Path(__file__).resolve().parent.parent
+
+
+def script_dependencies(script: Path) -> list[str]:
+    """The PEP 723 `dependencies` list declared by a uv entrypoint script."""
+    matches = [
+        match
+        for match in re.finditer(PEP_723_BLOCK, script.read_text(encoding="utf-8"))
+        if match.group("type") == "script"
+    ]
+    if len(matches) != 1:
+        raise SystemExit(f"{script}: expected exactly one PEP 723 script block")
+    content = "".join(
+        line[2:] if line.startswith("# ") else line[1:]
+        for line in matches[0].group("content").splitlines(keepends=True)
+    )
+    deps = tomllib.loads(content).get("dependencies", [])
+    return [str(dep) for dep in deps]
+
+
+def rashid_requirement(build_script: Path) -> str:
+    """The rashid requirement string pinned by the generator entrypoint."""
+    for dep in script_dependencies(build_script):
+        if re.match(r"^rashid\b", dep):
+            return dep
+    raise SystemExit(f"{build_script}: no rashid dependency in its PEP 723 header")
+
+
+def catalogs(root: Path, only: str | None) -> list[Path]:
+    """Every built catalog tree under examples/catalog/, by root catalog.json."""
+    found = sorted(
+        path.parent
+        for path in root.glob("examples/catalog/*/catalog.json")
+    )
+    if only:
+        found = [path for path in found if path.name == only]
+    return found
+
+
+def run_rashid(requirement: str, catalog: Path) -> dict:
+    """rashid's JSON report for one catalog tree."""
+    completed = subprocess.run(
+        [
+            "uv", "run", "--with", requirement,
+            "rashid", "check", "--schema", "--all", "--json", str(catalog),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if not completed.stdout.strip():
+        sys.stderr.write(completed.stderr)
+        raise SystemExit(f"rashid produced no report for {catalog}")
+    return json.loads(completed.stdout)
+
+
+def report(catalog: Path, data: dict, root: Path) -> bool:
+    """Print one catalog's findings. True when it passes the gate."""
+    print(f"::group::{catalog.relative_to(root)}")
+    for finding in data["findings"]:
+        print(
+            f"  {finding['severity']:<7} {finding['rule_id']}  "
+            f"{finding['path']}: {finding['message']}"
+        )
+    print(
+        f"  {data['error_count']} error(s), {data['warning_count']} warning(s), "
+        f"{data['info_count']} info(s) across {data['files_checked']} files."
+    )
+    print("::endgroup::")
+    return data["error_count"] + data["warning_count"] == 0
+
+
+def write_step_summary(rows: list[tuple[Path, dict, bool]]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    lines = [
+        "| Catalog | Errors | Warnings | Infos | Files |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    lines += [
+        f"| `{catalog.name}` | {data['error_count']} | {data['warning_count']} "
+        f"| {data['info_count']} | {data['files_checked']} |"
+        for catalog, data, _ in rows
+    ]
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    root = _repo_root()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--catalog", default=None, help="check only this catalog by directory name")
+    args = parser.parse_args()
+
+    requirement = rashid_requirement(root / "examples/tools/build.py")
+    print(f"rashid requirement: {requirement}")
+
+    trees = catalogs(root, args.catalog)
+    if not trees:
+        raise SystemExit(f"no catalogs found under {root / 'examples/catalog'}")
+
+    rows = []
+    for catalog in trees:
+        data = run_rashid(requirement, catalog)
+        rows.append((catalog, data, report(catalog, data, root)))
+
+    write_step_summary(rows)
+
+    failed = [catalog for catalog, _, ok in rows if not ok]
+    for catalog in failed:
+        print(
+            f"::error::{catalog.relative_to(root)} no longer validates. Rebuild it with "
+            f"'uv run examples/tools/build.py --catalog {catalog.name}' and commit the result."
+        )
+    print(f"\n{len(rows) - len(failed)}/{len(rows)} catalogs passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # dependencies = ["pyyaml>=6"]
 # ///
 """Verify requirements.yaml and the spec prose agree, both directions.


### PR DESCRIPTION
## What this changes

`examples/` is checked by CI for the first time. Nine generator checks that
already existed but never ran now gate every pull request, and a weekly job
reverifies each committed catalog against its upstream sources. rashid moves
off a git SHA onto the published `rashid[data]>=0.1.3,<0.2.0`.

## Why

The pinned SHA was `4302f16`, 57 commits stale, so the reference catalog was
being validated by a validator with six since-fixed bugs in it. Nothing
re-checked `examples/catalog/` between rebuilds, so it could drift out of
conformance and nobody would find out.

## Verification

Both new checks against `examples/catalog/reference`:

```
$ uv run scripts/check_catalogs.py
rashid requirement: rashid[data]>=0.1.3,<0.2.0
  0 error(s), 0 warning(s), 8 info(s) across 14 files.
1/1 catalogs passed

$ uv run examples/tools/tests/run_all.py
PASS    0.3s  check_cog.py          PASS    0.1s  check_tiles.py
PASS    2.4s  check_compliance.py   PASS    0.4s  check_validate.py
PASS    0.6s  check_fetch.py        PASS    0.4s  check_web_output.py
PASS    0.4s  check_styles.py
PASS    0.2s  check_thumb_geoms.py  9/9 generator checks passed
PASS    0.3s  check_thumbnails.py
```

Failure paths were run, not assumed. An injected `rel:'self'` link gives 2 errors
and exit 1, while a deliberately failing check is named and the other nine run on.

```
$ uv run scripts/check_catalogs.py --catalog broken
  2 error(s), 0 warning(s), 8 info(s) across 14 files.
::error::examples/catalog/broken no longer validates. Rebuild it with ...
0/1 catalogs passed          EXIT=1
```

A full rebuild is clean too. Its only diff is upstream drift on the two
live-endpoint Collections, so nothing regenerated is committed here.

- [ ] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Unblocks [#98](https://github.com/portolan-sdi/portolan-spec/issues/98), which
needs a validator that tells the truth before an item-mirror example can be
written honestly.
