### PR TITLE
feat(spec): make file:size and file:checksum SHOULD, not MUST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+### Changed
+
+- **Assets** (PORTO-CORE-028): `file:size` and `file:checksum` drop from MUST to
+  SHOULD. A catalog that describes data it does not host often cannot produce a
+  checksum, so the old MUST left it a choice between failing conformance and
+  publishing a fabricated value (#112).
+- **Assets** (PORTO-CORE-030): the publish-time regeneration rule is restated as
+  an outcome. Any `file:size` and `file:checksum` an asset carries MUST match the
+  bytes its `href` resolves to, whenever and however they were written. Its
+  enforcement moves from `process` to `validator`, since a data pass can check it.
+- **Assets** (PORTO-CORE-029): reworded to govern a `file:checksum` where one is
+  present. Multihash encoding is still required, unchanged in force.
+- **Requirements manifest**: still 115 requirements, now 83 MUST, 18 SHOULD, and
+  14 MAY.
+
 ## 0.1.0 - 2026-07-27
 
 First tagged release, consolidating the specification from a working draft into a

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -237,11 +237,19 @@ Styles](#visualization-styles)).
 Portolan reuses existing extensions rather than restating their fields: `file` for
 `file:values`, `table` for schema and columns, `raster` and `vector` for band and
 layer detail, `license` for per-asset license, and `scientific` for citation or
-DOI. Assets MUST carry `file:size` and `file:checksum` from the [file
-extension](https://github.com/stac-extensions/file). The checksum MUST use
-multihash encoding, not a raw sha256 string. These embedded values MUST be
-regenerated at publish time, in the same operation that uploads the files, so they
-always match what is in the bucket.
+DOI.
+
+Assets SHOULD carry `file:size` and `file:checksum` from the [file
+extension](https://github.com/stac-extensions/file). Both are cheap to compute for
+bytes the publisher uploads, and they let a client budget a download and verify
+what it received. Neither is required, because a catalog that describes data it
+does not host cannot always produce them, and a fabricated value is worse than an
+absent one.
+
+A `file:checksum` MUST use multihash encoding, not a raw sha256 string. Any
+`file:size` and `file:checksum` an asset carries MUST match the bytes its `href`
+resolves to. A stale value is a conformance failure, so a publisher that cannot
+keep one current should omit it.
 
 **Primary-vs-alternate.** A non-cloud-native representation MAY be included as an
 alternate asset as long as an equivalent cloud-native primary asset exists (e.g. a

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -272,11 +272,11 @@ requirements:
       with `iso-19115` used specifically for an ISO 19115 file.
 
   - id: PORTO-CORE-028
-    severity: MUST
+    severity: SHOULD
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      Assets MUST carry `file:size` and `file:checksum` from the [file
+      Assets SHOULD carry `file:size` and `file:checksum` from the [file
       extension](https://github.com/stac-extensions/file).
 
   - id: PORTO-CORE-029
@@ -284,16 +284,15 @@ requirements:
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      The checksum MUST use multihash encoding, not a raw sha256 string.
+      A `file:checksum` MUST use multihash encoding, not a raw sha256 string.
 
   - id: PORTO-CORE-030
     severity: MUST
-    enforcement: process
+    enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      These embedded values MUST be regenerated at publish time, in the same
-      operation that uploads the files, so they always match what is in the
-      bucket.
+      Any `file:size` and `file:checksum` an asset carries MUST match the bytes
+      its `href` resolves to.
 
   - id: PORTO-CORE-031
     severity: MAY

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The schema no longer requires `file:size` and `file:checksum` on every asset,
+  following the specification's move of both to SHOULD. Where either is present
+  the schema still checks its shape, and tooling still checks the checksum's
+  multihash encoding and its agreement with the bytes. A catalog that conformed
+  before still conforms, so this is a non-breaking relaxation under the pre-1.0
+  bump policy.
+- The extension registry lists File Info as a conditional MUST, owed when an
+  asset carries either field rather than on every object with assets.
+
 ## 0.1.0 - 2026-07-27
 
 First tagged release. The schema is published at

--- a/stac/README.md
+++ b/stac/README.md
@@ -26,7 +26,7 @@ The schema encodes the specification's structural requirements that STAC core le
 
 - Every Catalog and Collection has a non-empty `title` and `description`; every `child` and `item` link carries a `title` (spec: Human-Readable Titles).
 - No object carries a `self` link, and structural links (`root`, `parent`, `child`, `item`, `collection`) are relative and carry `type: "application/json"` (`application/geo+json` for links to items), keeping a catalog fully portable (spec: Links).
-- Every asset has `href`, a media `type`, at least one `role`, and `file:size` + `file:checksum` (spec: Assets). The checksum's multihash encoding is verified by tooling, not schema.
+- Every asset has `href`, a media `type`, and at least one `role` (spec: Assets). `file:size` and `file:checksum` are SHOULD-level, so the schema checks their shape where present without requiring them; the checksum's multihash encoding, and whether either value matches the bytes, are verified by tooling rather than schema.
 - Absolute asset hrefs use `https` — `s3://` and other bucket schemes are rejected; relative hrefs are allowed (spec: Assets).
 - Every Collection declares `providers` with at least one `producer` and a `host` reachable through `url` or `email`; that the host is exactly one and listed last is checked by tooling (spec: Providers).
 - Collection `license` is never the deprecated `proprietary`; SPDX validity and the `rel: "license"` link required with `other` are checked by tooling (spec: License).
@@ -43,7 +43,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
 | [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
-| [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | Every object with assets: `file:size` + `file:checksum` (multihash) on each asset |
+| [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | When an asset carries `file:size` or `file:checksum`, both of which are SHOULD-level per asset (checksum as multihash) |
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |
 | [Raster][] | `https://stac-extensions.github.io/raster/v2.0.0/schema.json`               | **MUST**    | When band-level detail is provided |

--- a/stac/json-schema/v0.1.0/schema.json
+++ b/stac/json-schema/v0.1.0/schema.json
@@ -337,14 +337,14 @@
       }
     },
     "assets_typed_and_roled": {
-      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. Every asset also carries file:size and file:checksum (spec: Assets); the checksum's multihash encoding is verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
+      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. file:size and file:checksum are SHOULD-level (spec: Assets), so the schema constrains their shape where present but does not require them; the checksum's multihash encoding and its agreement with the bytes are verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
       "type": "object",
       "properties": {
         "assets": {
           "type": "object",
           "additionalProperties": {
             "type": "object",
-            "required": ["href", "type", "roles", "file:size", "file:checksum"],
+            "required": ["href", "type", "roles"],
             "properties": {
               "href": {
                 "type": "string",


### PR DESCRIPTION
## What this changes

`PORTO-CORE-028` becomes a SHOULD. 029 and 030 stay MUSTs, restated to bind only
assets that carry the fields: a checksum is multihash, and any declared value
matches the bytes its `href` resolves to. The profile schema drops both keys
from the asset `required` list and keeps their type constraints.

## Why

As discussed on Slack, this moves `file:size` and `file:checksum` from must to
should. It is a fairly onerous requirement to always generate these, even just
for updating the current STAC catalogs. Should indicates something people ought
to do, without requiring it. Issue #112 is the case that blocks. Reporting a
whole catalog's size is worth pushing sooner, as its own PR.

## Verification

The manifest re-anchors, the four profile examples validate, and a mutation
harness over `stac/examples/vector-collection.json` shows the relaxation is
scoped:

```console
$ uv run specs/tools/check_requirements.py
OK: 115 requirements anchored; all keyword occurrences covered.

$ cd stac && npm test
Files: 4   Valid: 4   Invalid: 0

$ node prove-optional.js
VALID    file:size and file:checksum removed
INVALID  roles removed (must still fail)
INVALID  file:size as a string (must still fail)
```

Companion-PR: portolan-sdi/rashid#90
