### PR TITLE
docs(examples): rewrite golden example docs to best-practices standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+### Changed
+
+- Rewrote the golden-example documentation to the standard in
+  [`specs/best-practices/documentation.md`](specs/best-practices/documentation.md)
+  (#81). Every Collection README now opens with a researched narrative and
+  numbers, carries a tested Quick Start, a described schema table, suggested
+  uses, and candid limitations, and every AGENTS.md is dataset-specific with
+  join keys, quirks, CRS consequences, and tested query recipes. The prose
+  lives in the manifest as per-collection markdown templates with generated
+  `{{placeholder}}` blocks, so structure varies by Collection while counts,
+  schemas, and code cannot drift from the built assets. Catalog-level READMEs
+  became collections tables. A new `check_docs.py` executes every code block
+  in the committed docs, and `build.py --docs-only` regenerates documentation
+  without refetching data.
+- The `boundaries/netherlands-provinces` example now mirrors its upstream ISO
+  19115 record from the Nationaal Georegister as a `metadata`-role asset.
+- Corrected example metadata found during research for #81. The
+  `raster/sample-cog` license is CC0-1.0, matching rasterio's dedication of
+  its test images, its temporal extent starts at the Landsat 7 launch instead
+  of a placeholder, the Natural Earth temporal extents match the May 2022
+  5.1.x releases, and the Eurostat join documentation targets `ISO_A2_EH`
+  with the EL and UK remaps, the raw `ISO_A2` join silently dropped France,
+  Norway, and Kosovo.
+
 ## 0.1.0 - 2026-07-27
 
 First tagged release, consolidating the specification from a working draft into a

--- a/examples/catalog/portolan-reference/AGENTS.md
+++ b/examples/catalog/portolan-reference/AGENTS.md
@@ -1,5 +1,19 @@
-# Agent guidance, Portolan Reference Catalog
+# Agent Guidance, Portolan Reference Catalog
 
-This is Portolan Reference Catalog.
-Follow the child links to each nested Catalog and Collection.
-Every Collection carries a cloud-native data asset and cites its original upstream source with a real checksum.
+Eight small Collections, each with its own AGENTS.md worth reading before
+querying it. Two attribute joins connect them. The Eurostat electricity
+prices table joins Natural Earth countries on ISO_A2_EH after remapping
+Eurostat's EL to GR and UK to GB. Natural Earth populated places join
+Natural Earth countries on ADM0_A3 after remapping SSD to SDS for South
+Sudan. Everything else connects only spatially, and the boundary layers
+differ hugely in scale, from 1:110m world polygons to Boston parcels, so
+match scales before spatial joins.
+
+- Natural Earth Countries (1:110m), 177 polygons, guide at ./reference/natural-earth-countries/AGENTS.md
+- Natural Earth Populated Places (1:50m), 1,251 points, guide at ./reference/natural-earth-populated-places/AGENTS.md
+- United States Counties (2023, 1:500k), 3,235 polygons, guide at ./boundaries/us-counties/AGENTS.md
+- Boston Open Space, 1,012 polygons, guide at ./boundaries/boston-open-space/AGENTS.md
+- Netherlands Provinces, 12 polygons, guide at ./boundaries/netherlands-provinces/AGENTS.md
+- San Francisco Addresses (EAS), 5,000 points, guide at ./mirror/san-francisco-addresses/AGENTS.md
+- Sample Raster COG, 3-band raster, guide at ./raster/sample-cog/AGENTS.md
+- Eurostat Electricity Prices for Household Consumers, 65,412 rows, guide at ./tabular/eurostat-electricity-prices/AGENTS.md

--- a/examples/catalog/portolan-reference/README.md
+++ b/examples/catalog/portolan-reference/README.md
@@ -2,9 +2,34 @@
 
 A mixed reference catalog exercising every major case in the Portolan v0.1 specification with real, openly licensed data pulled from its original upstream sources, vector polygons and points, raster, tabular, mirror provenance, nested catalogs and flat collections.
 
-Collections, 8.
-Nested Catalogs, 5.
-Licenses, BSD-3-Clause, CC-BY-4.0, CC0-1.0, PDDL-1.0.
+Every Collection here is a mirror that cites its true upstream source
+with a real checksum, and every README and AGENTS.md is written to the
+standard in the spec's documentation best practices, so the catalog
+doubles as the worked example of what good catalog documentation looks
+like. The Netherlands provinces Collection also mirrors its upstream ISO
+19115 record as a metadata-role asset, and every code block in these
+docs is executed by the repository's checks before it publishes.
+
+Agents, each Collection carries its own AGENTS.md with join keys, quirks,
+and tested queries, and the catalog-level [AGENTS.md](./AGENTS.md) maps
+the joins between Collections.
+
+## Collections
+
+| Collection | Contents | Description |
+|---|---|---|
+| [Natural Earth Countries (1:110m)](./reference/natural-earth-countries/README.md) | 177 polygons | 177 country polygons at world scale, the public domain basemap behind most web choropleths. |
+| [Natural Earth Populated Places (1:50m)](./reference/natural-earth-populated-places/README.md) | 1,251 points | 1,251 curated city and town points with population estimates, from Tokyo to Antarctic research stations. |
+| [United States Counties (2023, 1:500k)](./boundaries/us-counties/README.md) | 3,235 polygons | All 3,235 county and equivalent boundaries as of January 1, 2023, keyed by the FIPS codes that unlock US county statistics. |
+| [Boston Open Space](./boundaries/boston-open-space/README.md) | 1,012 polygons | 1,012 open space polygons of conservation and recreation interest, regardless of ownership, from Franklin Park to community gardens. |
+| [Netherlands Provinces](./boundaries/netherlands-provinces/README.md) | 12 polygons | The 12 provinces from the cadastral registry, boundaries that reproduce the national statistics office's official areas to one decimal. |
+| [San Francisco Addresses (EAS)](./mirror/san-francisco-addresses/README.md) | 5,000 points | A fixed 5,000-record extract of San Francisco's 388,550-record master address database, kept small on purpose for spec demonstration. |
+| [Sample Raster COG](./raster/sample-cog/README.md) | 3-band raster | A 1 MB Landsat-derived reference COG for learning and testing cloud-optimized raster access, not for analysis. |
+| [Eurostat Electricity Prices for Household Consumers](./tabular/eurostat-electricity-prices/README.md) | 65,412 rows | 65,412 semi-annual household electricity prices for 41 European countries from 2007 on, the official record of the 2022 energy crisis. |
+
+## Where the Data Comes From
+
+Licenses, CC-BY-4.0, CC0-1.0, PDDL-1.0.
 Provenance, 8 mirror Collections.
 
 Upstream sources.

--- a/examples/catalog/portolan-reference/boundaries/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/AGENTS.md
@@ -1,4 +1,7 @@
-# Agent guidance, Administrative Boundaries
+# Agent Guidance, Administrative Boundaries
 
-This catalog groups 3 Collections under Administrative Boundaries.
-Follow the child links to each Collection.
+This catalog groups 3 Collections. Each carries its own AGENTS.md with join keys, quirks, and tested queries, so follow the per-collection guides below.
+
+- United States Counties (2023, 1:500k), 3,235 polygons, guide at ./us-counties/AGENTS.md
+- Boston Open Space, 1,012 polygons, guide at ./boston-open-space/AGENTS.md
+- Netherlands Provinces, 12 polygons, guide at ./netherlands-provinces/AGENTS.md

--- a/examples/catalog/portolan-reference/boundaries/README.md
+++ b/examples/catalog/portolan-reference/boundaries/README.md
@@ -2,7 +2,16 @@
 
 Administrative and open-space boundary Collections from official sources.
 
-Collections, 3.
+## Collections
+
+| Collection | Contents | Description |
+|---|---|---|
+| [United States Counties (2023, 1:500k)](./us-counties/README.md) | 3,235 polygons | All 3,235 county and equivalent boundaries as of January 1, 2023, keyed by the FIPS codes that unlock US county statistics. |
+| [Boston Open Space](./boston-open-space/README.md) | 1,012 polygons | 1,012 open space polygons of conservation and recreation interest, regardless of ownership, from Franklin Park to community gardens. |
+| [Netherlands Provinces](./netherlands-provinces/README.md) | 12 polygons | The 12 provinces from the cadastral registry, boundaries that reproduce the national statistics office's official areas to one decimal. |
+
+## Where the Data Comes From
+
 Licenses, CC-BY-4.0, CC0-1.0, PDDL-1.0.
 Provenance, 3 mirror Collections.
 

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
@@ -1,7 +1,90 @@
-# Agent guidance, Boston Open Space
+# Agent Guidance, Boston Open Space
 
-This collection holds Boston Open Space.
-Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("boston-open-space.parquet").
-For rendering use the visual PMTiles asset or the thumbnail.
-License is PDDL-1.0.
-The original upstream source is https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326 , a live endpoint referenced by URL only.
+Boston's official open space inventory, valuable and messy in the way
+municipal GIS data actually is. No stable key, free-text code columns,
+and sentinel strings. The quirks below are each verified against the
+data and each prevents a silently wrong answer.
+
+Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('boston-open-space.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For rendering use the visual PMTiles asset with its MapLibre styles.
+
+## Quirks
+
+- PROTECTION is a slash-separated free-text list with typos, Ch91 and
+  Ch 91, CATMit and CAT Mit. Match with LIKE '%A97%', never equality.
+  453 sites match A97, Article 97 constitutional protection.
+- Null OS_Mngmnt means the steward in OS_Own_Jur manages the site
+  itself. It is a meaningful value, not missing data.
+- Sentinel strings pollute several columns, None, NULL, n/a, and angle
+  bracket Null variants in OS_Own_Jur and AgncyJuris, plus one
+  lowercase South end in DISTRICT.
+- TypeLong has spelling variants, an and for ampersand form and a
+  trailing-space form. Normalize with trim and replace before GROUP BY,
+  and expect TYPECODE to contradict it on about 13 rows.
+- Nine real sites carry ACRES = 0, so WHERE ACRES > 0 drops them. Fall
+  back to geometry area for those.
+- DISTRICT is the open space plan's districting, not official Boston
+  neighborhoods, and four large linear parks are assigned the literal
+  value Multi-District rather than a place.
+
+## Area, Use the ACRES Column
+
+Geometry is WGS84 degrees, so `ST_Area` returns square degrees. The
+official `ACRES` column matches geodesic geometry area to a median of
+0.003 acres, use it. If you must compute, DuckDB's spheroid function
+wants latitude first, and skipping the flip shrinks Boston by more
+than half.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT round(sum(ST_Area_Spheroid(ST_FlipCoordinates(geom))) / 4046.8564) AS acres_flipped,
+       round(sum(ACRES)) AS acres_official
+FROM read_parquet('boston-open-space.parquet');
+-- 7374 from geometry against 7356 official. Without the flip, 3250.
+```
+
+Eighteen sites disagree with their geometry by more than 10 percent,
+documented cases like Condor Street Overlook where ACRES excludes
+mudflats the polygon includes.
+
+## Tested Queries
+
+Acreage by normalized type.
+
+```sql
+SELECT trim(replace(TypeLong, ' and ', ' & ')) AS site_type,
+       count(*) AS sites, round(sum(ACRES), 1) AS acres
+FROM read_parquet('boston-open-space.parquet')
+WHERE TypeLong IS NOT NULL
+GROUP BY site_type ORDER BY acres DESC;
+-- Six types, led by Parkways, Reservations & Beaches at 2,621.6 acres.
+```
+
+Which open space contains a point. Boston Common from its center.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT SITE_NAME, DISTRICT, ACRES
+FROM read_parquet('boston-open-space.parquet')
+WHERE ST_Contains(geom, ST_Point(-71.0656, 42.3550));
+-- Boston Common, Back Bay/Beacon Hill, 45.7 acres.
+```
+
+Protected share by district.
+
+```sql
+SELECT DISTRICT, round(sum(ACRES), 1) AS total_acres,
+       round(sum(ACRES) FILTER (WHERE POS = 'X'), 1) AS protected_acres
+FROM read_parquet('boston-open-space.parquet')
+GROUP BY DISTRICT ORDER BY total_acres DESC LIMIT 3;
+-- West Roxbury 1,215 total and 637 protected, then the Harbor Islands
+-- and Roslindale.
+```
+
+## Related Collections
+
+`boundaries/us-counties` contains Boston at a far coarser scale, and a
+spatial join is the only bridge. The upstream layer on Analyze Boston
+is continuously maintained and now carries columns this July 2026
+snapshot predates, OS_ID, ZipCode, ParcelNumber, YearAcquired.
+Converted from the city's Shapefile export with DuckDB spatial into
+web-optimized GeoParquet 2.0.

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/README.md
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/README.md
@@ -2,16 +2,33 @@
 
 City of Boston open spaces and parks, playgrounds, athletic fields, conservation land, and cemeteries, 1,012 polygons from the City of Boston GIS open data platform. Official primary source, republished as cloud-native GeoParquet with a PMTiles visualization and MapLibre styles.
 
-License, PDDL-1.0.
-Providers, City of Boston (producer, licensor), Portolan SDI (host).
-Original source, https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326 .
-Features, 1012.
-Cloud-native asset, boston-open-space.parquet (GeoParquet).
-Note, the upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.
+Every open space of conservation and recreation interest in Boston,
+1,012 polygons and 7,356 acres, from Franklin Park's 392 acres down to
+pocket gardens, maintained by the
+[Boston Parks and Recreation Department](https://www.boston.gov/departments/parks-and-recreation)
+and published on [Analyze Boston](https://data.boston.gov/dataset/open-space).
+The layer's defining trait is in its official description, regardless
+of ownership. City parks sit beside 214 privately owned sites, state
+reservations, cemeteries, and 124 community gardens.
 
-## Open the data
+This inventory is the basis of the city's
+[Open Space and Recreation Plan 2023-2029](https://www.boston.gov/departments/parks-and-recreation/updating-seven-year-open-space-plan),
+which reports 7.1 acres of protected open space per 1,000 residents,
+and every site in it triggers design review within 100 feet under
+Boston's Municipal Ordinance 7-4.11.
 
-The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column for fast web-client pruning. Read it with a recent GeoPandas built on pyarrow 24 or newer.
+Agents, [AGENTS.md](./AGENTS.md) documents the free-text traps in this
+very real municipal data, read it before aggregating.
+
+## What Is in It
+
+Six site types by acreage. Parkways, reservations, and beaches, 82
+sites and 2,622 acres. Parks, playgrounds, and athletic fields, 361
+sites and 2,559 acres. Cemeteries and burying grounds, 38 and 1,013.
+Urban wilds and natural areas, 144 and 929. Malls, squares, and
+plazas, 261 and 199. Community gardens, 124 sites and 32 acres.
+
+## Quick Start
 
 ```python
 import geopandas as gpd
@@ -20,9 +37,65 @@ gdf = gpd.read_parquet("boston-open-space.parquet")
 print(gdf.head())
 ```
 
-Or query it in place with a recent DuckDB spatial.
+The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column, so it needs a GeoPandas built on pyarrow 24 or newer. DuckDB spatial queries the same file in place, see [AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to this directory, and the same code works against the published URL.
+
+## Schema
+
+| Column | Type | Description |
+|---|---|---|
+| `SITE_NAME` | varchar | Best-known or official site name. Multi-parcel sites carry Roman numeral suffixes, Stony Brook Reservation I and II. |
+| `OWNERSHIP` | varchar | Fee owner where known. City of Boston, Commonwealth of Massachusetts, private owners, and agency abbreviations like BRA and BNAN. |
+| `PROTECTION` | varchar | Slash-separated legal protection instruments. A97 is Article 97 of the Massachusetts Constitution, the strongest. Free text, match with LIKE. |
+| `TYPECODE` | integer | Numeric open space type 1 through 7. Disagrees with TypeLong on about 13 rows, treat TypeLong as closer to intent. |
+| `DISTRICT` | varchar | Planning district per the city's open space plan, not the official neighborhood boundaries. Includes the non-spatial value Multi-District. |
+| `ACRES` | double | Official area in acres of the open-space portion, the figure to use instead of computing geometry area. |
+| `ADDRESS` | varchar | Street address if known, null for 589 rows. |
+| `ZonAgg` | varchar | Aggregated zoning district, for example Open Space District. |
+| `TypeLong` | varchar | Open space type as text, with minor spelling variants worth normalizing before grouping. |
+| `OS_Own_Jur` | varchar | The entity holding the open-space rights. BPRD, DCR, the Boston Conservation Commission, or None. |
+| `OS_Mngmnt` | varchar | Managing entity only when it differs from OS_Own_Jur. Null means the steward manages it, not missing data. |
+| `POS` | varchar | Protected open space flag. X permanently protected, N not. |
+| `PA` | varchar | Public access flag. X accessible, A by appointment, N no or unknown access. |
+| `ALT_NAME` | varchar | Official, previous, or colloquial alternate names. |
+| `AgncyJuris` | varchar | Agency of jurisdiction for government-owned unprotected sites. Sparsely populated by design. |
+| `ShapeSTAre` | double | ArcGIS-computed area in square meters from the source State Plane geometry. |
+| `ShapeSTLen` | double | ArcGIS-computed perimeter in meters. |
+| `geom` | geometry | Site geometry, WGS84 longitude and latitude. |
+| `bbox` | struct(xmin double, ymin double, xmax double, ymax double) | Per-feature bounding box struct, the GeoParquet covering. |
+
+The table has 21 columns in all. The full list with types lives in `table:columns` on the `data` asset.
+
+## Protection and Access Are Columns, Not Assumptions
+
+Being in this file does not mean a site is a public park. Cross the
+two flag columns before any access or equity claim. `POS` says whether
+a site is permanently protected, 450 sites and 5,015 acres are, mostly
+under Article 97 of the Massachusetts Constitution, which requires a
+two-thirds vote of the legislature to convert conservation land.
+`PA` says whether the public can actually get in, 724 sites yes, 4 by
+appointment only, and the rest unknown or no.
 
 ```sql
-INSTALL spatial; LOAD spatial;
-SELECT * FROM read_parquet('boston-open-space.parquet') LIMIT 5;
+SELECT SITE_NAME, ACRES, DISTRICT
+FROM read_parquet('boston-open-space.parquet')
+WHERE POS = 'X' AND PA = 'X'
+ORDER BY ACRES DESC LIMIT 5;
 ```
+
+## Limitations
+
+A planning inventory, not a legal record. The city's own disclaimer
+limits it to general planning, only deeds research and surveys settle
+boundaries. It also is not a complete greenspace layer, street trees,
+most schoolyards, and private yards are absent. This is a fixed
+snapshot from July 2026 of a continuously edited layer, and it carries
+no stable public identifier, so joins to later versions go through
+`SITE_NAME` or space.
+
+## Provenance and License
+
+License, PDDL-1.0.
+Providers, City of Boston (producer, licensor), Portolan SDI (host).
+Original source, https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326 .
+Features, 1,012. Cloud-native asset, boston-open-space.parquet (GeoParquet 2.0).
+The upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
@@ -78,79 +78,98 @@
         },
         {
           "name": "SITE_NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Best-known or official site name. Multi-parcel sites carry Roman numeral suffixes, Stony Brook Reservation I and II."
         },
         {
           "name": "OWNERSHIP",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Fee owner where known. City of Boston, Commonwealth of Massachusetts, private owners, and agency abbreviations like BRA and BNAN."
         },
         {
           "name": "PROTECTION",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Slash-separated legal protection instruments. A97 is Article 97 of the Massachusetts Constitution, the strongest. Free text, match with LIKE."
         },
         {
           "name": "TYPECODE",
-          "type": "integer"
+          "type": "integer",
+          "description": "Numeric open space type 1 through 7. Disagrees with TypeLong on about 13 rows, treat TypeLong as closer to intent."
         },
         {
           "name": "DISTRICT",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Planning district per the city's open space plan, not the official neighborhood boundaries. Includes the non-spatial value Multi-District."
         },
         {
           "name": "ACRES",
-          "type": "double"
+          "type": "double",
+          "description": "Official area in acres of the open-space portion, the figure to use instead of computing geometry area."
         },
         {
           "name": "ADDRESS",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Street address if known, null for 589 rows."
         },
         {
           "name": "ZonAgg",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Aggregated zoning district, for example Open Space District."
         },
         {
           "name": "TypeLong",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Open space type as text, with minor spelling variants worth normalizing before grouping."
         },
         {
           "name": "OS_Own_Jur",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "The entity holding the open-space rights. BPRD, DCR, the Boston Conservation Commission, or None."
         },
         {
           "name": "OS_Mngmnt",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Managing entity only when it differs from OS_Own_Jur. Null means the steward manages it, not missing data."
         },
         {
           "name": "POS",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Protected open space flag. X permanently protected, N not."
         },
         {
           "name": "PA",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Public access flag. X accessible, A by appointment, N no or unknown access."
         },
         {
           "name": "ALT_NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Official, previous, or colloquial alternate names."
         },
         {
           "name": "AgncyJuris",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Agency of jurisdiction for government-owned unprotected sites. Sparsely populated by design."
         },
         {
           "name": "ShapeSTAre",
-          "type": "double"
+          "type": "double",
+          "description": "ArcGIS-computed area in square meters from the source State Plane geometry."
         },
         {
           "name": "ShapeSTLen",
-          "type": "double"
+          "type": "double",
+          "description": "ArcGIS-computed perimeter in meters."
         },
         {
           "name": "geom",
-          "type": "geometry"
+          "type": "geometry",
+          "description": "Site geometry, WGS84 longitude and latitude."
         },
         {
           "name": "bbox",
-          "type": "struct(xmin double, ymin double, xmax double, ymax double)"
+          "type": "struct(xmin double, ymin double, xmax double, ymax double)",
+          "description": "Per-feature bounding box struct, the GeoParquet covering."
         }
       ],
       "table:primary_geometry": "geom",

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/AGENTS.md
@@ -1,7 +1,79 @@
-# Agent guidance, Netherlands Provinces
+# Agent Guidance, Netherlands Provinces
 
-This collection holds Netherlands Provinces.
-Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("netherlands-provinces.parquet").
-For rendering use the visual PMTiles asset or the thumbnail.
-License is CC-BY-4.0. Attribute as Kadaster / PDOK.
-The original upstream source is https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg , tagged on the source-role asset.
+Dutch province polygons whose `identificatie` codes PV20 to PV31 join
+CBS StatLine, the same code system all Dutch government data uses at
+province level. The `code` column, bare 20 to 31, joins the
+municipality layer of the same upstream GeoPackage on
+ligt_in_provincie_code.
+
+Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('netherlands-provinces.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For rendering use the visual PMTiles asset with its MapLibre styles.
+
+## CRS, a Metric National Grid
+
+EPSG:28992, Amersfoort / RD New, the Dutch national grid in meters,
+valid only for the European Netherlands. `ST_Area(geom)` returns
+square meters directly, divide by 1e6 for square kilometres, and the
+results match CBS official figures to one decimal. Web maps need
+`ST_Transform(geom, 'EPSG:28992', 'EPSG:4326', always_xy := true)`,
+and without always_xy the axes come back flipped. Points must be
+transformed into RD before ST_Contains. The bbox covering column is
+also in RD meters, while the STAC extent in collection.json is WGS84.
+
+## Quirks
+
+- Fryslân, not Friesland. The naam column uses official spellings with
+  diacritics.
+- Noord-Brabant is a 9-part multipolygon with 22 holes, the Baarle
+  enclave complex on the Belgian border. Belgian exclaves are punched
+  out and 8 tiny Dutch counter-enclaves float inside them, so
+  one-province-one-polygon assumptions and small-area filters both
+  break.
+- Provinces include their water. Fryslân is the largest by total area
+  and third by land.
+- CBS OData v3 keys carry trailing spaces, PV20 with two spaces. Trim
+  before joining.
+- fid order is arbitrary, Flevoland is 1 and Groningen is 11. Key on
+  code or identificatie.
+
+## Tested Queries
+
+Areas that reproduce official statistics.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT naam, code, round(ST_Area(geom) / 1e6, 1) AS area_km2
+FROM read_parquet('netherlands-provinces.parquet')
+ORDER BY area_km2 DESC LIMIT 3;
+-- Fryslân 5753.3, Gelderland 5136.3, Noord-Brabant 5082.1.
+```
+
+Which province contains a point, in RD meters. Amsterdam.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT naam FROM read_parquet('netherlands-provinces.parquet')
+WHERE ST_Contains(geom, ST_Point(121687, 487484));
+-- Noord-Holland.
+```
+
+The Baarle enclave forensic, parts of Noord-Brabant.
+
+```sql
+INSTALL spatial; LOAD spatial;
+WITH parts AS (
+  SELECT unnest(ST_Dump(geom)) AS d
+  FROM read_parquet('netherlands-provinces.parquet')
+  WHERE naam = 'Noord-Brabant')
+SELECT count(*) AS parts, round(min(ST_Area(d.geom)) / 1e6, 4) AS smallest_km2
+FROM parts;
+-- 9 parts, the smallest 0.0029 km2. DuckDB has no ST_GeometryN, use unnest.
+```
+
+## Related Collections
+
+The upstream GeoPackage also carries the 342 municipalities
+(gemeentegebied) and the national outline (landgebied), joined on the
+code columns above. Within this catalog the other boundary Collections
+connect only spatially. Converted from PDOK's GeoPackage with DuckDB
+spatial into web-optimized GeoParquet 2.0, preserving the source CRS.
+The mirrored ISO 19115 record is the metadata asset beside the data.

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/README.md
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/README.md
@@ -2,15 +2,26 @@
 
 The 12 provinces of the Netherlands, administrative boundaries from the Dutch national spatial data infrastructure PDOK, derived from the Kadaster BRK Bestuurlijke Gebieden. Republished as cloud-native GeoParquet with a PMTiles visualization and categorical, labeled MapLibre styles.
 
-License, CC-BY-4.0. Attribution, Kadaster / PDOK.
-Providers, Kadaster (producer, licensor), PDOK (processor), Portolan SDI (host).
-Original source, https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg .
-Features, 12.
-Cloud-native asset, netherlands-provinces.parquet (GeoParquet).
+[Kadaster](https://www.kadaster.nl), the Dutch cadastral agency,
+derives the country's administrative division from the cadastral
+registration and publishes it through
+[PDOK](https://www.pdok.nl/introductie/-/article/bestuurlijke-gebieden),
+the national open geodata platform, in an edition established every
+January when municipal reorganizations take effect. This Collection
+carries the 12 provinces of the 2026 edition, valid from January 1,
+2026. PDOK names the layer as the base of public applications from
+[atlasleefomgeving.nl](https://www.atlasleefomgeving.nl) to the
+official bathing water site [zwemwater.nl](https://www.zwemwater.nl).
 
-## Open the data
+The geometry checks out against the national statistics office.
+Computing `ST_Area` per province reproduces the official CBS surface
+figures to one decimal, Utrecht 1,560.1 square kilometres against the
+published 1,560.05.
 
-The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column for fast web-client pruning. Read it with a recent GeoPandas built on pyarrow 24 or newer.
+Agents, [AGENTS.md](./AGENTS.md) has the CBS join recipe, the Baarle
+enclave surprise, and the metric CRS consequences.
+
+## Quick Start
 
 ```python
 import geopandas as gpd
@@ -19,9 +30,62 @@ gdf = gpd.read_parquet("netherlands-provinces.parquet")
 print(gdf.head())
 ```
 
-Or query it in place with a recent DuckDB spatial.
+The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column, so it needs a GeoPandas built on pyarrow 24 or newer. DuckDB spatial queries the same file in place, see [AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to this directory, and the same code works against the published URL.
 
-```sql
-INSTALL spatial; LOAD spatial;
-SELECT * FROM read_parquet('netherlands-provinces.parquet') LIMIT 5;
-```
+## Machine-Readable Metadata
+
+Beside the data sits `iso19115.xml`, the upstream ISO 19115 metadata
+record for BRK Bestuurlijke Gebieden, mirrored on July 31, 2026 from
+the [Nationaal Georegister](https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/208bc283-7c66-4ce7-8ad3-1cf3e8933fb5)
+and carried as a metadata-role asset. Catalogs that already maintain
+ISO metadata can ship it alongside the STAC this way instead of
+abandoning it.
+
+## Schema
+
+| Column | Type | Description |
+|---|---|---|
+| `identificatie` | varchar | Province identifier PV20 through PV31, PV plus the CBS province code. The join key to CBS StatLine regional tables. |
+| `naam` | varchar | Official province name. Fryslân carries its official Frisian spelling, a filter on Friesland returns nothing. |
+| `code` | varchar | Two-digit CBS province code as a string, 20 through 31. Joins to ligt_in_provincie_code in the source's municipality layer. |
+| `ligt_in_land_code` | varchar | Country code, the constant 6030 for Nederland. |
+| `ligt_in_land_naam` | varchar | Country name, the constant Nederland. |
+| `geom` | geometry('epsg:28992') | Province geometry, multipolygon, in the Dutch national grid EPSG:28992 in meters. |
+| `bbox` | struct(xmin double, ymin double, xmax double, ymax double) | Per-feature bounding box struct in RD New meters, the GeoParquet covering. |
+
+The table has 8 columns in all. The full list with types lives in `table:columns` on the `data` asset.
+
+## Join the National Statistics
+
+`identificatie` holds the CBS region codes PV20 through PV31, the same
+keys every provincial table on
+[CBS StatLine](https://opendata.cbs.nl) uses, which connects these 12
+polygons to Dutch official statistics on population, income, land use,
+and more. Trim the CBS side first, the classic OData API pads its keys
+with trailing spaces.
+
+## Water Is Inside the Boundaries
+
+The provinces sum to 41,543 square kilometres while the land surface
+of the Netherlands is about 33,500. Administrative boundaries divide
+the Wadden Sea, the IJsselmeer, and the delta waters among provinces,
+so Fryslân is the largest province by total area and roughly 42
+percent water. Rankings and densities computed from these polygons
+answer the water-inclusive question unless you subtract water first,
+CBS publishes the land-only figures.
+
+## Limitations
+
+One annual snapshot, valid for January 1, 2026 only, and boundary
+history needs the matching year's edition, PDOK keeps five. Derived
+from the cadastre but not a substitute for it, parcel-level legal
+questions belong to the BRK itself. The Caribbean Netherlands,
+Bonaire, Sint Eustatius, and Saba, belongs to no province and is not
+here.
+
+## Provenance and License
+
+License, CC-BY-4.0. Attribution, Kadaster / PDOK.
+Providers, Kadaster (producer, licensor), PDOK (processor), Portolan SDI (host).
+Original source, https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg .
+Features, 12. Cloud-native asset, netherlands-provinces.parquet (GeoParquet 2.0).

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
@@ -82,31 +82,38 @@
         },
         {
           "name": "identificatie",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Province identifier PV20 through PV31, PV plus the CBS province code. The join key to CBS StatLine regional tables."
         },
         {
           "name": "naam",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Official province name. Frysl\u00e2n carries its official Frisian spelling, a filter on Friesland returns nothing."
         },
         {
           "name": "code",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Two-digit CBS province code as a string, 20 through 31. Joins to ligt_in_provincie_code in the source's municipality layer."
         },
         {
           "name": "ligt_in_land_code",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Country code, the constant 6030 for Nederland."
         },
         {
           "name": "ligt_in_land_naam",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Country name, the constant Nederland."
         },
         {
           "name": "geom",
-          "type": "geometry('epsg:28992')"
+          "type": "geometry('epsg:28992')",
+          "description": "Province geometry, multipolygon, in the Dutch national grid EPSG:28992 in meters."
         },
         {
           "name": "bbox",
-          "type": "struct(xmin double, ymin double, xmax double, ymax double)"
+          "type": "struct(xmin double, ymin double, xmax double, ymax double)",
+          "description": "Per-feature bounding box struct in RD New meters, the GeoParquet covering."
         }
       ],
       "table:primary_geometry": "geom",
@@ -162,6 +169,17 @@
       ],
       "file:size": 188545,
       "file:checksum": "12203e5bed76be1af81a77828cebf137805a4168848e56289de7d197eb7341ebb2b0"
+    },
+    "metadata": {
+      "href": "./iso19115.xml",
+      "type": "application/vnd.iso.19139+xml",
+      "title": "ISO 19115 metadata record, BRK Bestuurlijke Gebieden (Nationaal Georegister)",
+      "roles": [
+        "metadata",
+        "iso-19115"
+      ],
+      "file:size": 40942,
+      "file:checksum": "122039561f53e91b85883209646f809d8ff6a3976eb6539528d8e4802c5689f75fe7"
     }
   },
   "links": [

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/iso19115.xml
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/iso19115.xml
@@ -1,0 +1,802 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/iso/19139/20060504/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://schemas.opengis.net/iso/19139/20060504/gmx/gmx.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>208bc283-7c66-4ce7-8ad3-1cf3e8933fb5</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="dut">Nederlands; Vlaams</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:characterSet xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_ScopeCode">dataset</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:contact xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <gmd:CI_ResponsibleParty>
+      <gmd:individualName>
+        <gco:CharacterString>Directie Operatie, Dienstverlening en Registratie, afdeling Data-, Proces- en Informatiemanagement</gco:CharacterString>
+      </gmd:individualName>
+      <gmd:organisationName>
+        <gco:CharacterString>Kadaster</gco:CharacterString>
+      </gmd:organisationName>
+      <gmd:positionName>
+        <gco:CharacterString>algemeen contactpunt metadata</gco:CharacterString>
+      </gmd:positionName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <gmd:CI_Telephone>
+              <gmd:voice gco:nilReason="missing">
+                <gco:CharacterString />
+              </gmd:voice>
+              <gmd:facsimile gco:nilReason="missing">
+                <gco:CharacterString />
+              </gmd:facsimile>
+            </gmd:CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <gmd:CI_Address>
+              <gmd:deliveryPoint>
+                <gco:CharacterString>Hofstraat 110</gco:CharacterString>
+              </gmd:deliveryPoint>
+              <gmd:city>
+                <gco:CharacterString>Apeldoorn</gco:CharacterString>
+              </gmd:city>
+              <gmd:administrativeArea>
+                <gco:CharacterString>Gelderland</gco:CharacterString>
+              </gmd:administrativeArea>
+              <gmd:postalCode>
+                <gco:CharacterString>7311 KZ</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country>
+                <gco:CharacterString>Nederland</gco:CharacterString>
+              </gmd:country>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>dpi-gi@kadaster.nl</gco:CharacterString>
+              </gmd:electronicMailAddress>
+            </gmd:CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://www.kadaster.nl</gmd:URL>
+              </gmd:linkage>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeListValue="pointOfContact" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_RoleCode">contactpunt</gmd:CI_RoleCode>
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:Date>2026-07-07</gco:Date>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>Nederlands metadata profiel op ISO 19115 voor geografie 2.1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/http://www.opengis.net/def/crs/EPSG/0/4258">http://www.opengis.net/def/crs/EPSG/0/4258</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Bestuurlijke Gebieden</gco:CharacterString>
+          </gmd:title>
+          <gmd:alternateTitle>
+            <gco:CharacterString>Rijks-, provincie- en gemeentegrenzen</gco:CharacterString>
+          </gmd:alternateTitle>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-01-01</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeListValue="revision" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode">revisie</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gmx:Anchor xlink:href="http://kadaster/29f0fa66-3928-4e95-ae30-5b1eab818ac1">29f0fa66-3928-4e95-ae30-5b1eab818ac1</gmx:Anchor>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>Overzicht van de bestuurlijke indeling van Nederland in gemeenten en provincies alsmede de landsgrens. Gegevens zijn afgeleid uit de Basisregistratie Kadaster (BRK).</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:purpose>
+        <gco:CharacterString>Ruimtelijke analyse en planning op basis van bestuurlijke eenheden</gco:CharacterString>
+      </gmd:purpose>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeListValue="onGoing" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_ProgressCode">continu geactualiseerd</gmd:MD_ProgressCode>
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:individualName>
+            <gco:CharacterString>Klantcontactcenter Kadaster</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gmx:Anchor xlink:href="https://www.kadaster.nl">Kadaster</gmx:Anchor>
+          </gmd:organisationName>
+          <gmd:positionName>
+            <gco:CharacterString>algemeen contactpunt</gco:CharacterString>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>(+31) 088-1832200</gco:CharacterString>
+                  </gmd:voice>
+                  <gmd:facsimile gco:nilReason="missing">
+                    <gco:CharacterString />
+                  </gmd:facsimile>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint>
+                    <gco:CharacterString>Postbus 9046</gco:CharacterString>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>Apeldoorn</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:administrativeArea>
+                    <gco:CharacterString>Gelderland</gco:CharacterString>
+                  </gmd:administrativeArea>
+                  <gmd:postalCode>
+                    <gco:CharacterString>7300 GH</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>Nederland</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>kcc@kadaster.nl</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.kadaster.nl</gmd:URL>
+                  </gmd:linkage>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeListValue="pointOfContact" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_RoleCode">contactpunt</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="annually">jaarlijks</gmd:MD_MaintenanceFrequencyCode>
+          </gmd:maintenanceAndUpdateFrequency>
+          <gmd:dateOfNextUpdate>
+            <gco:Date>2027-01-01</gco:Date>
+          </gmd:dateOfNextUpdate>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:graphicOverview>
+        <gmd:MD_BrowseGraphic>
+          <gmd:fileName>
+            <gco:CharacterString>https://github.com/kadaster/metagegevens-voorbeelden/raw/master/Bestuurlijke_Gebieden.jpg</gco:CharacterString>
+          </gmd:fileName>
+          <gmd:fileDescription>
+            <gco:CharacterString>thumbnail</gco:CharacterString>
+          </gmd:fileDescription>
+          <gmd:fileType>
+            <gco:CharacterString>jpg</gco:CharacterString>
+          </gmd:fileType>
+        </gmd:MD_BrowseGraphic>
+      </gmd:graphicOverview>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>gemeentegrens</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>basisset NOVEX</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>provinciegrens</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>landsgrens</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>grenzen</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>administratieve grenzen</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>administratieve eenheden</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>rijksgrens</gco:CharacterString>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/nl/inspire-theme/au">Administratieve eenheden</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/inspire_themes">GEMET - INSPIRE themes, version 1.0</gmx:Anchor>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publicatie</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.nationaalgeoregister.nl:443/geonetwork/srv/eng/thesaurus.download?ref=external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national">Nationaal</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialScope">Ruimtelijke dekking</gmx:Anchor>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2019-05-22</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publicatie</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.nationaalgeoregister.nl:443/geonetwork/srv/eng/thesaurus.download?ref=external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope">geonetwork.thesaurus.external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg_impl/2023/138/oj">HVD</gmx:Anchor>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="http://data.europa.eu/bna/c_ac64a52d">Geospatiale data</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gmx:Anchor xlink:href="http://publications.europa.eu/resource/dataset/high-value-dataset-category">High-value dataset categories</gmx:Anchor>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2023-09-27</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeListValue="publication" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode">publicatie</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>Geen gebruiksbeperkingen</gco:CharacterString>
+          </gmd:useLimitation>
+        </gmd:MD_Constraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode">anders</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://creativecommons.org/licenses/by/4.0/deed.nl">Naamsvermelding verplicht, Kadaster, Bestuurlijke Gebieden</gmx:Anchor>
+          </gmd:otherConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply">Er zijn geen condities voor toegang en gebruik</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode">anders</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Geen beperkingen voor publieke toegang</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_SecurityConstraints>
+          <gmd:classification>
+            <gmd:MD_ClassificationCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_ClassificationCode" codeListValue="unclassified">vrij toegankelijk</gmd:MD_ClassificationCode>
+          </gmd:classification>
+        </gmd:MD_SecurityConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeListValue="vector" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode">vector</gmd:MD_SpatialRepresentationTypeCode>
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>1000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="dut">Nederlands; Vlaams</gmd:LanguageCode>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode">utf8</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>society</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:description>
+            <gco:CharacterString>Nederland</gco:CharacterString>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>3.30</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>7.24</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>50.73</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>53.60</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimePeriod gml:id="d99417e352a1053982">
+                  <gml:beginPosition>2022-01-01</gml:beginPosition>
+                  <gml:endPosition indeterminatePosition="now" />
+                </gml:TimePeriod>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:supplementalInformation>
+        <gco:CharacterString>https://www.kadaster.nl</gco:CharacterString>
+      </gmd:supplementalInformation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat>
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>GML</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>3.2.1</gco:CharacterString>
+          </gmd:version>
+          <gmd:specification gco:nilReason="missing">
+            <gco:CharacterString />
+          </gmd:specification>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:distributionFormat>
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>Geopackage</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>1.2</gco:CharacterString>
+          </gmd:version>
+          <gmd:specification gco:nilReason="missing">
+            <gco:CharacterString />
+          </gmd:specification>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName>
+                <gco:CharacterString>klantcontactcenter</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:organisationName>
+                <gco:CharacterString>Kadaster</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:positionName>
+                <gco:CharacterString>algemeen contactpunt</gco:CharacterString>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <gmd:CI_Telephone>
+                      <gmd:voice>
+                        <gco:CharacterString>(+31) 088-1832200</gco:CharacterString>
+                      </gmd:voice>
+                      <gmd:facsimile gco:nilReason="missing">
+                        <gco:CharacterString />
+                      </gmd:facsimile>
+                    </gmd:CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:deliveryPoint>
+                        <gco:CharacterString>Postbus 9046</gco:CharacterString>
+                      </gmd:deliveryPoint>
+                      <gmd:city>
+                        <gco:CharacterString>Apeldoorn</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:administrativeArea>
+                        <gco:CharacterString>Gelderland</gco:CharacterString>
+                      </gmd:administrativeArea>
+                      <gmd:postalCode>
+                        <gco:CharacterString>7300 GH</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>NL</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>kcc@kadaster.nl</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>https://www.kadaster.nl</gmd:URL>
+                      </gmd:linkage>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">contactpunt</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:java="java:org.fao.geonet.util.XslUtil">
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/wfs/v1_0?request=GetCapabilities&amp;service=WFS</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gmx:Anchor xlink:href="http://www.opengis.net/def/serviceType/ogc/wfs">OGC:WFS</gmx:Anchor>
+              </gmd:protocol>
+              <gmd:applicationProfile>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</gmx:Anchor>
+              </gmd:applicationProfile>
+              <gmd:name>
+                <gco:CharacterString>Bestuurlijke gebieden (WFS)</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</gmx:Anchor>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:java="java:org.fao.geonet.util.XslUtil">
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/index.xml</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gmx:Anchor xlink:href="https://tools.ietf.org/html/rfc4287">INSPIRE Atom</gmx:Anchor>
+              </gmd:protocol>
+              <gmd:applicationProfile>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</gmx:Anchor>
+              </gmd:applicationProfile>
+              <gmd:name>
+                <gco:CharacterString>Bestuurlijke Gebieden download</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</gmx:Anchor>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:java="java:org.fao.geonet.util.XslUtil">
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/wms/v1_0?request=GetCapabilities&amp;service=WMS</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gmx:Anchor xlink:href="http://www.opengis.net/def/serviceType/ogc/wms">OGC:WMS</gmx:Anchor>
+              </gmd:protocol>
+              <gmd:applicationProfile>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</gmx:Anchor>
+              </gmd:applicationProfile>
+              <gmd:name>
+                <gco:CharacterString>Bestuurlijke Gebieden WMS</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</gmx:Anchor>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://api.pdok.nl/kadaster/brk-bestuurlijke-gebieden/ogc/v1</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gmx:Anchor xlink:href="https://www.w3.org/TR/vocab-dcat-2/#Property:resource_landing_page">landingpage</gmx:Anchor>
+              </gmd:protocol>
+              <gmd:applicationProfile>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">other</gmx:Anchor>
+              </gmd:applicationProfile>
+              <gmd:name>
+                <gco:CharacterString>Bestuurlijke gebieden OGC API (Vector) Tiles</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</gmx:Anchor>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://api.pdok.nl/kadaster/brk-bestuurlijke-gebieden/ogc/v1</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gmx:Anchor xlink:href="https://www.w3.org/TR/vocab-dcat-2/#Property:resource_landing_page">landingpage</gmx:Anchor>
+              </gmd:protocol>
+              <gmd:applicationProfile>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">other</gmx:Anchor>
+              </gmd:applicationProfile>
+              <gmd:name>
+                <gco:CharacterString>Bestuurlijke gebieden OGC API Styles</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</gmx:Anchor>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://api.pdok.nl/kadaster/brk-bestuurlijke-gebieden/ogc/v1</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gmx:Anchor xlink:href="http://www.opengis.net/def/interface/ogcapi-features">OGC:API features</gmx:Anchor>
+              </gmd:protocol>
+              <gmd:applicationProfile>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">other</gmx:Anchor>
+              </gmd:applicationProfile>
+              <gmd:name>
+                <gco:CharacterString>Bestuurlijke gebieden OGC API Features</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint">accessPoint</gmx:Anchor>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_ScopeCode">dataset</gmd:MD_ScopeCode>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:report>
+        <gmd:DQ_DomainConsistency>
+          <gmd:result>
+            <gmd:DQ_ConformanceResult>
+              <gmd:specification>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>VERORDENING (EU) Nr. 1089/2010 VAN DE COMMISSIE van 23 november 2010 ter uitvoering van Richtlijn 2007/2/EG van het Europees Parlement en de Raad betreffende de interoperabiliteit van verzamelingen ruimtelijke gegevens en van diensten met betrekking tot ruimtelijke gegevens</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:alternateTitle>
+                    <gco:CharacterString>INSPIRE</gco:CharacterString>
+                  </gmd:alternateTitle>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2010-12-08</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeListValue="publication" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode">publicatie</gmd:CI_DateTypeCode>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:specification>
+              <gmd:explanation>
+                <gco:CharacterString>De gehanteerde domeinen zijn conform Nederlands model. De data is conform de INSPIRE dataspecificaties, zijnde de as-is versie voor zowel de Administratieve Eenheden als Statistische Eenheden.</gco:CharacterString>
+              </gmd:explanation>
+              <gmd:pass>
+                <gco:Boolean>true</gco:Boolean>
+              </gmd:pass>
+            </gmd:DQ_ConformanceResult>
+          </gmd:result>
+        </gmd:DQ_DomainConsistency>
+      </gmd:report>
+      <gmd:report>
+        <gmd:DQ_DomainConsistency>
+          <gmd:result>
+            <gmd:DQ_ConformanceResult>
+              <gmd:specification>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>INSPIRE Data Specification on Administrative units - Guidelines</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2010-05-03</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publicatie</gmd:CI_DateTypeCode>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:specification>
+              <gmd:explanation>
+                <gco:CharacterString>Structuur en inhoud wijken af van de INSPIRE-specificatie. De gehanteerde domeinen zijn conform Nederlands model. De data is conform de INSPIRE dataspecificaties,zijnde de as-is versie voor zowel de Administratieve Eenheden als Statistische Eenheden.</gco:CharacterString>
+              </gmd:explanation>
+              <gmd:pass>
+                <gco:Boolean>false</gco:Boolean>
+              </gmd:pass>
+            </gmd:DQ_ConformanceResult>
+          </gmd:result>
+        </gmd:DQ_DomainConsistency>
+      </gmd:report>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement>
+            <gco:CharacterString>Gegevens zijn afgeleid uit de Basis Registratie Kadaster (BRK)</gco:CharacterString>
+          </gmd:statement>
+          <gmd:processStep>
+            <gmd:LI_ProcessStep>
+              <gmd:description />
+              <gmd:processor>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>Kadaster</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:address>
+                        <gmd:CI_Address>
+                          <gmd:electronicMailAddress gco:nilReason="missing">
+                            <gco:CharacterString />
+                          </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                      </gmd:address>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeListValue="processor" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_RoleCode">bewerker</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:processor>
+            </gmd:LI_ProcessStep>
+          </gmd:processStep>
+          <gmd:source>
+            <gmd:LI_Source>
+              <gmd:description>
+                <gco:CharacterString>Basisregistratie Kadaster</gco:CharacterString>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmd:LI_ProcessStep>
+                  <gmd:description />
+                  <gmd:processor>
+                    <gmd:CI_ResponsibleParty>
+                      <gmd:organisationName>
+                        <gco:CharacterString>Kadaster</gco:CharacterString>
+                      </gmd:organisationName>
+                      <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                          <gmd:address>
+                            <gmd:CI_Address>
+                              <gmd:electronicMailAddress gco:nilReason="missing">
+                                <gco:CharacterString />
+                              </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                          </gmd:address>
+                        </gmd:CI_Contact>
+                      </gmd:contactInfo>
+                      <gmd:role>
+                        <gmd:CI_RoleCode codeListValue="custodian" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#CI_RoleCode">beheerder</gmd:CI_RoleCode>
+                      </gmd:role>
+                    </gmd:CI_ResponsibleParty>
+                  </gmd:processor>
+                </gmd:LI_ProcessStep>
+              </gmd:sourceStep>
+            </gmd:LI_Source>
+          </gmd:source>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</gmd:MD_Metadata>
+

--- a/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
@@ -1,7 +1,84 @@
-# Agent guidance, United States Counties (2023, 1:500k)
+# Agent Guidance, United States Counties (2023, 1:500k)
 
-This collection holds United States Counties (2023, 1:500k).
-Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("us-counties.parquet").
-For rendering use the visual PMTiles asset or the thumbnail.
-License is CC0-1.0.
-The original upstream source is https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip , tagged on the source-role asset.
+County polygons whose value is the `GEOID` column, the five-digit FIPS
+key to US county statistics. Join ACS and decennial downloads on
+`GEOIDFQ` instead, it matches their GEO_ID column verbatim. `COUNTYNS`
+is the identifier that survives FIPS changes across years.
+
+Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('us-counties.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For rendering use the visual PMTiles asset with its MapLibre styles.
+
+## Quirks
+
+- GEOID is a zero-padded string. Cast it to integer and Alabama's 01001
+  becomes 1001, silently unjoining every state below FIPS 10. CSV
+  round-trips are the usual culprit.
+- NAME is wildly ambiguous, 31 Washingtons, and independent cities
+  collide with the counties that share their name. Baltimore city is
+  24510, Baltimore County is 24005. The lowercase word city in NAMELSAD
+  is what marks an independent city.
+- Connecticut has nine planning regions, GEOIDs 09110 to 09190, LSAD
+  PL, since the 2022 change. Datasets keyed to the old 09001 to 09015
+  match nothing here.
+- Aleutians West Census Area crosses the antimeridian, so its stored
+  bbox spans nearly all longitudes and it passes almost every naive
+  bbox filter. Handle it before bbox-windowing the world.
+- Geometry is clipped to shoreline but AWATER is not, so San
+  Francisco's polygon covers 122 km2 while ALAND plus AWATER is 601
+  km2. Offshore points in legal county water fall in no polygon.
+
+## Areas, the Wrong Way and the Right Way
+
+Coordinates are NAD83 degrees, EPSG:4269, so `ST_Area` returns square
+degrees and DuckDB's `ST_Area_Spheroid` returns NaN or wrong values on
+several of these multipolygons. Trust `ALAND` and `AWATER`, or
+transform to an equal-area CRS.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT NAMELSAD,
+       round(ST_Area(ST_Transform(geom, 'EPSG:4269', 'EPSG:5070', always_xy := true)) / 1e6, 1) AS km2,
+       round(ALAND / 1e6, 1) AS aland_km2
+FROM read_parquet('us-counties.parquet') WHERE GEOID = '08031';
+-- Denver County, 400.7 km2 from geometry, 396.5 km2 of official land.
+```
+
+For web mapping, treating the NAD83 coordinates as WGS84 shifts
+nothing visible at this generalization level.
+
+## Tested Queries
+
+Counties per state.
+
+```sql
+SELECT STUSPS, count(*) AS n
+FROM read_parquet('us-counties.parquet')
+GROUP BY STUSPS ORDER BY n DESC LIMIT 5;
+-- Texas 254, Georgia 159, Virginia 133, Kentucky 120, Missouri 115.
+```
+
+Which county contains a point, longitude first.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT GEOID, NAMELSAD, STUSPS
+FROM read_parquet('us-counties.parquet')
+WHERE ST_Contains(geom, ST_Point(-104.9903, 39.7392));
+-- 08031, Denver County, CO.
+```
+
+Cheap spatial windows from the bbox covering column.
+
+```sql
+SELECT count(*) FROM read_parquet('us-counties.parquet')
+WHERE bbox.xmin > -109.06 AND bbox.xmax < -102.04
+  AND bbox.ymin > 36.99 AND bbox.ymax < 41.01;
+-- 62 of Colorado's 64 counties, two generalized bboxes nick the state line.
+```
+
+## Related Collections
+
+No attribute join inside this catalog, the FIPS ecosystem lives
+outside it. Spatial joins against `boundaries/boston-open-space` or the
+Natural Earth layers work at matching scales. Converted from the
+upstream zipped Shapefile with DuckDB spatial into web-optimized
+GeoParquet 2.0.

--- a/examples/catalog/portolan-reference/boundaries/us-counties/README.md
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/README.md
@@ -2,15 +2,24 @@
 
 County and equivalent boundaries for the United States, the 2023 cartographic boundary file at 1:500,000 from the US Census Bureau, generalized for small-scale mapping. Republished as cloud-native GeoParquet alongside the original zipped Shapefile.
 
-License, CC0-1.0.
-Providers, U.S. Census Bureau (producer, licensor), Portolan SDI (host).
-Original source, https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip .
-Features, 3235.
-Cloud-native asset, us-counties.parquet (GeoParquet).
+Every county and county equivalent in the United States and its
+territories, 3,235 polygons as of January 1, 2023, from the
+[US Census Bureau's cartographic boundary files](https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html).
+Cartographic boundary files are generalized from the authoritative
+[TIGER/Line](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html)
+database for thematic mapping, simplified to 1:500,000 and clipped to
+the shoreline, so coastal counties look like the coastline rather than
+extending into their legal water area. A new vintage ships every year.
 
-## Open the data
+The `GEOID` column is the five-digit county FIPS code that keys county
+statistics across the US government, Census ACS and decennial tables,
+BLS employment, CDC health data, USDA agriculture. That join is what
+this Collection is for.
 
-The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column for fast web-client pruning. Read it with a recent GeoPandas built on pyarrow 24 or newer.
+Agents, [AGENTS.md](./AGENTS.md) carries the FIPS join hazards, the
+area-calculation trap, and tested queries.
+
+## Quick Start
 
 ```python
 import geopandas as gpd
@@ -19,9 +28,73 @@ gdf = gpd.read_parquet("us-counties.parquet")
 print(gdf.head())
 ```
 
-Or query it in place with a recent DuckDB spatial.
+The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column, so it needs a GeoPandas built on pyarrow 24 or newer. DuckDB spatial queries the same file in place, see [AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to this directory, and the same code works against the published URL.
 
-```sql
-INSTALL spatial; LOAD spatial;
-SELECT * FROM read_parquet('us-counties.parquet') LIMIT 5;
+## Not Every County Is a County
+
+The file holds 3,144 county equivalents in the 50 states and DC plus 91
+in the territories, and the `LSAD` column tells them apart, 2,999
+counties, 78 Puerto Rico municipios, 64 Louisiana parishes, 40
+independent cities, Alaska's boroughs and census areas, and more.
+Connecticut is the one to know about. In June 2022 the Census Bureau
+[replaced its eight legacy counties](https://www.federalregister.gov/documents/2022/06/06/2022-12063/change-to-county-equivalents-in-the-state-of-connecticut)
+with nine planning regions, so this file carries GEOIDs 09110 through
+09190 and any dataset still keyed to 09001 through 09015 will not join.
+
+## Schema
+
+| Column | Type | Description |
+|---|---|---|
+| `STATEFP` | varchar | Two-digit state or territory FIPS code as a zero-padded string. |
+| `COUNTYFP` | varchar | Three-digit county FIPS code, unique within its state. |
+| `COUNTYNS` | varchar | Eight-digit ANSI (GNIS) code, the permanent identifier that survives FIPS reassignment. |
+| `GEOIDFQ` | varchar | Fully qualified GEOID, 0500000US plus GEOID. Matches the GEO_ID column in data.census.gov downloads directly. Called AFFGEOID before the 2023 vintage. |
+| `GEOID` | varchar | Five-digit STATEFP plus COUNTYFP concatenation, the standard join key for US county statistics. Keep it a string, integer casts strip the leading zero. |
+| `NAME` | varchar | Base name only, for example Denver. 31 rows are named Washington, so never key on it. |
+| `NAMELSAD` | varchar | Name with its legal or statistical description, for example St. Louis city. The display name. |
+| `STUSPS` | varchar | Two-letter USPS state or territory abbreviation. |
+| `STATE_NAME` | varchar | Full state or territory name. |
+| `LSAD` | varchar | Legal or statistical area description code. Twelve kinds of county equivalent appear in this file. |
+| `ALAND` | bigint | Land area in square meters, computed from the full-resolution legal boundary, not from this generalized geometry. |
+| `AWATER` | bigint | Water area in square meters, including territorial water that lies outside the clipped shoreline geometry. |
+| `geom` | geometry('epsg:4269') | County geometry clipped to the shoreline, NAD83 longitude and latitude. |
+| `bbox` | struct(xmin double, ymin double, xmax double, ymax double) | Per-feature bounding box struct, the GeoParquet covering. |
+
+The table has 15 columns in all. The full list with types lives in `table:columns` on the `data` asset.
+
+## Join Census Data
+
+`GEOIDFQ` equals the GEO_ID column of every table downloaded from
+[data.census.gov](https://data.census.gov), so American Community
+Survey data joins with no string surgery. The pattern, with the ACS
+table read from a downloaded CSV.
+
 ```
+SELECT c.NAMELSAD, acs.estimate
+FROM 'us-counties.parquet' c
+JOIN 'acs_table.csv' acs ON acs.GEO_ID = c.GEOIDFQ
+```
+
+## Suggested Uses
+
+County choropleths of any FIPS-keyed statistic, the same role the
+Census files play behind the D3 ecosystem's
+[us-atlas](https://github.com/topojson/us-atlas), state-level rollups
+via `STATEFP`, and point-in-county lookups at city scale and coarser.
+
+## Limitations
+
+The Census Bureau's own guidance rules out geographic analysis
+including area or perimeter calculation, geocoding, and legal boundary
+determination. Use `ALAND` and `AWATER` for areas, they come from the
+full-resolution geography. At neighborhood zoom the generalized lines
+visibly cut corners, and small offshore islands may be missing
+entirely. Boundaries are the January 1, 2023 vintage, so data keyed to
+other years can mismatch, Connecticut above all.
+
+## Provenance and License
+
+License, CC0-1.0.
+Providers, U.S. Census Bureau (producer, licensor), Portolan SDI (host).
+Original source, https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip .
+Features, 3,235. Cloud-native asset, us-counties.parquet (GeoParquet 2.0).

--- a/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
@@ -74,59 +74,73 @@
         },
         {
           "name": "STATEFP",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Two-digit state or territory FIPS code as a zero-padded string."
         },
         {
           "name": "COUNTYFP",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Three-digit county FIPS code, unique within its state."
         },
         {
           "name": "COUNTYNS",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Eight-digit ANSI (GNIS) code, the permanent identifier that survives FIPS reassignment."
         },
         {
           "name": "GEOIDFQ",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Fully qualified GEOID, 0500000US plus GEOID. Matches the GEO_ID column in data.census.gov downloads directly. Called AFFGEOID before the 2023 vintage."
         },
         {
           "name": "GEOID",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Five-digit STATEFP plus COUNTYFP concatenation, the standard join key for US county statistics. Keep it a string, integer casts strip the leading zero."
         },
         {
           "name": "NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Base name only, for example Denver. 31 rows are named Washington, so never key on it."
         },
         {
           "name": "NAMELSAD",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Name with its legal or statistical description, for example St. Louis city. The display name."
         },
         {
           "name": "STUSPS",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Two-letter USPS state or territory abbreviation."
         },
         {
           "name": "STATE_NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Full state or territory name."
         },
         {
           "name": "LSAD",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Legal or statistical area description code. Twelve kinds of county equivalent appear in this file."
         },
         {
           "name": "ALAND",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "Land area in square meters, computed from the full-resolution legal boundary, not from this generalized geometry."
         },
         {
           "name": "AWATER",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "Water area in square meters, including territorial water that lies outside the clipped shoreline geometry."
         },
         {
           "name": "geom",
-          "type": "geometry('epsg:4269')"
+          "type": "geometry('epsg:4269')",
+          "description": "County geometry clipped to the shoreline, NAD83 longitude and latitude."
         },
         {
           "name": "bbox",
-          "type": "struct(xmin double, ymin double, xmax double, ymax double)"
+          "type": "struct(xmin double, ymin double, xmax double, ymax double)",
+          "description": "Per-feature bounding box struct, the GeoParquet covering."
         }
       ],
       "table:primary_geometry": "geom",

--- a/examples/catalog/portolan-reference/mirror/AGENTS.md
+++ b/examples/catalog/portolan-reference/mirror/AGENTS.md
@@ -1,4 +1,5 @@
-# Agent guidance, Mirrored Collections
+# Agent Guidance, Mirrored Collections
 
-This catalog groups 1 Collections under Mirrored Collections.
-Follow the child links to each Collection.
+This catalog groups 1 Collections. Each carries its own AGENTS.md with join keys, quirks, and tested queries, so follow the per-collection guides below.
+
+- San Francisco Addresses (EAS), 5,000 points, guide at ./san-francisco-addresses/AGENTS.md

--- a/examples/catalog/portolan-reference/mirror/README.md
+++ b/examples/catalog/portolan-reference/mirror/README.md
@@ -2,7 +2,14 @@
 
 Cloud-native mirror Collections of data maintained elsewhere.
 
-Collections, 1.
+## Collections
+
+| Collection | Contents | Description |
+|---|---|---|
+| [San Francisco Addresses (EAS)](./san-francisco-addresses/README.md) | 5,000 points | A fixed 5,000-record extract of San Francisco's 388,550-record master address database, kept small on purpose for spec demonstration. |
+
+## Where the Data Comes From
+
 Licenses, PDDL-1.0.
 Provenance, 1 mirror Collection.
 

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
@@ -1,7 +1,80 @@
-# Agent guidance, San Francisco Addresses (EAS)
+# Agent Guidance, San Francisco Addresses (EAS)
 
-This collection holds San Francisco Addresses (EAS).
-Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("san-francisco-addresses.parquet").
-For rendering use the visual PMTiles asset or the thumbnail.
-License is PDDL-1.0.
-The original upstream source is https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id , a live endpoint referenced by URL only.
+A fixed 5,000-row extract of a 388,550-row live address layer. Two
+rules prevent most wrong answers. Never extrapolate counts or
+densities from this sample to San Francisco. Never count rows when
+you mean addresses, one row is a base address, a unit, and a parcel
+link, so `count(*)` is 5,000 while distinct buildings are 4,488.
+
+Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('san-francisco-addresses.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For rendering use the visual PMTiles asset with its MapLibre styles.
+
+## Quirks
+
+- 327 Fulton St appears 18 times, identical address, 18 condo parcel
+  links. Count buildings with count(DISTINCT eas_baseid) and
+  addresses with count(DISTINCT eas_subid).
+- Units carry their building's single point, every eas_baseid has
+  exactly one distinct geometry. Deduplicate by base before density
+  maps or clustering.
+- parcel_number is null on 1,596 rows, mostly records sourced from
+  the State of CA, so a parcel join silently drops a third of the
+  extract.
+- data_updated_at holds the epoch sentinel 1970-01-01 on 2,378 rows,
+  meaning never updated, not 1970. Filter before temporal analysis.
+- Nearly every column is text, including latitude, longitude,
+  supervisor, and zip_code. Cast before arithmetic, and read
+  coordinates from geom instead.
+- numbertext spells out the supervisor district, not the address
+  number, and supname holds the 2026 incumbents, which dates the
+  snapshot.
+
+## CRS
+
+EPSG:4326 degrees, so ST_Distance returns degrees. Use
+ST_Distance_Sphere for meters, or transform to EPSG:26910 for planar
+work.
+
+## Tested Queries
+
+The grain, records against buildings against units.
+
+```sql
+SELECT count(*) AS record_count,
+       count(DISTINCT eas_baseid) AS buildings,
+       count(*) FILTER (unit_number IS NOT NULL) AS unit_records
+FROM read_parquet('san-francisco-addresses.parquet');
+-- 5000, 4488, 2060.
+```
+
+Addresses within 250 meters of a point, metric distance done right.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT address,
+       round(ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237))) AS meters
+FROM read_parquet('san-francisco-addresses.parquet')
+WHERE ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237)) < 250
+ORDER BY meters LIMIT 5;
+-- 512 Van Ness Ave #415 at 104 meters leads.
+```
+
+Buildings with the most sampled units.
+
+```sql
+SELECT any_value(address_number) AS num,
+       any_value(street_full_street_name) AS street,
+       count(DISTINCT unit_number) AS units
+FROM read_parquet('san-francisco-addresses.parquet')
+WHERE unit_number IS NOT NULL
+GROUP BY eas_baseid ORDER BY units DESC LIMIT 3;
+-- 1000 Pine St with 17 sampled units, 601 Van Ness Ave with 11.
+```
+
+## Related Collections
+
+Nothing joins inside this catalog, the EAS keys point outward.
+parcel_number joins DataSF's Parcels layer on blklot, cnn joins the
+street centerlines, nhood joins Analysis Neighborhoods by name. The
+upstream is a live Socrata endpoint, referenced by URL only. This
+extract was converted to GeoParquet 2.0 with DuckDB spatial and dates
+itself, every row carries data_as_of July 24, 2026.

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/README.md
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/README.md
@@ -2,16 +2,29 @@
 
 Point addresses from the City and County of San Francisco Enterprise Addressing System, a 5,000-feature extract of the official DataSF open data layer, converted to cloud-native GeoParquet with a PMTiles visualization. The source asset points at the full live DataSF layer.
 
-License, PDDL-1.0.
-Providers, City and County of San Francisco (producer, licensor), DataSF (processor), Portolan SDI (host).
-Original source, https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id .
-Features, 5000.
-Cloud-native asset, san-francisco-addresses.parquet (GeoParquet).
-Note, the upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.
+Five thousand records from the
+[Enterprise Addressing System](https://data.sfgov.org/Geographic-Locations-and-Boundaries/Addresses-with-Units-Enterprise-Addressing-System/ramy-di5m),
+San Francisco's master address database. Read this first, the full
+layer holds 388,550 records and refreshes nightly, and this Collection
+is deliberately a fixed 1.3 percent extract, the first 5,000 records
+in the portal's internal order from the July 24, 2026 snapshot. It
+exists to demonstrate the Portolan mirror pattern against a live
+upstream at a size that keeps this reference catalog small. Query it
+to learn the data's shape, then take real questions to the full layer.
 
-## Open the data
+The EAS is the city's operational address registry, aggregated from
+the Department of Building Inspection, Planning, the Assessor's
+Office, and the Department of Technology, and only DBI-approved
+addresses enter it. Its rows have a grain worth understanding before
+counting anything. One row is a base address, a unit, and a parcel
+link, so a building appears once per unit and once per linked condo
+parcel. The extract holds 4,488 distinct buildings under its 5,000
+rows.
 
-The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column for fast web-client pruning. Read it with a recent GeoPandas built on pyarrow 24 or newer.
+Agents, [AGENTS.md](./AGENTS.md) carries the row-grain rules and the
+sentinel-value traps.
+
+## Quick Start
 
 ```python
 import geopandas as gpd
@@ -20,9 +33,73 @@ gdf = gpd.read_parquet("san-francisco-addresses.parquet")
 print(gdf.head())
 ```
 
-Or query it in place with a recent DuckDB spatial.
+The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column, so it needs a GeoPandas built on pyarrow 24 or newer. DuckDB spatial queries the same file in place, see [AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to this directory, and the same code works against the published URL.
 
-```sql
-INSTALL spatial; LOAD spatial;
-SELECT * FROM read_parquet('san-francisco-addresses.parquet') LIMIT 5;
+## Getting the Real Thing
+
+The full live layer is one request away, the Socrata API serves it as
+GeoJSON, CSV, or JSON pages.
+
+```bash
+curl 'https://data.sfgov.org/resource/ramy-di5m.json?$select=count(*)'
+# 388550 as of July 2026
 ```
+
+## Schema
+
+| Column | Type | Description |
+|---|---|---|
+| `street_full_street_name` | varchar | Street name and type together. |
+| `zip_code` | varchar | Five-digit ZIP code as a string. |
+| `latitude` | varchar | Latitude as text. Prefer the geometry column. |
+| `address_number_suffix` | varchar | Street number suffix such as A, null for nearly all rows. |
+| `complete_landmark_name` | varchar | Landmark name for the few rows that carry one, Millennium Tower. |
+| `eas_fullid` | varchar | Unique row identifier, base id, sub id, and parcel link id joined with dashes. The only column unique per row. |
+| `direct_source` | varchar | Where the record entered the EAS, SF DBI, State of CA, or The Presidio Trust. |
+| `cnn` | varchar | Centerline Network Number, the street-segment key of the city basemap, joins to the DataSF street centerlines. |
+| `data_loaded_at` | timestamp with time zone | When the portal loaded the record. |
+| `longitude` | varchar | Longitude as text. Prefer the geometry column. |
+| `street_name` | varchar | Parsed street name. |
+| `eas_baseid` | varchar | Identifier of the base address, the building. Units share it, so count distinct eas_baseid for buildings. |
+| `nhood` | varchar | DataSF analysis neighborhood name, joins to the Analysis Neighborhoods dataset by name. |
+| `block` | varchar | Assessor block number as a string. |
+| `street_type` | varchar | Parsed street type, ST or AVE. Null for streets like BROADWAY that have no type. |
+| `eas_subid` | varchar | Identifier of the sub-address, a unit or apartment, within its base. |
+| `lot` | varchar | Assessor lot number as a string. |
+| `address` | varchar | Full address string, with the unit as a hash suffix when present. |
+| `unit_number` | varchar | Unit designator, null on base-address rows. |
+| `supervisor` | varchar | Supervisor district number as a string. |
+| `data_updated_at` | timestamp with time zone | Record update timestamp, with a 1970 epoch sentinel on never-updated rows. |
+| `address_number` | varchar | Street number. |
+| `parcel_number` | varchar | Assessor parcel number, block plus lot. Null on 32 percent of rows, a parcel join drops them silently. |
+| `data_as_of` | timestamp with time zone | Snapshot timestamp of the upstream export, July 24, 2026 for every row here. |
+| `geom` | geometry | Address point, WGS84 longitude and latitude. Units stack on their building's single point. |
+| `bbox` | struct(xmin double, ymin double, xmax double, ymax double) | Per-feature bounding box struct, the GeoParquet covering. |
+
+The table has 32 columns in all. The full list with types lives in `table:columns` on the `data` asset.
+
+## Suggested Uses
+
+Demonstrating and testing address-data patterns, base-versus-unit
+modeling, parcel joins on `parcel_number` to DataSF's parcels layer,
+neighborhood rollups on `nhood`, at a size where every query is
+instant. The upstream EAS itself feeds DBI permitting and the
+Planning Department's Property Information Map.
+
+## Limitations
+
+Wrong for any question about San Francisco itself. Geocoding against
+it misses about 98.7 percent of the city's addresses, per-area counts
+reflect sample order rather than density, and the snapshot ages while
+upstream changes nightly. Points sit at building entrances, not
+parcel centroids, and a third of rows carry no parcel link at all.
+Presence of a unit record says nothing about occupancy or mail
+deliverability.
+
+## Provenance and License
+
+License, PDDL-1.0.
+Providers, City and County of San Francisco (producer, licensor), DataSF (processor), Portolan SDI (host).
+Original source, https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id .
+Features, 5,000. Cloud-native asset, san-francisco-addresses.parquet (GeoParquet 2.0).
+The upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
@@ -81,19 +81,23 @@
         },
         {
           "name": "street_full_street_name",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Street name and type together."
         },
         {
           "name": "zip_code",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Five-digit ZIP code as a string."
         },
         {
           "name": "latitude",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Latitude as text. Prefer the geometry column."
         },
         {
           "name": "address_number_suffix",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Street number suffix such as A, null for nearly all rows."
         },
         {
           "name": "supdistpad",
@@ -101,31 +105,38 @@
         },
         {
           "name": "complete_landmark_name",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Landmark name for the few rows that carry one, Millennium Tower."
         },
         {
           "name": "eas_fullid",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Unique row identifier, base id, sub id, and parcel link id joined with dashes. The only column unique per row."
         },
         {
           "name": "direct_source",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Where the record entered the EAS, SF DBI, State of CA, or The Presidio Trust."
         },
         {
           "name": "cnn",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Centerline Network Number, the street-segment key of the city basemap, joins to the DataSF street centerlines."
         },
         {
           "name": "data_loaded_at",
-          "type": "timestamp with time zone"
+          "type": "timestamp with time zone",
+          "description": "When the portal loaded the record."
         },
         {
           "name": "longitude",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Longitude as text. Prefer the geometry column."
         },
         {
           "name": "street_name",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Parsed street name."
         },
         {
           "name": "supdist",
@@ -133,15 +144,18 @@
         },
         {
           "name": "eas_baseid",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Identifier of the base address, the building. Units share it, so count distinct eas_baseid for buildings."
         },
         {
           "name": "nhood",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "DataSF analysis neighborhood name, joins to the Analysis Neighborhoods dataset by name."
         },
         {
           "name": "block",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Assessor block number as a string."
         },
         {
           "name": "supname",
@@ -149,39 +163,48 @@
         },
         {
           "name": "street_type",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Parsed street type, ST or AVE. Null for streets like BROADWAY that have no type."
         },
         {
           "name": "eas_subid",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Identifier of the sub-address, a unit or apartment, within its base."
         },
         {
           "name": "lot",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Assessor lot number as a string."
         },
         {
           "name": "address",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Full address string, with the unit as a hash suffix when present."
         },
         {
           "name": "unit_number",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Unit designator, null on base-address rows."
         },
         {
           "name": "supervisor",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Supervisor district number as a string."
         },
         {
           "name": "data_updated_at",
-          "type": "timestamp with time zone"
+          "type": "timestamp with time zone",
+          "description": "Record update timestamp, with a 1970 epoch sentinel on never-updated rows."
         },
         {
           "name": "address_number",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Street number."
         },
         {
           "name": "parcel_number",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Assessor parcel number, block plus lot. Null on 32 percent of rows, a parcel join drops them silently."
         },
         {
           "name": "numbertext",
@@ -189,7 +212,8 @@
         },
         {
           "name": "data_as_of",
-          "type": "timestamp with time zone"
+          "type": "timestamp with time zone",
+          "description": "Snapshot timestamp of the upstream export, July 24, 2026 for every row here."
         },
         {
           "name": "landmark_aliases",
@@ -197,11 +221,13 @@
         },
         {
           "name": "geom",
-          "type": "geometry"
+          "type": "geometry",
+          "description": "Address point, WGS84 longitude and latitude. Units stack on their building's single point."
         },
         {
           "name": "bbox",
-          "type": "struct(xmin double, ymin double, xmax double, ymax double)"
+          "type": "struct(xmin double, ymin double, xmax double, ymax double)",
+          "description": "Per-feature bounding box struct, the GeoParquet covering."
         }
       ],
       "table:primary_geometry": "geom",

--- a/examples/catalog/portolan-reference/raster/AGENTS.md
+++ b/examples/catalog/portolan-reference/raster/AGENTS.md
@@ -1,4 +1,5 @@
-# Agent guidance, Raster Data
+# Agent Guidance, Raster Data
 
-This catalog groups 1 Collections under Raster Data.
-Follow the child links to each Collection.
+This catalog groups 1 Collections. Each carries its own AGENTS.md with join keys, quirks, and tested queries, so follow the per-collection guides below.
+
+- Sample Raster COG, 3-band raster, guide at ./sample-cog/AGENTS.md

--- a/examples/catalog/portolan-reference/raster/README.md
+++ b/examples/catalog/portolan-reference/raster/README.md
@@ -2,8 +2,15 @@
 
 Cloud Optimized GeoTIFF raster Collections.
 
-Collections, 1.
-Licenses, BSD-3-Clause.
+## Collections
+
+| Collection | Contents | Description |
+|---|---|---|
+| [Sample Raster COG](./sample-cog/README.md) | 3-band raster | A 1 MB Landsat-derived reference COG for learning and testing cloud-optimized raster access, not for analysis. |
+
+## Where the Data Comes From
+
+Licenses, CC0-1.0.
 Provenance, 1 mirror Collection.
 
 Upstream sources.

--- a/examples/catalog/portolan-reference/raster/sample-cog/AGENTS.md
+++ b/examples/catalog/portolan-reference/raster/sample-cog/AGENTS.md
@@ -1,7 +1,56 @@
-# Agent guidance, Sample Raster COG
+# Agent Guidance, Sample Raster COG
 
-This collection holds Sample Raster COG.
-Read the COG `data` asset with rioxarray.open_rasterio("sample-cog.tif") for xarray, or rasterio.
-For a quick preview use the thumbnail asset.
-License is BSD-3-Clause.
-The original upstream source is https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif , tagged on the source-role asset.
+A reference COG for exercising raster tooling, Landsat-derived RGB
+over Andros Island in the Bahamas. Nothing here supports analysis, the
+value is mechanical, a small well-formed COG with verified statistics.
+
+Read the COG `data` asset with rioxarray.open_rasterio("sample-cog.tif", masked=True) or rasterio. It serves windowed reads and overviews over HTTP range requests, so read the window you need rather than the whole file. For a quick preview use the thumbnail asset.
+
+## Quirks
+
+- Nodata is 0 and about 33 percent of pixels are the rotated-scene
+  collar. Valid data starts at 1, so always read with masking on,
+  treating 0 as a measurement skews every statistic.
+- There is no acquisition timestamp anywhere. The collection temporal
+  start is the Landsat 7 launch date, a bound, not a date.
+- Eastings run 101,985 to 339,315 meters, far west of the UTM zone 18
+  central meridian. Legal values, they just look odd.
+
+## CRS and Pixel Math
+
+EPSG:32618, WGS84 UTM zone 18N, in meters. Pixels are 300.04 meters
+square, so one pixel is about 9 hectares and pixel counts convert to
+area by multiplying by 300.04 squared. Reproject bounds to EPSG:4326
+before overlaying anything in longitude and latitude.
+
+## Tested Reads
+
+Windowed read and an overview read with rasterio.
+
+```python
+import rasterio
+from rasterio.windows import Window
+
+with rasterio.open("sample-cog.tif") as src:
+    window = src.read(window=Window(256, 256, 128, 128))
+    overview = src.read(1, out_shape=(src.height // 2, src.width // 2))
+    print(window.shape, overview.shape)
+# (3, 128, 128) (359, 395), the second served from the embedded overview.
+```
+
+Masked statistics with rioxarray.
+
+```python
+import rioxarray
+
+da = rioxarray.open_rasterio("sample-cog.tif", masked=True)
+print(float(da.sel(band=3).mean()))
+# 71.3, and blue > green > red across the scene, bright shallow water.
+```
+
+## Related Collections
+
+None. This is the catalog's only raster and joins to nothing. The
+upstream fixture is tagged on the source asset with its checksum, and
+band statistics live in the STAC bands metadata and as GDAL
+STATISTICS_* tags in the file header, written by the same build.

--- a/examples/catalog/portolan-reference/raster/sample-cog/README.md
+++ b/examples/catalog/portolan-reference/raster/sample-cog/README.md
@@ -1,17 +1,27 @@
 # Sample Raster COG
 
-A small 3-band Cloud Optimized GeoTIFF used to exercise the raster path end to end. Optimized to a COG with per-band statistics, minimum, maximum, mean, and standard deviation, embedded in the header. From the rasterio test fixtures, a 3-band raster in UTM zone 18N (EPSG:32618).
+A small 3-band Cloud Optimized GeoTIFF used to exercise the raster path end to end, rasterio's RGB.byte.tif test fixture, derived from USGS Landsat 7 imagery over Andros Island in the Bahamas. Optimized to a COG with per-band statistics, minimum, maximum, mean, and standard deviation, embedded in the header, in UTM zone 18N (EPSG:32618).
 
-License, BSD-3-Clause.
-Providers, rasterio (producer, licensor), Portolan SDI (host).
-Original source, https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif .
-Bands, 3.
-CRS, EPSG:32618.
-Cloud-native asset, sample-cog.tif (COG).
+A 791 by 718 pixel, 3-band, 8-bit image at roughly 300 meter
+resolution whose georeferencing places it over Andros Island in the
+Bahamas, the shallow Great Bahama Bank to its west and the deep Tongue
+of the Ocean along its east coast. It is
+[rasterio's](https://github.com/rasterio/rasterio) RGB.byte.tif test
+fixture, derived from USGS Landsat 7 imagery per the project's
+[test data notes](https://github.com/rasterio/rasterio/blob/main/tests/data/README.rst),
+in the repository since rasterio's first tests in November 2013 and
+the workhorse image of its README and topic guides ever since. Anyone
+who has learned rasterio has seen this picture.
 
-## Open the data
+Here it exercises the Portolan raster path end to end, a Cloud
+Optimized GeoTIFF with internal tiling, an overview level, and
+per-band statistics embedded in both the STAC metadata and the GeoTIFF
+header.
 
-The `data` asset is a Cloud Optimized GeoTIFF. Open it as an xarray array with rioxarray.
+Agents, [AGENTS.md](./AGENTS.md) covers the nodata trap and windowed
+reads.
+
+## Quick Start
 
 ```python
 import rioxarray
@@ -20,12 +30,42 @@ da = rioxarray.open_rasterio("sample-cog.tif", masked=True)
 print(da)
 ```
 
-Or read bands and metadata with rasterio.
+The `data` asset is a Cloud Optimized GeoTIFF, so the same call against the published URL streams only the bytes it needs over HTTP range requests. Pass masked=True so nodata reads as NaN.
 
-```python
-import rasterio
+## Why a COG, Watching the Range Reads
 
-with rasterio.open("sample-cog.tif") as src:
-    print(src.profile)
-    band1 = src.read(1)
+A Cloud Optimized GeoTIFF serves partial reads over HTTP. Opening the
+published copy with GDAL's debug output on shows it, a 64 pixel window
+costs two range requests of roughly 0.4 MB, not the whole file.
+
+```bash
+CPL_DEBUG=ON gdal_translate -srcwin 0 0 64 64 \
+  /vsicurl/https://data.source.coop/portolan/portolan-pipeline/portolan-reference/main/raster/sample-cog/sample-cog.tif \
+  /tmp/window.tif
+# VSICURL: Downloading 0-16383 ... 229376-655359
 ```
+
+## Suggested Uses
+
+Learning and testing COG access patterns, windowed reads, overview
+reads, HTTP range requests, at a size where experiments cost nothing.
+Its familiarity is the feature, tutorials and bug reports written
+against rasterio's docs transfer directly.
+
+## Limitations
+
+Not an analytically useful dataset, and the documentation should be
+the last place you learn that. The acquisition date and Landsat scene
+id are unrecorded, the temporal extent here starts at the Landsat 7
+launch in April 1999 only as an honest lower bound. Bands are
+display-stretched 8-bit RGB, not calibrated reflectance, so no
+conclusion about the Bahamas should be drawn from these pixels. About
+a third of the image is a nodata collar from the rotated scene
+footprint.
+
+## Provenance and License
+
+License, CC0-1.0.
+Providers, rasterio (producer, licensor), Portolan SDI (host).
+Original source, https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif .
+Bands, 3. CRS, EPSG:32618. Cloud-native asset, sample-cog.tif (COG).

--- a/examples/catalog/portolan-reference/raster/sample-cog/collection.json
+++ b/examples/catalog/portolan-reference/raster/sample-cog/collection.json
@@ -8,8 +8,8 @@
   ],
   "id": "raster/sample-cog",
   "title": "Sample Raster COG",
-  "description": "A small 3-band Cloud Optimized GeoTIFF used to exercise the raster path end to end. Optimized to a COG with per-band statistics, minimum, maximum, mean, and standard deviation, embedded in the header. From the rasterio test fixtures, a 3-band raster in UTM zone 18N (EPSG:32618).",
-  "license": "BSD-3-Clause",
+  "description": "A small 3-band Cloud Optimized GeoTIFF used to exercise the raster path end to end, rasterio's RGB.byte.tif test fixture, derived from USGS Landsat 7 imagery over Andros Island in the Bahamas. Optimized to a COG with per-band statistics, minimum, maximum, mean, and standard deviation, embedded in the header, in UTM zone 18N (EPSG:32618).",
+  "license": "CC0-1.0",
   "keywords": [
     "raster",
     "cog",
@@ -49,7 +49,7 @@
     "temporal": {
       "interval": [
         [
-          "2020-01-01T00:00:00Z",
+          "1999-04-15T00:00:00Z",
           null
         ]
       ]

--- a/examples/catalog/portolan-reference/reference/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/AGENTS.md
@@ -1,4 +1,6 @@
-# Agent guidance, Reference Basemaps
+# Agent Guidance, Reference Basemaps
 
-This catalog groups 2 Collections under Reference Basemaps.
-Follow the child links to each Collection.
+This catalog groups 2 Collections. Each carries its own AGENTS.md with join keys, quirks, and tested queries, so follow the per-collection guides below.
+
+- Natural Earth Countries (1:110m), 177 polygons, guide at ./natural-earth-countries/AGENTS.md
+- Natural Earth Populated Places (1:50m), 1,251 points, guide at ./natural-earth-populated-places/AGENTS.md

--- a/examples/catalog/portolan-reference/reference/README.md
+++ b/examples/catalog/portolan-reference/reference/README.md
@@ -2,7 +2,15 @@
 
 Public domain reference basemap layers for general orientation and joins.
 
-Collections, 2.
+## Collections
+
+| Collection | Contents | Description |
+|---|---|---|
+| [Natural Earth Countries (1:110m)](./natural-earth-countries/README.md) | 177 polygons | 177 country polygons at world scale, the public domain basemap behind most web choropleths. |
+| [Natural Earth Populated Places (1:50m)](./natural-earth-populated-places/README.md) | 1,251 points | 1,251 curated city and town points with population estimates, from Tokyo to Antarctic research stations. |
+
+## Where the Data Comes From
+
 Licenses, CC0-1.0.
 Provenance, 2 mirror Collections.
 

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
@@ -1,7 +1,69 @@
-# Agent guidance, Natural Earth Countries (1:110m)
+# Agent Guidance, Natural Earth Countries (1:110m)
 
-This collection holds Natural Earth Countries (1:110m).
-Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("natural-earth-countries.parquet").
-For a quick preview use the thumbnail asset.
-License is CC0-1.0.
-The original upstream source is https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip , tagged on the source-role asset.
+World country polygons for joins and rollups, not for legal boundaries
+or precise areas. The stable key is `ADM0_A3`. External statistics join
+on `ISO_A3_EH` or `ISO_A2_EH`. The raw `ISO_A3` and `ISO_A2` columns
+hold the sentinel -99 for France, Norway, Kosovo, Northern Cyprus, and
+Somaliland, so a filter like ISO_A3 = 'FRA' matches nothing.
+
+Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('natural-earth-countries.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For a quick preview use the thumbnail asset.
+
+## Quirks
+
+- -99 is the global no-data sentinel, in the ISO columns and in numeric
+  columns like TINY and MAPCOLOR13. Check for it before trusting a value.
+- France includes French Guiana as one row, so its bbox spans from
+  South America to Europe and bbox filters on South America catch France.
+- South Sudan is `SDS` here but `SSD` in the populated places file. An
+  `ADM0_A3` join between the two layers drops it unless you remap.
+- Antarctica is a country row with population 4,490, and the continent
+  column also holds Seven seas (open ocean) for the French Southern and
+  Antarctic Lands.
+- Russia and Fiji cross the antimeridian, so their bboxes span the full
+  longitude range and naive bbox-width logic breaks.
+
+## CRS, Degrees In, Degrees Out
+
+EPSG:4326, longitude and latitude in degrees. `ST_Area(geom)` returns
+square degrees, which makes Greenland read nearly as large as Brazil.
+For real areas use the spheroid function, and flip coordinates first
+because DuckDB's geodesic functions expect latitude first.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT NAME, round(ST_Area_Spheroid(ST_FlipCoordinates(geom)) / 1e6) AS km2
+FROM read_parquet('natural-earth-countries.parquet')
+ORDER BY km2 DESC LIMIT 5;
+-- Russia 17,018,507 then Antarctica, Canada, United States, China.
+-- Without the flip, Brazil returns 5.2M km2 instead of 8.5M and 33
+-- countries return NaN.
+```
+
+## Tested Queries
+
+Population by continent.
+
+```sql
+SELECT CONTINENT, count(*) AS countries, sum(POP_EST)::BIGINT AS pop
+FROM read_parquet('natural-earth-countries.parquet')
+GROUP BY CONTINENT ORDER BY pop DESC;
+-- Asia 4.55B across 47 rows, Africa 1.31B across 51, eight groups in all.
+```
+
+Which country contains a point.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT NAME, ADM0_A3
+FROM read_parquet('natural-earth-countries.parquet')
+WHERE ST_Contains(geom, ST_Point(13.405, 52.52));
+-- Germany, DEU. ST_Point takes longitude first.
+```
+
+## Related Collections
+
+`reference/natural-earth-populated-places` joins on `ADM0_A3` with the
+South Sudan remap above. `tabular/eurostat-electricity-prices` joins on
+`ISO_A2_EH` after remapping Eurostat's EL and UK codes, the worked
+example lives in that Collection's README. Converted from the upstream
+zipped Shapefile with DuckDB spatial into web-optimized GeoParquet 2.0.

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/README.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/README.md
@@ -2,15 +2,27 @@
 
 World country boundaries at 1:110m scale from Natural Earth, the public domain reference basemap maintained by NACIS. Republished as cloud-native GeoParquet alongside the original zipped Shapefile.
 
-License, CC0-1.0.
-Providers, Natural Earth (producer, licensor), Portolan SDI (host).
-Original source, https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip .
-Features, 177.
-Cloud-native asset, natural-earth-countries.parquet (GeoParquet).
+[Natural Earth](https://www.naturalearthdata.com) is the public domain
+reference map dataset that Nathaniel Vaughn Kelso and Tom Patterson
+started in 2009 and maintain with volunteer cartographers under
+[NACIS](https://nacis.org). This collection carries its 1:110m countries
+theme, version 5.1.1 from May 2022, and holds 177 country polygons with
+171 attribute columns of names in 26 languages, ISO codes, population
+and GDP estimates from 2019, and cartographic styling hints. It is the
+geometry behind [world-atlas](https://github.com/topojson/world-atlas)
+and with that most of the world choropleths on the web.
 
-## Open the data
+Boundaries follow Natural Earth's
+[de facto policy](https://www.naturalearthdata.com/about/disputed-boundaries-policy/),
+showing who controls territory rather than legal claims, so Somaliland
+and Northern Cyprus appear as their own rows. The 34 FCLASS point-of-view
+columns added in December 2021 let a map follow a specific national
+worldview instead.
 
-The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column for fast web-client pruning. Read it with a recent GeoPandas built on pyarrow 24 or newer.
+Agents, read [AGENTS.md](./AGENTS.md) first. It carries the join keys,
+the sentinel-value traps, and tested queries.
+
+## Quick Start
 
 ```python
 import geopandas as gpd
@@ -19,9 +31,78 @@ gdf = gpd.read_parquet("natural-earth-countries.parquet")
 print(gdf.head())
 ```
 
-Or query it in place with a recent DuckDB spatial.
+The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column, so it needs a GeoPandas built on pyarrow 24 or newer. DuckDB spatial queries the same file in place, see [AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to this directory, and the same code works against the published URL.
+
+## Schema, the Columns That Matter
+
+Twenty-two of the 171 columns do most of the work.
+
+| Column | Type | Description |
+|---|---|---|
+| `SOVEREIGNT` | varchar | The owning sovereign state, which differs from ADMIN for territories such as Greenland (Denmark). |
+| `TYPE` | varchar | Unit type, Sovereign country, Country, Dependency, Disputed, Indeterminate, or Sovereignty. |
+| `ADM0_A3` | varchar | Natural Earth's own three-letter country code. Never a sentinel value, and the join key to the populated places Collection. |
+| `NAME` | varchar | Short map label, for example Dem. Rep. Congo. |
+| `NAME_LONG` | varchar | Long-form name, for example Democratic Republic of the Congo. Differs from NAME on 21 rows. |
+| `POP_EST` | double | Population estimate, mostly the 2019 vintage. See POP_YEAR. |
+| `POP_YEAR` | integer | Year the population estimate refers to. |
+| `GDP_MD` | integer | GDP in millions of US dollars, mostly the 2019 vintage. See GDP_YEAR. |
+| `GDP_YEAR` | integer | Year the GDP figure refers to. |
+| `ISO_A2` | varchar | ISO 3166-1 alpha-2 code, -99 for the same five countries as ISO_A3. |
+| `ISO_A2_EH` | varchar | ISO alpha-2 with France, Norway, and Kosovo (XK) repaired. |
+| `ISO_A3` | varchar | ISO 3166-1 alpha-3 code, with the sentinel -99 for France, Norway, Kosovo, Northern Cyprus, and Somaliland. Prefer ISO_A3_EH. |
+| `ISO_A3_EH` | varchar | ISO alpha-3 with France and Norway repaired. The column to join external ISO-coded statistics on. |
+| `CONTINENT` | varchar | Continent rollup. Includes the value Seven seas (open ocean), so a GROUP BY returns eight groups. |
+| `REGION_UN` | varchar | United Nations macro region. |
+| `SUBREGION` | varchar | United Nations subregion. |
+| `LABEL_X` | double | Longitude of the preferred label point. |
+| `LABEL_Y` | double | Latitude of the preferred label point. |
+| `NE_ID` | bigint | Stable Natural Earth feature id, unique in this file. |
+| `WIKIDATAID` | varchar | Wikidata QID, present on all 177 rows. |
+| `geom` | geometry | Country geometry, polygon or multipolygon, WGS84 longitude and latitude. |
+| `bbox` | struct(xmin double, ymin double, xmax double, ymax double) | Per-feature bounding box struct, the GeoParquet covering used for spatial predicate pushdown. |
+
+The table has 171 columns in all. The full list with types lives in `table:columns` on the `data` asset.
+
+## Join Statistics to Geometry
+
+The reason this Collection is in the catalog. Any table keyed by ISO
+country code joins here for mapping, like the Eurostat electricity
+prices table two directories over. Join on `ISO_A2_EH` or `ISO_A3_EH`,
+not the raw ISO columns, which hold -99 for France and Norway.
 
 ```sql
 INSTALL spatial; LOAD spatial;
-SELECT * FROM read_parquet('natural-earth-countries.parquet') LIMIT 5;
+SELECT n.NAME, e.OBS_VALUE AS eur_per_kwh, n.geom
+FROM read_parquet('../../tabular/eurostat-electricity-prices/eurostat-electricity-prices.parquet') e
+JOIN read_parquet('natural-earth-countries.parquet') n
+  ON (CASE e.geo WHEN 'EL' THEN 'GR' WHEN 'UK' THEN 'GB' ELSE e.geo END) = n.ISO_A2_EH
+WHERE e.TIME_PERIOD = '2025-S2' AND e.nrg_cons = 'KWH2500-4999'
+  AND e.tax = 'I_TAX' AND e.currency = 'EUR';
 ```
+
+## Suggested Uses
+
+Choropleths of ISO-coded statistics, continent and region rollups, and
+quick spatial-query demos. The `MAPCOLOR7` through `MAPCOLOR13` columns
+assign map colors so neighboring countries differ, and `LABEL_X` and
+`LABEL_Y` carry hand-placed label points, both there for basemap
+rendering.
+
+## Limitations
+
+Not authoritative for legal boundaries. Natural Earth draws de facto
+control, so Crimea, Kashmir, and Western Sahara follow the situation on
+the ground, not treaties. Not measurement geometry either. At 1:110m a
+coastline is simplified by tens of kilometres, and 43 small countries
+and territories, from Andorra and Malta to Singapore and the Vatican,
+have no polygon at all. Population and GDP are 2019 estimates. Upstream
+publishes no formal accuracy figures, and the last cultural release was
+in May 2022.
+
+## Provenance and License
+
+License, CC0-1.0.
+Providers, Natural Earth (producer, licensor), Portolan SDI (host).
+Original source, https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip .
+Features, 177. Cloud-native asset, natural-earth-countries.parquet (GeoParquet 2.0).

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
@@ -50,7 +50,7 @@
     "temporal": {
       "interval": [
         [
-          "2025-01-01T00:00:00Z",
+          "2022-05-12T00:00:00Z",
           null
         ]
       ]
@@ -85,7 +85,8 @@
         },
         {
           "name": "SOVEREIGNT",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "The owning sovereign state, which differs from ADMIN for territories such as Greenland (Denmark)."
         },
         {
           "name": "SOV_A3",
@@ -101,7 +102,8 @@
         },
         {
           "name": "TYPE",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Unit type, Sovereign country, Country, Dependency, Disputed, Indeterminate, or Sovereignty."
         },
         {
           "name": "TLC",
@@ -113,7 +115,8 @@
         },
         {
           "name": "ADM0_A3",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Natural Earth's own three-letter country code. Never a sentinel value, and the join key to the populated places Collection."
         },
         {
           "name": "GEOU_DIF",
@@ -145,11 +148,13 @@
         },
         {
           "name": "NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Short map label, for example Dem. Rep. Congo."
         },
         {
           "name": "NAME_LONG",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Long-form name, for example Democratic Republic of the Congo. Differs from NAME on 21 rows."
         },
         {
           "name": "BRK_A3",
@@ -217,7 +222,8 @@
         },
         {
           "name": "POP_EST",
-          "type": "double"
+          "type": "double",
+          "description": "Population estimate, mostly the 2019 vintage. See POP_YEAR."
         },
         {
           "name": "POP_RANK",
@@ -225,15 +231,18 @@
         },
         {
           "name": "POP_YEAR",
-          "type": "integer"
+          "type": "integer",
+          "description": "Year the population estimate refers to."
         },
         {
           "name": "GDP_MD",
-          "type": "integer"
+          "type": "integer",
+          "description": "GDP in millions of US dollars, mostly the 2019 vintage. See GDP_YEAR."
         },
         {
           "name": "GDP_YEAR",
-          "type": "integer"
+          "type": "integer",
+          "description": "Year the GDP figure refers to."
         },
         {
           "name": "ECONOMY",
@@ -249,19 +258,23 @@
         },
         {
           "name": "ISO_A2",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "ISO 3166-1 alpha-2 code, -99 for the same five countries as ISO_A3."
         },
         {
           "name": "ISO_A2_EH",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "ISO alpha-2 with France, Norway, and Kosovo (XK) repaired."
         },
         {
           "name": "ISO_A3",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "ISO 3166-1 alpha-3 code, with the sentinel -99 for France, Norway, Kosovo, Northern Cyprus, and Somaliland. Prefer ISO_A3_EH."
         },
         {
           "name": "ISO_A3_EH",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "ISO alpha-3 with France and Norway repaired. The column to join external ISO-coded statistics on."
         },
         {
           "name": "ISO_N3",
@@ -441,15 +454,18 @@
         },
         {
           "name": "CONTINENT",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Continent rollup. Includes the value Seven seas (open ocean), so a GROUP BY returns eight groups."
         },
         {
           "name": "REGION_UN",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "United Nations macro region."
         },
         {
           "name": "SUBREGION",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "United Nations subregion."
         },
         {
           "name": "REGION_WB",
@@ -489,19 +505,23 @@
         },
         {
           "name": "LABEL_X",
-          "type": "double"
+          "type": "double",
+          "description": "Longitude of the preferred label point."
         },
         {
           "name": "LABEL_Y",
-          "type": "double"
+          "type": "double",
+          "description": "Latitude of the preferred label point."
         },
         {
           "name": "NE_ID",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "Stable Natural Earth feature id, unique in this file."
         },
         {
           "name": "WIKIDATAID",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Wikidata QID, present on all 177 rows."
         },
         {
           "name": "NAME_AR",
@@ -745,11 +765,13 @@
         },
         {
           "name": "geom",
-          "type": "geometry"
+          "type": "geometry",
+          "description": "Country geometry, polygon or multipolygon, WGS84 longitude and latitude."
         },
         {
           "name": "bbox",
-          "type": "struct(xmin double, ymin double, xmax double, ymax double)"
+          "type": "struct(xmin double, ymin double, xmax double, ymax double)",
+          "description": "Per-feature bounding box struct, the GeoParquet covering used for spatial predicate pushdown."
         }
       ],
       "table:primary_geometry": "geom",

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
@@ -1,7 +1,57 @@
-# Agent guidance, Natural Earth Populated Places (1:50m)
+# Agent Guidance, Natural Earth Populated Places (1:50m)
 
-This collection holds Natural Earth Populated Places (1:50m).
-Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("natural-earth-populated-places.parquet").
-For a quick preview use the thumbnail asset.
-License is CC0-1.0.
-The original upstream source is https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip , tagged on the source-role asset.
+Curated world city points that join to the countries Collection on
+`ADM0_A3`. Join by attribute, never spatially. 113 of the 1,251 points,
+Istanbul, Montevideo, and Geneva among them, fall outside their own
+country's generalized 1:110m polygon because coastal simplification
+pushes them offshore.
+
+Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('natural-earth-populated-places.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For a quick preview use the thumbnail asset.
+
+## Quirks
+
+- The United States capital is spelled with two spaces after the comma,
+  so NAME = 'Washington, D.C.' matches nothing. Use LIKE 'Washington%'
+  or ADM0CAP = 1 with ADM0_A3 = 'USA'.
+- South Sudan is `SSD` here but `SDS` in the countries file. Remap one
+  side before joining, or Juba, Malakal, and Wau drop out.
+- The legacy LATITUDE and LONGITUDE columns diverge from the geometry
+  by up to 0.22 degrees. They are old label anchors, read `geom`.
+- The UN time series columns POP1950 through POP2050 are populated only
+  for the 463 UN-tracked agglomerations, zero elsewhere, and POP2050 is
+  a projection.
+- 59 places carry POP_MAX below 1,000, mostly stations and outposts, so
+  population filters silently drop real capitals of small territories.
+
+## Tested Queries
+
+Capitals per continent, with the country join done correctly.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT c.CONTINENT, count(*) AS capitals
+FROM read_parquet('natural-earth-populated-places.parquet') p
+JOIN read_parquet('../natural-earth-countries/natural-earth-countries.parquet') c
+  ON (CASE p.ADM0_A3 WHEN 'SSD' THEN 'SDS' ELSE p.ADM0_A3 END) = c.ADM0_A3
+WHERE p.ADM0CAP = 1
+GROUP BY c.CONTINENT ORDER BY capitals DESC;
+-- Africa 52, Asia 45, Europe 39, then the Americas and Oceania.
+```
+
+Nearest city to a point, distance in kilometres.
+
+```sql
+INSTALL spatial; LOAD spatial;
+SELECT NAME, ADM0NAME,
+       round(ST_Distance_Sphere(geom, ST_Point(-122.4783, 37.8199)) / 1000, 1) AS km
+FROM read_parquet('natural-earth-populated-places.parquet')
+ORDER BY km LIMIT 3;
+-- San Francisco 9.0 km, San Jose 71.7 km, Sacramento 120.4 km.
+```
+
+## Related Collections
+
+`reference/natural-earth-countries` is the polygon companion, same
+producer and vintage family, joined on `ADM0_A3` with the South Sudan
+remap. Converted from the upstream zipped Shapefile with DuckDB spatial
+into web-optimized GeoParquet 2.0.

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/README.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/README.md
@@ -2,15 +2,27 @@
 
 Point locations of populated places, cities and towns, at 1:50m scale from Natural Earth. Public domain reference points, republished as cloud-native GeoParquet alongside the original zipped Shapefile.
 
-License, CC0-1.0.
-Providers, Natural Earth (producer, licensor), Portolan SDI (host).
-Original source, https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip .
-Features, 1251.
-Cloud-native asset, natural-earth-populated-places.parquet (GeoParquet).
+City and town points at 1:50m scale from
+[Natural Earth](https://www.naturalearthdata.com), version 5.1.2 from
+May 2022. The 1,251 points cover every national and most first-level
+capitals, major cities, and, in Natural Earth's own words, a sampling
+of smaller towns in sparsely inhabited regions, favoring regional
+significance over population census. LandScan-derived population
+estimates cover about 90 percent of the places.
 
-## Open the data
+Agents, read [AGENTS.md](./AGENTS.md) first, especially before joining
+these points to country polygons.
 
-The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column for fast web-client pruning. Read it with a recent GeoPandas built on pyarrow 24 or newer.
+## What Counts as a Place
+
+The `FEATURECLA` column answers it. 482 Admin-1 capitals, 414 plain
+populated places, 202 national capitals, and some surprises, 40
+Antarctic research stations including Amundsen-Scott at exactly 90
+degrees south, 13 alternate capitals such as The Hague and Lagos, and
+one historic place, the abandoned Siberian port of Ambarchik with
+population zero. Filter on it before counting cities.
+
+## Quick Start
 
 ```python
 import geopandas as gpd
@@ -19,9 +31,62 @@ gdf = gpd.read_parquet("natural-earth-populated-places.parquet")
 print(gdf.head())
 ```
 
-Or query it in place with a recent DuckDB spatial.
+The `data` asset is GeoParquet 2.0 with a native geometry type and a covering bbox column, so it needs a GeoPandas built on pyarrow 24 or newer. DuckDB spatial queries the same file in place, see [AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to this directory, and the same code works against the published URL.
+
+## Sizing and Filtering Labels
+
+The cartographic columns are the point of this theme. Natural Earth's
+guidance is to size labels from `POP_MAX` and thin them with the scale
+rankings, and `MIN_ZOOM` maps that to web-map zoom levels directly.
 
 ```sql
-INSTALL spatial; LOAD spatial;
-SELECT * FROM read_parquet('natural-earth-populated-places.parquet') LIMIT 5;
+SELECT NAME, POP_MAX, SCALERANK
+FROM read_parquet('natural-earth-populated-places.parquet')
+WHERE SCALERANK = 0
+ORDER BY POP_MAX DESC LIMIT 5;
 ```
+
+## Schema, the Columns That Matter
+
+Nineteen of the 140 columns cover most uses.
+
+| Column | Type | Description |
+|---|---|---|
+| `SCALERANK` | integer | Importance rank 0 to 10, 0 most important. Filter on it to thin labels by zoom. |
+| `FEATURECLA` | varchar | What kind of place this is. Admin-0 capital, Admin-1 capital, Populated place, Scientific station, and four rarer classes. |
+| `NAME` | varchar | Display name with diacritics, for example Neuquén. Not unique, several city names repeat across countries. |
+| `NAMEASCII` | varchar | ASCII fallback spelling of the name. |
+| `ADM0CAP` | integer | 1 marks a national capital, 200 rows in this file. |
+| `WORLDCITY` | integer | 1 flags 70 globally prominent cities. |
+| `MEGACITY` | integer | 1 flags the 462 places Natural Earth treats as megacities. |
+| `ADM0NAME` | varchar | Country name the point belongs to. |
+| `ADM0_A3` | varchar | Natural Earth country code, the join key to the countries Collection. |
+| `ADM1NAME` | varchar | First-level admin region the point belongs to. |
+| `POP_MAX` | bigint | Population of the metro area, LandScan derived. Tokyo carries 35,676,000. |
+| `POP_MIN` | bigint | Population of the city proper. Tokyo carries 8,336,599. |
+| `TIMEZONE` | varchar | IANA time zone name, empty for 114 rows. |
+| `MIN_ZOOM` | double | Suggested minimum web-map zoom for showing the place. |
+| `WIKIDATAID` | varchar | Wikidata QID, missing for 7 rows. |
+| `NE_ID` | bigint | Stable Natural Earth feature id, unique in this file. |
+| `GEONAMESID` | bigint | GeoNames id, missing for 43 rows. |
+| `geom` | geometry | Point geometry, WGS84 longitude and latitude. Use it instead of the legacy LATITUDE and LONGITUDE columns. |
+| `bbox` | struct(xmin double, ymin double, xmax double, ymax double) | Per-feature bounding box struct, the GeoParquet covering. |
+
+The table has 140 columns in all. The full list with types lives in `table:columns` on the `data` asset.
+
+## Limitations
+
+A curated cartographic layer, not a gazetteer and not a demographic
+dataset. Absence means Natural Earth chose not to include a town, not
+that it does not exist, and the population figures are 2019-era
+estimates for label sizing, not census data. `POP_MAX` counts the
+metro area and `POP_MIN` the city proper, so ranking cities without
+picking one deliberately mixes definitions. Names repeat, Mérida,
+Portland, and Valencia each appear twice, so use `NE_ID` as the key.
+
+## Provenance and License
+
+License, CC0-1.0.
+Providers, Natural Earth (producer, licensor), Portolan SDI (host).
+Original source, https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip .
+Features, 1,251. Cloud-native asset, natural-earth-populated-places.parquet (GeoParquet 2.0).

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
@@ -50,7 +50,7 @@
     "temporal": {
       "interval": [
         [
-          "2025-01-01T00:00:00Z",
+          "2022-05-13T00:00:00Z",
           null
         ]
       ]
@@ -73,7 +73,8 @@
         },
         {
           "name": "SCALERANK",
-          "type": "integer"
+          "type": "integer",
+          "description": "Importance rank 0 to 10, 0 most important. Filter on it to thin labels by zoom."
         },
         {
           "name": "NATSCALE",
@@ -85,11 +86,13 @@
         },
         {
           "name": "FEATURECLA",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "What kind of place this is. Admin-0 capital, Admin-1 capital, Populated place, Scientific station, and four rarer classes."
         },
         {
           "name": "NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Display name with diacritics, for example Neuqu\u00e9n. Not unique, several city names repeat across countries."
         },
         {
           "name": "NAMEPAR",
@@ -101,11 +104,13 @@
         },
         {
           "name": "NAMEASCII",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "ASCII fallback spelling of the name."
         },
         {
           "name": "ADM0CAP",
-          "type": "integer"
+          "type": "integer",
+          "description": "1 marks a national capital, 200 rows in this file."
         },
         {
           "name": "CAPIN",
@@ -113,11 +118,13 @@
         },
         {
           "name": "WORLDCITY",
-          "type": "integer"
+          "type": "integer",
+          "description": "1 flags 70 globally prominent cities."
         },
         {
           "name": "MEGACITY",
-          "type": "integer"
+          "type": "integer",
+          "description": "1 flags the 462 places Natural Earth treats as megacities."
         },
         {
           "name": "SOV0NAME",
@@ -129,15 +136,18 @@
         },
         {
           "name": "ADM0NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Country name the point belongs to."
         },
         {
           "name": "ADM0_A3",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Natural Earth country code, the join key to the countries Collection."
         },
         {
           "name": "ADM1NAME",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "First-level admin region the point belongs to."
         },
         {
           "name": "ISO_A2",
@@ -157,11 +167,13 @@
         },
         {
           "name": "POP_MAX",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "Population of the metro area, LandScan derived. Tokyo carries 35,676,000."
         },
         {
           "name": "POP_MIN",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "Population of the city proper. Tokyo carries 8,336,599."
         },
         {
           "name": "POP_OTHER",
@@ -281,7 +293,8 @@
         },
         {
           "name": "TIMEZONE",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "IANA time zone name, empty for 114 rows."
         },
         {
           "name": "UN_FID",
@@ -357,11 +370,13 @@
         },
         {
           "name": "MIN_ZOOM",
-          "type": "double"
+          "type": "double",
+          "description": "Suggested minimum web-map zoom for showing the place."
         },
         {
           "name": "WIKIDATAID",
-          "type": "varchar"
+          "type": "varchar",
+          "description": "Wikidata QID, missing for 7 rows."
         },
         {
           "name": "WOF_ID",
@@ -461,7 +476,8 @@
         },
         {
           "name": "NE_ID",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "Stable Natural Earth feature id, unique in this file."
         },
         {
           "name": "NAME_FA",
@@ -485,7 +501,8 @@
         },
         {
           "name": "GEONAMESID",
-          "type": "bigint"
+          "type": "bigint",
+          "description": "GeoNames id, missing for 43 rows."
         },
         {
           "name": "FCLASS_ISO",
@@ -621,11 +638,13 @@
         },
         {
           "name": "geom",
-          "type": "geometry"
+          "type": "geometry",
+          "description": "Point geometry, WGS84 longitude and latitude. Use it instead of the legacy LATITUDE and LONGITUDE columns."
         },
         {
           "name": "bbox",
-          "type": "struct(xmin double, ymin double, xmax double, ymax double)"
+          "type": "struct(xmin double, ymin double, xmax double, ymax double)",
+          "description": "Per-feature bounding box struct, the GeoParquet covering."
         }
       ],
       "table:primary_geometry": "geom",

--- a/examples/catalog/portolan-reference/tabular/AGENTS.md
+++ b/examples/catalog/portolan-reference/tabular/AGENTS.md
@@ -1,4 +1,5 @@
-# Agent guidance, Tabular Data
+# Agent Guidance, Tabular Data
 
-This catalog groups 1 Collections under Tabular Data.
-Follow the child links to each Collection.
+This catalog groups 1 Collections. Each carries its own AGENTS.md with join keys, quirks, and tested queries, so follow the per-collection guides below.
+
+- Eurostat Electricity Prices for Household Consumers, 65,412 rows, guide at ./eurostat-electricity-prices/AGENTS.md

--- a/examples/catalog/portolan-reference/tabular/README.md
+++ b/examples/catalog/portolan-reference/tabular/README.md
@@ -2,7 +2,14 @@
 
 Non-geospatial companion tables published as Parquet.
 
-Collections, 1.
+## Collections
+
+| Collection | Contents | Description |
+|---|---|---|
+| [Eurostat Electricity Prices for Household Consumers](./eurostat-electricity-prices/README.md) | 65,412 rows | 65,412 semi-annual household electricity prices for 41 European countries from 2007 on, the official record of the 2022 energy crisis. |
+
+## Where the Data Comes From
+
 Licenses, CC-BY-4.0.
 Provenance, 1 mirror Collection.
 

--- a/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/AGENTS.md
+++ b/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/AGENTS.md
@@ -1,8 +1,77 @@
-# Agent guidance, Eurostat Electricity Prices for Household Consumers
+# Agent Guidance, Eurostat Electricity Prices for Household Consumers
 
-This collection holds Eurostat Electricity Prices for Household Consumers.
-Read the Parquet `data` asset with pandas, pd.read_parquet("eurostat-electricity-prices.parquet").
-For a quick preview use the thumbnail asset.
-License is CC-BY-4.0. Attribute as Source, Eurostat.
-The original upstream source is https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false , a live endpoint referenced by URL only.
-This table has no geometry. Join column geo to reference/natural-earth-countries on ISO_A2 to map it, see the README.
+Semi-annual household electricity prices, one row per combination of
+consumption band, tax level, currency, country, and semester, verified
+unique on those five. Filter all five dimensions before comparing
+anything. The headline combination is nrg_cons = 'KWH2500-4999',
+tax = 'I_TAX', currency = 'EUR'.
+
+Query the Parquet `data` asset in place with DuckDB, read_parquet('eurostat-electricity-prices.parquet'), or load it with pandas.
+
+## Quirks
+
+- EU27_2020 and EA sit in geo alongside countries, so unfiltered
+  rankings place the EU average mid-table as if it were a country.
+  Exclude them for country-level analysis.
+- The LAST UPDATE column is frozen at one 2019 timestamp on all 65,412
+  rows of this snapshot while data runs to 2025-S2. It also has a space
+  in its name, quote it as "LAST UPDATE".
+- The panel is ragged. The UK stops after 2020-S1, Ukraine after
+  2021-S1, Iceland lags a semester, and 2007-S1 has only 8 reporters.
+- TOT_KWH is itself a weighted average of the five bands and exists
+  only from 2017-S2. Never mix it into a band aggregate.
+- For euro-area countries NAC duplicates EUR, so counting rows across
+  currencies triple-counts observations.
+- About 2 percent of rows carry flags, e estimated, p provisional, d
+  definition differs, and provisional values are revised in later
+  snapshots, so this fixed copy can disagree with the live API on
+  recent semesters.
+
+## Tested Queries
+
+Latest prices ranked, aggregates excluded.
+
+```sql
+SELECT geo, OBS_VALUE AS eur_per_kwh
+FROM read_parquet('eurostat-electricity-prices.parquet')
+WHERE nrg_cons = 'KWH2500-4999' AND tax = 'I_TAX' AND currency = 'EUR'
+  AND TIME_PERIOD = (SELECT max(TIME_PERIOD) FROM read_parquet('eurostat-electricity-prices.parquet'))
+  AND geo NOT IN ('EU27_2020', 'EA')
+ORDER BY eur_per_kwh DESC;
+-- Ireland 0.4042, Germany 0.3869, Belgium 0.3499, down to Turkey 0.0636.
+```
+
+A time series with real dates from the semester strings.
+
+```sql
+SELECT TIME_PERIOD,
+       make_date(CAST(TIME_PERIOD[1:4] AS INT),
+                 CASE WHEN TIME_PERIOD LIKE '%S1' THEN 1 ELSE 7 END, 1) AS period_start,
+       OBS_VALUE AS eur_per_kwh
+FROM read_parquet('eurostat-electricity-prices.parquet')
+WHERE geo = 'DE' AND nrg_cons = 'KWH2500-4999' AND tax = 'I_TAX'
+  AND currency = 'EUR'
+ORDER BY TIME_PERIOD;
+-- 38 semesters, 0.2025 in 2007-S1, peaking at 0.4125 in 2023-S1.
+```
+
+The tax ladder, what levies add.
+
+```sql
+SELECT tax, OBS_VALUE
+FROM read_parquet('eurostat-electricity-prices.parquet')
+WHERE geo = 'EU27_2020' AND TIME_PERIOD = '2025-S2'
+  AND nrg_cons = 'KWH2500-4999' AND currency = 'EUR'
+ORDER BY OBS_VALUE;
+-- X_TAX 0.2059, X_VAT 0.2456, I_TAX 0.2896, all matching Eurostat's
+-- published article to four decimals.
+```
+
+## Related Collections
+
+`reference/natural-earth-countries` is the geometry partner, join
+recipe in the README of this Collection. Sibling Eurostat tables
+outside this catalog, nrg_pc_205 for non-household prices and
+nrg_pc_204_c for price components, share the same dimension scheme.
+Converted from Eurostat's SDMX-CSV API output, a live endpoint, to
+Parquet with DuckDB on July 21, 2026.

--- a/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/README.md
+++ b/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/README.md
@@ -2,17 +2,24 @@
 
 Semi-annual electricity prices for household consumers across European countries by consumption band, tax component, and currency, Eurostat table nrg_pc_204. Non-geospatial companion table, join key is the country code column geo (NUTS-0), converted to cloud-native Parquet.
 
-License, CC-BY-4.0. Attribution, Source, Eurostat.
-Providers, Eurostat (producer, licensor), Portolan SDI (host).
-Original source, https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false .
-Rows, 65412.
-Columns, 13.
-Non-geospatial table, spatial requirements relaxed. The bounding box is the area of interest the data pertains to, [-31.5, 34.0, 46.5, 71.5], not a geometry footprint.
-Note, the upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.
+What households pay for electricity across Europe, semester by
+semester since 2007. This is Eurostat table
+[nrg_pc_204](https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_204/default/table),
+65,412 observations covering 41 countries and territories plus the
+EU27 and euro area aggregates, collected under
+[Regulation (EU) 2016/1952](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32016R1952)
+as consumption-weighted national average prices per six-month period.
+New semesters land each April and October, and Eurostat's own
+[price statistics article](https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics)
+is written from this table. It is the official record of the 2022
+energy crisis, Germany's all-tax price for a typical household rose
+from 0.33 to a 0.41 euro per kilowatt-hour peak in the first half of
+2023.
 
-## Open the data
+Agents, [AGENTS.md](./AGENTS.md) decodes every dimension and carries
+the aggregate-row trap.
 
-The `data` asset is Parquet. Open it with pandas.
+## Quick Start
 
 ```python
 import pandas as pd
@@ -21,25 +28,78 @@ df = pd.read_parquet("eurostat-electricity-prices.parquet")
 print(df.head())
 ```
 
-Or query it in place with DuckDB.
+The `data` asset is plain Parquet, so pandas, DuckDB, and Polars all read it directly. Paths are relative to this directory, and the same code works against the published URL.
 
-```sql
-SELECT * FROM read_parquet('eurostat-electricity-prices.parquet') LIMIT 5;
-```
+## Reading a Price Correctly
 
-## Join to geometry
+Every price is qualified by four dimensions, and comparisons only mean
+something within a fixed combination. The band, how much the household
+consumes per year, where KWH2500-4999 is the band Eurostat headlines.
+The tax level, X_TAX before taxes, X_VAT before VAT, I_TAX what a
+household actually pays. The currency, where EUR is nominal, NAC is
+national currency, and PPS adjusts for price levels, Bulgaria's 2025-S2
+price is 0.14 EUR but 0.22 PPS, and the gap is the point. And the
+semester string, 2025-S2 meaning July to December 2025.
 
-This table carries no geometry. Join it to `reference/natural-earth-countries` to map it.
+## Schema
 
-- This table's join column, `geo`.
-- Geometry collection, `reference/natural-earth-countries`, join column `ISO_A2`.
+| Column | Type | Description |
+|---|---|---|
+| `DATAFLOW` | varchar | Eurostat dataflow identifier, the constant ESTAT nrg_pc_204 version 1.0. |
+| `LAST UPDATE` | timestamp | Frozen at one 2019 timestamp for every row of this snapshot while the data runs to 2025. Unreliable, do not derive freshness from it. |
+| `freq` | varchar | Observation frequency, the constant S for semi-annual. S1 is January to June, S2 is July to December. |
+| `siec` | varchar | Energy product code, the constant E7000 for electricity. |
+| `nrg_cons` | varchar | Annual consumption band. KWH_LT1000, KWH1000-2499, KWH2500-4999 the headline household band, KWH5000-14999, KWH_GE15000, and TOT_KWH the weighted all-band average that exists only from 2017-S2. |
+| `unit` | varchar | Unit of measure, the constant KWH. Prices are per kilowatt-hour. |
+| `tax` | varchar | Tax level. X_TAX excludes all taxes and levies, X_VAT excludes VAT and recoverable taxes, I_TAX includes everything a household pays. |
+| `currency` | varchar | EUR, NAC for national currency, or PPS purchasing power standard. NAC equals EUR in the euro area. |
+| `geo` | varchar | Reporting country as a Eurostat NUTS-0 code, ISO 3166-1 alpha-2 except EL for Greece and UK for the United Kingdom, plus the aggregates EU27_2020 and EA. The join key to a geometry Collection. |
+| `TIME_PERIOD` | varchar | Reference semester as a string, 2025-S2. Fixed format, so string ordering and MAX work. |
+| `OBS_VALUE` | double | The observed electricity price in the stated currency per kilowatt-hour. |
+| `OBS_FLAG` | varchar | Observation status, e estimated, p provisional, d definition differs, null for 98 percent of rows. |
+| `CONF_STATUS` | varchar | Confidentiality status, entirely null in this snapshot. |
 
-Eurostat uses NUTS-0 country codes, which match ISO 3166-1 alpha-2 for most countries but not all. Greece is EL rather than GR and the United Kingdom is UK rather than GB, so remap those two before joining if you need them.
+The same descriptions live in `table:columns` on the `data` asset, so tools that read STAC see them too.
+
+## Join to Geometry
+
+This table carries no geometry. The `geo` codes join to the Natural
+Earth countries Collection in this catalog on `ISO_A2_EH`, after
+remapping Eurostat's two non-ISO codes. Greece is EL and the United
+Kingdom is UK. The raw ISO_A2 column would silently drop France,
+Norway, and Kosovo, Natural Earth stores -99 there.
 
 ```sql
 INSTALL spatial; LOAD spatial;
-SELECT t.*, g.geom
-FROM read_parquet('eurostat-electricity-prices.parquet') t
-JOIN read_parquet('../../reference/natural-earth-countries/natural-earth-countries.parquet') g
-  ON t."geo" = g."ISO_A2";
+SELECT n.NAME, e.OBS_VALUE AS eur_per_kwh, n.geom
+FROM read_parquet('eurostat-electricity-prices.parquet') e
+JOIN read_parquet('../../reference/natural-earth-countries/natural-earth-countries.parquet') n
+  ON (CASE e.geo WHEN 'EL' THEN 'GR' WHEN 'UK' THEN 'GB' ELSE e.geo END) = n.ISO_A2_EH
+WHERE e.TIME_PERIOD = '2025-S2' AND e.nrg_cons = 'KWH2500-4999'
+  AND e.tax = 'I_TAX' AND e.currency = 'EUR'
+ORDER BY eur_per_kwh DESC;
 ```
+
+Malta and Liechtenstein stay unmatched, the 1:110m basemap has no
+polygon for them, and the EU27_2020 and EA aggregates have no
+geometry by nature.
+
+## Limitations
+
+These are averages over suppliers and six months, not offers, Eurostat
+itself notes there is no single price for electricity. One number per
+country per semester, nothing sub-national. Values from the second
+half of 2021 onward embed government subsidies and caps, so 2022 to
+2024 understate underlying costs in heavily supported countries, and
+Romania's 59 percent jump in late 2025 is a cap ending, not a market
+shock. Data before 2007 lives in a separate, methodologically
+incompatible table, never splice them.
+
+## Provenance and License
+
+License, CC-BY-4.0. Attribution, Source, Eurostat.
+Providers, Eurostat (producer, licensor), Portolan SDI (host).
+Original source, https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false .
+Rows, 65,412. Columns, 13. Cloud-native asset, eurostat-electricity-prices.parquet (Parquet).
+Non-geospatial table, the bounding box is the area of interest the data pertains to, [-31.5, 34.0, 46.5, 71.5].
+The upstream source is a live endpoint, so it is referenced by URL only and not archived as a source asset.

--- a/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
+++ b/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
@@ -70,67 +70,67 @@
         {
           "name": "DATAFLOW",
           "type": "varchar",
-          "description": "Eurostat dataflow identifier, agency, table code, and version."
+          "description": "Eurostat dataflow identifier, the constant ESTAT nrg_pc_204 version 1.0."
         },
         {
           "name": "LAST UPDATE",
           "type": "timestamp",
-          "description": "Timestamp of the last update Eurostat published for this table."
+          "description": "Frozen at one 2019 timestamp for every row of this snapshot while the data runs to 2025. Unreliable, do not derive freshness from it."
         },
         {
           "name": "freq",
           "type": "varchar",
-          "description": "Observation frequency. S is semi-annual."
+          "description": "Observation frequency, the constant S for semi-annual. S1 is January to June, S2 is July to December."
         },
         {
           "name": "siec",
           "type": "varchar",
-          "description": "Standard International Energy Product Classification code for the energy carrier, here electricity."
+          "description": "Energy product code, the constant E7000 for electricity."
         },
         {
           "name": "nrg_cons",
           "type": "varchar",
-          "description": "Annual household electricity consumption band the price applies to."
+          "description": "Annual consumption band. KWH_LT1000, KWH1000-2499, KWH2500-4999 the headline household band, KWH5000-14999, KWH_GE15000, and TOT_KWH the weighted all-band average that exists only from 2017-S2."
         },
         {
           "name": "unit",
           "type": "varchar",
-          "description": "Unit of measure for the observed value, for example kilowatt hour."
+          "description": "Unit of measure, the constant KWH. Prices are per kilowatt-hour."
         },
         {
           "name": "tax",
           "type": "varchar",
-          "description": "Tax and levy component, which taxes the quoted price includes or excludes."
+          "description": "Tax level. X_TAX excludes all taxes and levies, X_VAT excludes VAT and recoverable taxes, I_TAX includes everything a household pays."
         },
         {
           "name": "currency",
           "type": "varchar",
-          "description": "Currency of the observed value, euro, national currency, or purchasing power standard."
+          "description": "EUR, NAC for national currency, or PPS purchasing power standard. NAC equals EUR in the euro area."
         },
         {
           "name": "geo",
           "type": "varchar",
-          "description": "Reporting country as a Eurostat NUTS-0 code. This is the join key to a geometry Collection."
+          "description": "Reporting country as a Eurostat NUTS-0 code, ISO 3166-1 alpha-2 except EL for Greece and UK for the United Kingdom, plus the aggregates EU27_2020 and EA. The join key to a geometry Collection."
         },
         {
           "name": "TIME_PERIOD",
           "type": "varchar",
-          "description": "Reference period, year and semester."
+          "description": "Reference semester as a string, 2025-S2. Fixed format, so string ordering and MAX work."
         },
         {
           "name": "OBS_VALUE",
           "type": "double",
-          "description": "The observed electricity price in the stated unit and currency."
+          "description": "The observed electricity price in the stated currency per kilowatt-hour."
         },
         {
           "name": "OBS_FLAG",
           "type": "varchar",
-          "description": "Observation status flag, for example p provisional, e estimated, d definition differs."
+          "description": "Observation status, e estimated, p provisional, d definition differs, null for 98 percent of rows."
         },
         {
           "name": "CONF_STATUS",
           "type": "varchar",
-          "description": "Confidentiality status of the observation."
+          "description": "Confidentiality status, entirely null in this snapshot."
         }
       ],
       "table:row_count": 65412

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -94,6 +94,41 @@ catalogs:
     description: >-
       Non-geospatial companion tables published as Parquet.
 
+# Root catalog documentation. Like the per-collection docs, markdown templates
+# with generated blocks, {{collections}}, {{sources}}, and {{agents_index}}.
+docs:
+  readme: |
+    Every Collection here is a mirror that cites its true upstream source
+    with a real checksum, and every README and AGENTS.md is written to the
+    standard in the spec's documentation best practices, so the catalog
+    doubles as the worked example of what good catalog documentation looks
+    like. The Netherlands provinces Collection also mirrors its upstream ISO
+    19115 record as a metadata-role asset, and every code block in these
+    docs is executed by the repository's checks before it publishes.
+
+    Agents, each Collection carries its own AGENTS.md with join keys, quirks,
+    and tested queries, and the catalog-level [AGENTS.md](./AGENTS.md) maps
+    the joins between Collections.
+
+    ## Collections
+
+    {{collections}}
+
+    ## Where the Data Comes From
+
+    {{sources}}
+  agents: |
+    Eight small Collections, each with its own AGENTS.md worth reading before
+    querying it. Two attribute joins connect them. The Eurostat electricity
+    prices table joins Natural Earth countries on ISO_A2_EH after remapping
+    Eurostat's EL to GR and UK to GB. Natural Earth populated places join
+    Natural Earth countries on ADM0_A3 after remapping SSD to SDS for South
+    Sudan. Everything else connects only spatially, and the boundary layers
+    differ hugely in scale, from 1:110m world polygons to Boston parcels, so
+    match scales before spatial joins.
+
+    {{agents_index}}
+
 collections:
   # ---------------------------------------------------------------- reference/
   - id: reference/natural-earth-countries
@@ -117,7 +152,9 @@ collections:
     provenance:
       via: https://www.naturalearthdata.com/downloads/110m-cultural-vectors/
       updated: "2026-07-16T00:00:00Z"
-    temporal: ["2025-01-01T00:00:00Z", null]
+    # Data vintage, the 5.1.1 release of May 12, 2022, per the upstream
+    # CHANGELOG. Attribute vintages inside are mostly 2019.
+    temporal: ["2022-05-12T00:00:00Z", null]
     # No PMTiles on purpose. At 281 KB this GeoParquet is small enough for a client
     # to draw directly, which is the render-from-source path core.md offers
     # alongside a visualization derivative. Keeping it derivative-free is what
@@ -126,6 +163,169 @@ collections:
     derivatives: {pmtiles: false, thumbnail: true}
     # Colour the world by continent so the preview reads as a map, not one blob.
     style: {color: "#4d7ea8", category_field: CONTINENT, variants: [categorical]}
+    blurb: >-
+      177 country polygons at world scale, the public domain basemap behind
+      most web choropleths.
+    columns:
+      ADM0_A3: Natural Earth's own three-letter country code. Never a sentinel value, and the join key to the populated places Collection.
+      ISO_A3: ISO 3166-1 alpha-3 code, with the sentinel -99 for France, Norway, Kosovo, Northern Cyprus, and Somaliland. Prefer ISO_A3_EH.
+      ISO_A3_EH: ISO alpha-3 with France and Norway repaired. The column to join external ISO-coded statistics on.
+      ISO_A2: ISO 3166-1 alpha-2 code, -99 for the same five countries as ISO_A3.
+      ISO_A2_EH: ISO alpha-2 with France, Norway, and Kosovo (XK) repaired.
+      NAME: Short map label, for example Dem. Rep. Congo.
+      NAME_LONG: Long-form name, for example Democratic Republic of the Congo. Differs from NAME on 21 rows.
+      SOVEREIGNT: The owning sovereign state, which differs from ADMIN for territories such as Greenland (Denmark).
+      TYPE: Unit type, Sovereign country, Country, Dependency, Disputed, Indeterminate, or Sovereignty.
+      CONTINENT: Continent rollup. Includes the value Seven seas (open ocean), so a GROUP BY returns eight groups.
+      REGION_UN: United Nations macro region.
+      SUBREGION: United Nations subregion.
+      POP_EST: Population estimate, mostly the 2019 vintage. See POP_YEAR.
+      POP_YEAR: Year the population estimate refers to.
+      GDP_MD: GDP in millions of US dollars, mostly the 2019 vintage. See GDP_YEAR.
+      GDP_YEAR: Year the GDP figure refers to.
+      LABEL_X: Longitude of the preferred label point.
+      LABEL_Y: Latitude of the preferred label point.
+      NE_ID: Stable Natural Earth feature id, unique in this file.
+      WIKIDATAID: Wikidata QID, present on all 177 rows.
+      geom: Country geometry, polygon or multipolygon, WGS84 longitude and latitude.
+      bbox: Per-feature bounding box struct, the GeoParquet covering used for spatial predicate pushdown.
+    docs:
+      readme: |
+        [Natural Earth](https://www.naturalearthdata.com) is the public domain
+        reference map dataset that Nathaniel Vaughn Kelso and Tom Patterson
+        started in 2009 and maintain with volunteer cartographers under
+        [NACIS](https://nacis.org). This collection carries its 1:110m countries
+        theme, version 5.1.1 from May 2022, and holds 177 country polygons with
+        171 attribute columns of names in 26 languages, ISO codes, population
+        and GDP estimates from 2019, and cartographic styling hints. It is the
+        geometry behind [world-atlas](https://github.com/topojson/world-atlas)
+        and with that most of the world choropleths on the web.
+
+        Boundaries follow Natural Earth's
+        [de facto policy](https://www.naturalearthdata.com/about/disputed-boundaries-policy/),
+        showing who controls territory rather than legal claims, so Somaliland
+        and Northern Cyprus appear as their own rows. The 34 FCLASS point-of-view
+        columns added in December 2021 let a map follow a specific national
+        worldview instead.
+
+        Agents, read [AGENTS.md](./AGENTS.md) first. It carries the join keys,
+        the sentinel-value traps, and tested queries.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Schema, the Columns That Matter
+
+        Twenty-two of the 171 columns do most of the work.
+
+        {{schema}}
+
+        ## Join Statistics to Geometry
+
+        The reason this Collection is in the catalog. Any table keyed by ISO
+        country code joins here for mapping, like the Eurostat electricity
+        prices table two directories over. Join on `ISO_A2_EH` or `ISO_A3_EH`,
+        not the raw ISO columns, which hold -99 for France and Norway.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT n.NAME, e.OBS_VALUE AS eur_per_kwh, n.geom
+        FROM read_parquet('../../tabular/eurostat-electricity-prices/eurostat-electricity-prices.parquet') e
+        JOIN read_parquet('natural-earth-countries.parquet') n
+          ON (CASE e.geo WHEN 'EL' THEN 'GR' WHEN 'UK' THEN 'GB' ELSE e.geo END) = n.ISO_A2_EH
+        WHERE e.TIME_PERIOD = '2025-S2' AND e.nrg_cons = 'KWH2500-4999'
+          AND e.tax = 'I_TAX' AND e.currency = 'EUR';
+        ```
+
+        ## Suggested Uses
+
+        Choropleths of ISO-coded statistics, continent and region rollups, and
+        quick spatial-query demos. The `MAPCOLOR7` through `MAPCOLOR13` columns
+        assign map colors so neighboring countries differ, and `LABEL_X` and
+        `LABEL_Y` carry hand-placed label points, both there for basemap
+        rendering.
+
+        ## Limitations
+
+        Not authoritative for legal boundaries. Natural Earth draws de facto
+        control, so Crimea, Kashmir, and Western Sahara follow the situation on
+        the ground, not treaties. Not measurement geometry either. At 1:110m a
+        coastline is simplified by tens of kilometres, and 43 small countries
+        and territories, from Andorra and Malta to Singapore and the Vatican,
+        have no polygon at all. Population and GDP are 2019 estimates. Upstream
+        publishes no formal accuracy figures, and the last cultural release was
+        in May 2022.
+
+        {{provenance}}
+      agents: |
+        World country polygons for joins and rollups, not for legal boundaries
+        or precise areas. The stable key is `ADM0_A3`. External statistics join
+        on `ISO_A3_EH` or `ISO_A2_EH`. The raw `ISO_A3` and `ISO_A2` columns
+        hold the sentinel -99 for France, Norway, Kosovo, Northern Cyprus, and
+        Somaliland, so a filter like ISO_A3 = 'FRA' matches nothing.
+
+        {{access}}
+
+        ## Quirks
+
+        - -99 is the global no-data sentinel, in the ISO columns and in numeric
+          columns like TINY and MAPCOLOR13. Check for it before trusting a value.
+        - France includes French Guiana as one row, so its bbox spans from
+          South America to Europe and bbox filters on South America catch France.
+        - South Sudan is `SDS` here but `SSD` in the populated places file. An
+          `ADM0_A3` join between the two layers drops it unless you remap.
+        - Antarctica is a country row with population 4,490, and the continent
+          column also holds Seven seas (open ocean) for the French Southern and
+          Antarctic Lands.
+        - Russia and Fiji cross the antimeridian, so their bboxes span the full
+          longitude range and naive bbox-width logic breaks.
+
+        ## CRS, Degrees In, Degrees Out
+
+        EPSG:4326, longitude and latitude in degrees. `ST_Area(geom)` returns
+        square degrees, which makes Greenland read nearly as large as Brazil.
+        For real areas use the spheroid function, and flip coordinates first
+        because DuckDB's geodesic functions expect latitude first.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT NAME, round(ST_Area_Spheroid(ST_FlipCoordinates(geom)) / 1e6) AS km2
+        FROM read_parquet('natural-earth-countries.parquet')
+        ORDER BY km2 DESC LIMIT 5;
+        -- Russia 17,018,507 then Antarctica, Canada, United States, China.
+        -- Without the flip, Brazil returns 5.2M km2 instead of 8.5M and 33
+        -- countries return NaN.
+        ```
+
+        ## Tested Queries
+
+        Population by continent.
+
+        ```sql
+        SELECT CONTINENT, count(*) AS countries, sum(POP_EST)::BIGINT AS pop
+        FROM read_parquet('natural-earth-countries.parquet')
+        GROUP BY CONTINENT ORDER BY pop DESC;
+        -- Asia 4.55B across 47 rows, Africa 1.31B across 51, eight groups in all.
+        ```
+
+        Which country contains a point.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT NAME, ADM0_A3
+        FROM read_parquet('natural-earth-countries.parquet')
+        WHERE ST_Contains(geom, ST_Point(13.405, 52.52));
+        -- Germany, DEU. ST_Point takes longitude first.
+        ```
+
+        ## Related Collections
+
+        `reference/natural-earth-populated-places` joins on `ADM0_A3` with the
+        South Sudan remap above. `tabular/eurostat-electricity-prices` joins on
+        `ISO_A2_EH` after remapping Eurostat's EL and UK codes, the worked
+        example lives in that Collection's README. Converted from the upstream
+        zipped Shapefile with DuckDB spatial into web-optimized GeoParquet 2.0.
 
   - id: reference/natural-earth-populated-places
     kind: vector
@@ -148,11 +348,148 @@ collections:
     provenance:
       via: https://www.naturalearthdata.com/downloads/50m-cultural-vectors/
       updated: "2026-07-16T00:00:00Z"
-    temporal: ["2025-01-01T00:00:00Z", null]
+    # Data vintage, the 5.1.2 release of May 13, 2022, per the upstream
+    # CHANGELOG.
+    temporal: ["2022-05-13T00:00:00Z", null]
     # No PMTiles on purpose, same render-from-source reasoning as the countries
     # Collection above. 604 KB of points a client can draw itself.
     derivatives: {pmtiles: false, thumbnail: true}
     style: {color: "#c65b3c"}
+    blurb: >-
+      1,251 curated city and town points with population estimates, from Tokyo
+      to Antarctic research stations.
+    columns:
+      NAME: Display name with diacritics, for example Neuquén. Not unique, several city names repeat across countries.
+      NAMEASCII: ASCII fallback spelling of the name.
+      FEATURECLA: What kind of place this is. Admin-0 capital, Admin-1 capital, Populated place, Scientific station, and four rarer classes.
+      ADM0CAP: 1 marks a national capital, 200 rows in this file.
+      ADM0_A3: Natural Earth country code, the join key to the countries Collection.
+      ADM0NAME: Country name the point belongs to.
+      ADM1NAME: First-level admin region the point belongs to.
+      POP_MAX: Population of the metro area, LandScan derived. Tokyo carries 35,676,000.
+      POP_MIN: Population of the city proper. Tokyo carries 8,336,599.
+      SCALERANK: Importance rank 0 to 10, 0 most important. Filter on it to thin labels by zoom.
+      MIN_ZOOM: Suggested minimum web-map zoom for showing the place.
+      MEGACITY: 1 flags the 462 places Natural Earth treats as megacities.
+      WORLDCITY: 1 flags 70 globally prominent cities.
+      TIMEZONE: IANA time zone name, empty for 114 rows.
+      NE_ID: Stable Natural Earth feature id, unique in this file.
+      WIKIDATAID: Wikidata QID, missing for 7 rows.
+      GEONAMESID: GeoNames id, missing for 43 rows.
+      geom: Point geometry, WGS84 longitude and latitude. Use it instead of the legacy LATITUDE and LONGITUDE columns.
+      bbox: Per-feature bounding box struct, the GeoParquet covering.
+    docs:
+      readme: |
+        City and town points at 1:50m scale from
+        [Natural Earth](https://www.naturalearthdata.com), version 5.1.2 from
+        May 2022. The 1,251 points cover every national and most first-level
+        capitals, major cities, and, in Natural Earth's own words, a sampling
+        of smaller towns in sparsely inhabited regions, favoring regional
+        significance over population census. LandScan-derived population
+        estimates cover about 90 percent of the places.
+
+        Agents, read [AGENTS.md](./AGENTS.md) first, especially before joining
+        these points to country polygons.
+
+        ## What Counts as a Place
+
+        The `FEATURECLA` column answers it. 482 Admin-1 capitals, 414 plain
+        populated places, 202 national capitals, and some surprises, 40
+        Antarctic research stations including Amundsen-Scott at exactly 90
+        degrees south, 13 alternate capitals such as The Hague and Lagos, and
+        one historic place, the abandoned Siberian port of Ambarchik with
+        population zero. Filter on it before counting cities.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Sizing and Filtering Labels
+
+        The cartographic columns are the point of this theme. Natural Earth's
+        guidance is to size labels from `POP_MAX` and thin them with the scale
+        rankings, and `MIN_ZOOM` maps that to web-map zoom levels directly.
+
+        ```sql
+        SELECT NAME, POP_MAX, SCALERANK
+        FROM read_parquet('natural-earth-populated-places.parquet')
+        WHERE SCALERANK = 0
+        ORDER BY POP_MAX DESC LIMIT 5;
+        ```
+
+        ## Schema, the Columns That Matter
+
+        Nineteen of the 140 columns cover most uses.
+
+        {{schema}}
+
+        ## Limitations
+
+        A curated cartographic layer, not a gazetteer and not a demographic
+        dataset. Absence means Natural Earth chose not to include a town, not
+        that it does not exist, and the population figures are 2019-era
+        estimates for label sizing, not census data. `POP_MAX` counts the
+        metro area and `POP_MIN` the city proper, so ranking cities without
+        picking one deliberately mixes definitions. Names repeat, Mérida,
+        Portland, and Valencia each appear twice, so use `NE_ID` as the key.
+
+        {{provenance}}
+      agents: |
+        Curated world city points that join to the countries Collection on
+        `ADM0_A3`. Join by attribute, never spatially. 113 of the 1,251 points,
+        Istanbul, Montevideo, and Geneva among them, fall outside their own
+        country's generalized 1:110m polygon because coastal simplification
+        pushes them offshore.
+
+        {{access}}
+
+        ## Quirks
+
+        - The United States capital is spelled with two spaces after the comma,
+          so NAME = 'Washington, D.C.' matches nothing. Use LIKE 'Washington%'
+          or ADM0CAP = 1 with ADM0_A3 = 'USA'.
+        - South Sudan is `SSD` here but `SDS` in the countries file. Remap one
+          side before joining, or Juba, Malakal, and Wau drop out.
+        - The legacy LATITUDE and LONGITUDE columns diverge from the geometry
+          by up to 0.22 degrees. They are old label anchors, read `geom`.
+        - The UN time series columns POP1950 through POP2050 are populated only
+          for the 463 UN-tracked agglomerations, zero elsewhere, and POP2050 is
+          a projection.
+        - 59 places carry POP_MAX below 1,000, mostly stations and outposts, so
+          population filters silently drop real capitals of small territories.
+
+        ## Tested Queries
+
+        Capitals per continent, with the country join done correctly.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT c.CONTINENT, count(*) AS capitals
+        FROM read_parquet('natural-earth-populated-places.parquet') p
+        JOIN read_parquet('../natural-earth-countries/natural-earth-countries.parquet') c
+          ON (CASE p.ADM0_A3 WHEN 'SSD' THEN 'SDS' ELSE p.ADM0_A3 END) = c.ADM0_A3
+        WHERE p.ADM0CAP = 1
+        GROUP BY c.CONTINENT ORDER BY capitals DESC;
+        -- Africa 52, Asia 45, Europe 39, then the Americas and Oceania.
+        ```
+
+        Nearest city to a point, distance in kilometres.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT NAME, ADM0NAME,
+               round(ST_Distance_Sphere(geom, ST_Point(-122.4783, 37.8199)) / 1000, 1) AS km
+        FROM read_parquet('natural-earth-populated-places.parquet')
+        ORDER BY km LIMIT 3;
+        -- San Francisco 9.0 km, San Jose 71.7 km, Sacramento 120.4 km.
+        ```
+
+        ## Related Collections
+
+        `reference/natural-earth-countries` is the polygon companion, same
+        producer and vintage family, joined on `ADM0_A3` with the South Sudan
+        remap. Converted from the upstream zipped Shapefile with DuckDB spatial
+        into web-optimized GeoParquet 2.0.
 
   # --------------------------------------------------------------- boundaries/
   - id: boundaries/us-counties
@@ -196,6 +533,176 @@ collections:
       category_field: STATE_NAME
       label_field: NAME
       variants: [categorical, labeled]
+    blurb: >-
+      All 3,235 county and equivalent boundaries as of January 1, 2023,
+      keyed by the FIPS codes that unlock US county statistics.
+    columns:
+      STATEFP: Two-digit state or territory FIPS code as a zero-padded string.
+      COUNTYFP: Three-digit county FIPS code, unique within its state.
+      COUNTYNS: Eight-digit ANSI (GNIS) code, the permanent identifier that survives FIPS reassignment.
+      GEOIDFQ: Fully qualified GEOID, 0500000US plus GEOID. Matches the GEO_ID column in data.census.gov downloads directly. Called AFFGEOID before the 2023 vintage.
+      GEOID: Five-digit STATEFP plus COUNTYFP concatenation, the standard join key for US county statistics. Keep it a string, integer casts strip the leading zero.
+      NAME: Base name only, for example Denver. 31 rows are named Washington, so never key on it.
+      NAMELSAD: Name with its legal or statistical description, for example St. Louis city. The display name.
+      STUSPS: Two-letter USPS state or territory abbreviation.
+      STATE_NAME: Full state or territory name.
+      LSAD: Legal or statistical area description code. Twelve kinds of county equivalent appear in this file.
+      ALAND: Land area in square meters, computed from the full-resolution legal boundary, not from this generalized geometry.
+      AWATER: Water area in square meters, including territorial water that lies outside the clipped shoreline geometry.
+      geom: County geometry clipped to the shoreline, NAD83 longitude and latitude.
+      bbox: Per-feature bounding box struct, the GeoParquet covering.
+    docs:
+      readme: |
+        Every county and county equivalent in the United States and its
+        territories, 3,235 polygons as of January 1, 2023, from the
+        [US Census Bureau's cartographic boundary files](https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html).
+        Cartographic boundary files are generalized from the authoritative
+        [TIGER/Line](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html)
+        database for thematic mapping, simplified to 1:500,000 and clipped to
+        the shoreline, so coastal counties look like the coastline rather than
+        extending into their legal water area. A new vintage ships every year.
+
+        The `GEOID` column is the five-digit county FIPS code that keys county
+        statistics across the US government, Census ACS and decennial tables,
+        BLS employment, CDC health data, USDA agriculture. That join is what
+        this Collection is for.
+
+        Agents, [AGENTS.md](./AGENTS.md) carries the FIPS join hazards, the
+        area-calculation trap, and tested queries.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Not Every County Is a County
+
+        The file holds 3,144 county equivalents in the 50 states and DC plus 91
+        in the territories, and the `LSAD` column tells them apart, 2,999
+        counties, 78 Puerto Rico municipios, 64 Louisiana parishes, 40
+        independent cities, Alaska's boroughs and census areas, and more.
+        Connecticut is the one to know about. In June 2022 the Census Bureau
+        [replaced its eight legacy counties](https://www.federalregister.gov/documents/2022/06/06/2022-12063/change-to-county-equivalents-in-the-state-of-connecticut)
+        with nine planning regions, so this file carries GEOIDs 09110 through
+        09190 and any dataset still keyed to 09001 through 09015 will not join.
+
+        ## Schema
+
+        {{schema}}
+
+        ## Join Census Data
+
+        `GEOIDFQ` equals the GEO_ID column of every table downloaded from
+        [data.census.gov](https://data.census.gov), so American Community
+        Survey data joins with no string surgery. The pattern, with the ACS
+        table read from a downloaded CSV.
+
+        ```
+        SELECT c.NAMELSAD, acs.estimate
+        FROM 'us-counties.parquet' c
+        JOIN 'acs_table.csv' acs ON acs.GEO_ID = c.GEOIDFQ
+        ```
+
+        ## Suggested Uses
+
+        County choropleths of any FIPS-keyed statistic, the same role the
+        Census files play behind the D3 ecosystem's
+        [us-atlas](https://github.com/topojson/us-atlas), state-level rollups
+        via `STATEFP`, and point-in-county lookups at city scale and coarser.
+
+        ## Limitations
+
+        The Census Bureau's own guidance rules out geographic analysis
+        including area or perimeter calculation, geocoding, and legal boundary
+        determination. Use `ALAND` and `AWATER` for areas, they come from the
+        full-resolution geography. At neighborhood zoom the generalized lines
+        visibly cut corners, and small offshore islands may be missing
+        entirely. Boundaries are the January 1, 2023 vintage, so data keyed to
+        other years can mismatch, Connecticut above all.
+
+        {{provenance}}
+      agents: |
+        County polygons whose value is the `GEOID` column, the five-digit FIPS
+        key to US county statistics. Join ACS and decennial downloads on
+        `GEOIDFQ` instead, it matches their GEO_ID column verbatim. `COUNTYNS`
+        is the identifier that survives FIPS changes across years.
+
+        {{access}}
+
+        ## Quirks
+
+        - GEOID is a zero-padded string. Cast it to integer and Alabama's 01001
+          becomes 1001, silently unjoining every state below FIPS 10. CSV
+          round-trips are the usual culprit.
+        - NAME is wildly ambiguous, 31 Washingtons, and independent cities
+          collide with the counties that share their name. Baltimore city is
+          24510, Baltimore County is 24005. The lowercase word city in NAMELSAD
+          is what marks an independent city.
+        - Connecticut has nine planning regions, GEOIDs 09110 to 09190, LSAD
+          PL, since the 2022 change. Datasets keyed to the old 09001 to 09015
+          match nothing here.
+        - Aleutians West Census Area crosses the antimeridian, so its stored
+          bbox spans nearly all longitudes and it passes almost every naive
+          bbox filter. Handle it before bbox-windowing the world.
+        - Geometry is clipped to shoreline but AWATER is not, so San
+          Francisco's polygon covers 122 km2 while ALAND plus AWATER is 601
+          km2. Offshore points in legal county water fall in no polygon.
+
+        ## Areas, the Wrong Way and the Right Way
+
+        Coordinates are NAD83 degrees, EPSG:4269, so `ST_Area` returns square
+        degrees and DuckDB's `ST_Area_Spheroid` returns NaN or wrong values on
+        several of these multipolygons. Trust `ALAND` and `AWATER`, or
+        transform to an equal-area CRS.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT NAMELSAD,
+               round(ST_Area(ST_Transform(geom, 'EPSG:4269', 'EPSG:5070', always_xy := true)) / 1e6, 1) AS km2,
+               round(ALAND / 1e6, 1) AS aland_km2
+        FROM read_parquet('us-counties.parquet') WHERE GEOID = '08031';
+        -- Denver County, 400.7 km2 from geometry, 396.5 km2 of official land.
+        ```
+
+        For web mapping, treating the NAD83 coordinates as WGS84 shifts
+        nothing visible at this generalization level.
+
+        ## Tested Queries
+
+        Counties per state.
+
+        ```sql
+        SELECT STUSPS, count(*) AS n
+        FROM read_parquet('us-counties.parquet')
+        GROUP BY STUSPS ORDER BY n DESC LIMIT 5;
+        -- Texas 254, Georgia 159, Virginia 133, Kentucky 120, Missouri 115.
+        ```
+
+        Which county contains a point, longitude first.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT GEOID, NAMELSAD, STUSPS
+        FROM read_parquet('us-counties.parquet')
+        WHERE ST_Contains(geom, ST_Point(-104.9903, 39.7392));
+        -- 08031, Denver County, CO.
+        ```
+
+        Cheap spatial windows from the bbox covering column.
+
+        ```sql
+        SELECT count(*) FROM read_parquet('us-counties.parquet')
+        WHERE bbox.xmin > -109.06 AND bbox.xmax < -102.04
+          AND bbox.ymin > 36.99 AND bbox.ymax < 41.01;
+        -- 62 of Colorado's 64 counties, two generalized bboxes nick the state line.
+        ```
+
+        ## Related Collections
+
+        No attribute join inside this catalog, the FIPS ecosystem lives
+        outside it. Spatial joins against `boundaries/boston-open-space` or the
+        Natural Earth layers work at matching scales. Converted from the
+        upstream zipped Shapefile with DuckDB spatial into web-optimized
+        GeoParquet 2.0.
 
   - id: boundaries/boston-open-space
     kind: vector
@@ -228,6 +735,182 @@ collections:
       label_field: SITE_NAME
       graduated_field: ACRES
       variants: [categorical, labeled, graduated]
+    blurb: >-
+      1,012 open space polygons of conservation and recreation interest,
+      regardless of ownership, from Franklin Park to community gardens.
+    columns:
+      SITE_NAME: Best-known or official site name. Multi-parcel sites carry Roman numeral suffixes, Stony Brook Reservation I and II.
+      OWNERSHIP: Fee owner where known. City of Boston, Commonwealth of Massachusetts, private owners, and agency abbreviations like BRA and BNAN.
+      PROTECTION: Slash-separated legal protection instruments. A97 is Article 97 of the Massachusetts Constitution, the strongest. Free text, match with LIKE.
+      TYPECODE: Numeric open space type 1 through 7. Disagrees with TypeLong on about 13 rows, treat TypeLong as closer to intent.
+      DISTRICT: Planning district per the city's open space plan, not the official neighborhood boundaries. Includes the non-spatial value Multi-District.
+      ACRES: Official area in acres of the open-space portion, the figure to use instead of computing geometry area.
+      ADDRESS: Street address if known, null for 589 rows.
+      ZonAgg: Aggregated zoning district, for example Open Space District.
+      TypeLong: Open space type as text, with minor spelling variants worth normalizing before grouping.
+      OS_Own_Jur: The entity holding the open-space rights. BPRD, DCR, the Boston Conservation Commission, or None.
+      OS_Mngmnt: Managing entity only when it differs from OS_Own_Jur. Null means the steward manages it, not missing data.
+      POS: Protected open space flag. X permanently protected, N not.
+      PA: Public access flag. X accessible, A by appointment, N no or unknown access.
+      ALT_NAME: Official, previous, or colloquial alternate names.
+      AgncyJuris: Agency of jurisdiction for government-owned unprotected sites. Sparsely populated by design.
+      ShapeSTAre: ArcGIS-computed area in square meters from the source State Plane geometry.
+      ShapeSTLen: ArcGIS-computed perimeter in meters.
+      geom: Site geometry, WGS84 longitude and latitude.
+      bbox: Per-feature bounding box struct, the GeoParquet covering.
+    docs:
+      readme: |
+        Every open space of conservation and recreation interest in Boston,
+        1,012 polygons and 7,356 acres, from Franklin Park's 392 acres down to
+        pocket gardens, maintained by the
+        [Boston Parks and Recreation Department](https://www.boston.gov/departments/parks-and-recreation)
+        and published on [Analyze Boston](https://data.boston.gov/dataset/open-space).
+        The layer's defining trait is in its official description, regardless
+        of ownership. City parks sit beside 214 privately owned sites, state
+        reservations, cemeteries, and 124 community gardens.
+
+        This inventory is the basis of the city's
+        [Open Space and Recreation Plan 2023-2029](https://www.boston.gov/departments/parks-and-recreation/updating-seven-year-open-space-plan),
+        which reports 7.1 acres of protected open space per 1,000 residents,
+        and every site in it triggers design review within 100 feet under
+        Boston's Municipal Ordinance 7-4.11.
+
+        Agents, [AGENTS.md](./AGENTS.md) documents the free-text traps in this
+        very real municipal data, read it before aggregating.
+
+        ## What Is in It
+
+        Six site types by acreage. Parkways, reservations, and beaches, 82
+        sites and 2,622 acres. Parks, playgrounds, and athletic fields, 361
+        sites and 2,559 acres. Cemeteries and burying grounds, 38 and 1,013.
+        Urban wilds and natural areas, 144 and 929. Malls, squares, and
+        plazas, 261 and 199. Community gardens, 124 sites and 32 acres.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Schema
+
+        {{schema}}
+
+        ## Protection and Access Are Columns, Not Assumptions
+
+        Being in this file does not mean a site is a public park. Cross the
+        two flag columns before any access or equity claim. `POS` says whether
+        a site is permanently protected, 450 sites and 5,015 acres are, mostly
+        under Article 97 of the Massachusetts Constitution, which requires a
+        two-thirds vote of the legislature to convert conservation land.
+        `PA` says whether the public can actually get in, 724 sites yes, 4 by
+        appointment only, and the rest unknown or no.
+
+        ```sql
+        SELECT SITE_NAME, ACRES, DISTRICT
+        FROM read_parquet('boston-open-space.parquet')
+        WHERE POS = 'X' AND PA = 'X'
+        ORDER BY ACRES DESC LIMIT 5;
+        ```
+
+        ## Limitations
+
+        A planning inventory, not a legal record. The city's own disclaimer
+        limits it to general planning, only deeds research and surveys settle
+        boundaries. It also is not a complete greenspace layer, street trees,
+        most schoolyards, and private yards are absent. This is a fixed
+        snapshot from July 2026 of a continuously edited layer, and it carries
+        no stable public identifier, so joins to later versions go through
+        `SITE_NAME` or space.
+
+        {{provenance}}
+      agents: |
+        Boston's official open space inventory, valuable and messy in the way
+        municipal GIS data actually is. No stable key, free-text code columns,
+        and sentinel strings. The quirks below are each verified against the
+        data and each prevents a silently wrong answer.
+
+        {{access}}
+
+        ## Quirks
+
+        - PROTECTION is a slash-separated free-text list with typos, Ch91 and
+          Ch 91, CATMit and CAT Mit. Match with LIKE '%A97%', never equality.
+          453 sites match A97, Article 97 constitutional protection.
+        - Null OS_Mngmnt means the steward in OS_Own_Jur manages the site
+          itself. It is a meaningful value, not missing data.
+        - Sentinel strings pollute several columns, None, NULL, n/a, and angle
+          bracket Null variants in OS_Own_Jur and AgncyJuris, plus one
+          lowercase South end in DISTRICT.
+        - TypeLong has spelling variants, an and for ampersand form and a
+          trailing-space form. Normalize with trim and replace before GROUP BY,
+          and expect TYPECODE to contradict it on about 13 rows.
+        - Nine real sites carry ACRES = 0, so WHERE ACRES > 0 drops them. Fall
+          back to geometry area for those.
+        - DISTRICT is the open space plan's districting, not official Boston
+          neighborhoods, and four large linear parks are assigned the literal
+          value Multi-District rather than a place.
+
+        ## Area, Use the ACRES Column
+
+        Geometry is WGS84 degrees, so `ST_Area` returns square degrees. The
+        official `ACRES` column matches geodesic geometry area to a median of
+        0.003 acres, use it. If you must compute, DuckDB's spheroid function
+        wants latitude first, and skipping the flip shrinks Boston by more
+        than half.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT round(sum(ST_Area_Spheroid(ST_FlipCoordinates(geom))) / 4046.8564) AS acres_flipped,
+               round(sum(ACRES)) AS acres_official
+        FROM read_parquet('boston-open-space.parquet');
+        -- 7374 from geometry against 7356 official. Without the flip, 3250.
+        ```
+
+        Eighteen sites disagree with their geometry by more than 10 percent,
+        documented cases like Condor Street Overlook where ACRES excludes
+        mudflats the polygon includes.
+
+        ## Tested Queries
+
+        Acreage by normalized type.
+
+        ```sql
+        SELECT trim(replace(TypeLong, ' and ', ' & ')) AS site_type,
+               count(*) AS sites, round(sum(ACRES), 1) AS acres
+        FROM read_parquet('boston-open-space.parquet')
+        WHERE TypeLong IS NOT NULL
+        GROUP BY site_type ORDER BY acres DESC;
+        -- Six types, led by Parkways, Reservations & Beaches at 2,621.6 acres.
+        ```
+
+        Which open space contains a point. Boston Common from its center.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT SITE_NAME, DISTRICT, ACRES
+        FROM read_parquet('boston-open-space.parquet')
+        WHERE ST_Contains(geom, ST_Point(-71.0656, 42.3550));
+        -- Boston Common, Back Bay/Beacon Hill, 45.7 acres.
+        ```
+
+        Protected share by district.
+
+        ```sql
+        SELECT DISTRICT, round(sum(ACRES), 1) AS total_acres,
+               round(sum(ACRES) FILTER (WHERE POS = 'X'), 1) AS protected_acres
+        FROM read_parquet('boston-open-space.parquet')
+        GROUP BY DISTRICT ORDER BY total_acres DESC LIMIT 3;
+        -- West Roxbury 1,215 total and 637 protected, then the Harbor Islands
+        -- and Roslindale.
+        ```
+
+        ## Related Collections
+
+        `boundaries/us-counties` contains Boston at a far coarser scale, and a
+        spatial join is the only bridge. The upstream layer on Analyze Boston
+        is continuously maintained and now carries columns this July 2026
+        snapshot predates, OS_ID, ZipCode, ParcelNumber, YearAcquired.
+        Converted from the city's Shapefile export with DuckDB spatial into
+        web-optimized GeoParquet 2.0.
 
   - id: boundaries/netherlands-provinces
     kind: vector
@@ -263,6 +946,171 @@ collections:
       category_field: naam
       label_field: naam
       variants: [categorical, labeled]
+    # The upstream ISO 19115 dataset record from the Nationaal Georegister,
+    # mirrored beside the data as a metadata-role asset. Mirrored rather than
+    # linked because GeoNetwork regenerates its XML, and a checksum pinned to
+    # bytes the catalog does not control rots, the live-endpoint rule again.
+    metadata:
+      url: https://www.nationaalgeoregister.nl/geonetwork/srv/api/records/208bc283-7c66-4ce7-8ad3-1cf3e8933fb5/formatters/xml
+      media_type: application/vnd.iso.19139+xml
+      title: ISO 19115 metadata record, BRK Bestuurlijke Gebieden (Nationaal Georegister)
+      standard: iso-19115
+    blurb: >-
+      The 12 provinces from the cadastral registry, boundaries that reproduce
+      the national statistics office's official areas to one decimal.
+    columns:
+      identificatie: Province identifier PV20 through PV31, PV plus the CBS province code. The join key to CBS StatLine regional tables.
+      naam: Official province name. Fryslân carries its official Frisian spelling, a filter on Friesland returns nothing.
+      code: Two-digit CBS province code as a string, 20 through 31. Joins to ligt_in_provincie_code in the source's municipality layer.
+      ligt_in_land_code: Country code, the constant 6030 for Nederland.
+      ligt_in_land_naam: Country name, the constant Nederland.
+      geom: Province geometry, multipolygon, in the Dutch national grid EPSG:28992 in meters.
+      bbox: Per-feature bounding box struct in RD New meters, the GeoParquet covering.
+    docs:
+      readme: |
+        [Kadaster](https://www.kadaster.nl), the Dutch cadastral agency,
+        derives the country's administrative division from the cadastral
+        registration and publishes it through
+        [PDOK](https://www.pdok.nl/introductie/-/article/bestuurlijke-gebieden),
+        the national open geodata platform, in an edition established every
+        January when municipal reorganizations take effect. This Collection
+        carries the 12 provinces of the 2026 edition, valid from January 1,
+        2026. PDOK names the layer as the base of public applications from
+        [atlasleefomgeving.nl](https://www.atlasleefomgeving.nl) to the
+        official bathing water site [zwemwater.nl](https://www.zwemwater.nl).
+
+        The geometry checks out against the national statistics office.
+        Computing `ST_Area` per province reproduces the official CBS surface
+        figures to one decimal, Utrecht 1,560.1 square kilometres against the
+        published 1,560.05.
+
+        Agents, [AGENTS.md](./AGENTS.md) has the CBS join recipe, the Baarle
+        enclave surprise, and the metric CRS consequences.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Machine-Readable Metadata
+
+        Beside the data sits `iso19115.xml`, the upstream ISO 19115 metadata
+        record for BRK Bestuurlijke Gebieden, mirrored on July 31, 2026 from
+        the [Nationaal Georegister](https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/208bc283-7c66-4ce7-8ad3-1cf3e8933fb5)
+        and carried as a metadata-role asset. Catalogs that already maintain
+        ISO metadata can ship it alongside the STAC this way instead of
+        abandoning it.
+
+        ## Schema
+
+        {{schema}}
+
+        ## Join the National Statistics
+
+        `identificatie` holds the CBS region codes PV20 through PV31, the same
+        keys every provincial table on
+        [CBS StatLine](https://opendata.cbs.nl) uses, which connects these 12
+        polygons to Dutch official statistics on population, income, land use,
+        and more. Trim the CBS side first, the classic OData API pads its keys
+        with trailing spaces.
+
+        ## Water Is Inside the Boundaries
+
+        The provinces sum to 41,543 square kilometres while the land surface
+        of the Netherlands is about 33,500. Administrative boundaries divide
+        the Wadden Sea, the IJsselmeer, and the delta waters among provinces,
+        so Fryslân is the largest province by total area and roughly 42
+        percent water. Rankings and densities computed from these polygons
+        answer the water-inclusive question unless you subtract water first,
+        CBS publishes the land-only figures.
+
+        ## Limitations
+
+        One annual snapshot, valid for January 1, 2026 only, and boundary
+        history needs the matching year's edition, PDOK keeps five. Derived
+        from the cadastre but not a substitute for it, parcel-level legal
+        questions belong to the BRK itself. The Caribbean Netherlands,
+        Bonaire, Sint Eustatius, and Saba, belongs to no province and is not
+        here.
+
+        {{provenance}}
+      agents: |
+        Dutch province polygons whose `identificatie` codes PV20 to PV31 join
+        CBS StatLine, the same code system all Dutch government data uses at
+        province level. The `code` column, bare 20 to 31, joins the
+        municipality layer of the same upstream GeoPackage on
+        ligt_in_provincie_code.
+
+        {{access}}
+
+        ## CRS, a Metric National Grid
+
+        EPSG:28992, Amersfoort / RD New, the Dutch national grid in meters,
+        valid only for the European Netherlands. `ST_Area(geom)` returns
+        square meters directly, divide by 1e6 for square kilometres, and the
+        results match CBS official figures to one decimal. Web maps need
+        `ST_Transform(geom, 'EPSG:28992', 'EPSG:4326', always_xy := true)`,
+        and without always_xy the axes come back flipped. Points must be
+        transformed into RD before ST_Contains. The bbox covering column is
+        also in RD meters, while the STAC extent in collection.json is WGS84.
+
+        ## Quirks
+
+        - Fryslân, not Friesland. The naam column uses official spellings with
+          diacritics.
+        - Noord-Brabant is a 9-part multipolygon with 22 holes, the Baarle
+          enclave complex on the Belgian border. Belgian exclaves are punched
+          out and 8 tiny Dutch counter-enclaves float inside them, so
+          one-province-one-polygon assumptions and small-area filters both
+          break.
+        - Provinces include their water. Fryslân is the largest by total area
+          and third by land.
+        - CBS OData v3 keys carry trailing spaces, PV20 with two spaces. Trim
+          before joining.
+        - fid order is arbitrary, Flevoland is 1 and Groningen is 11. Key on
+          code or identificatie.
+
+        ## Tested Queries
+
+        Areas that reproduce official statistics.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT naam, code, round(ST_Area(geom) / 1e6, 1) AS area_km2
+        FROM read_parquet('netherlands-provinces.parquet')
+        ORDER BY area_km2 DESC LIMIT 3;
+        -- Fryslân 5753.3, Gelderland 5136.3, Noord-Brabant 5082.1.
+        ```
+
+        Which province contains a point, in RD meters. Amsterdam.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT naam FROM read_parquet('netherlands-provinces.parquet')
+        WHERE ST_Contains(geom, ST_Point(121687, 487484));
+        -- Noord-Holland.
+        ```
+
+        The Baarle enclave forensic, parts of Noord-Brabant.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        WITH parts AS (
+          SELECT unnest(ST_Dump(geom)) AS d
+          FROM read_parquet('netherlands-provinces.parquet')
+          WHERE naam = 'Noord-Brabant')
+        SELECT count(*) AS parts, round(min(ST_Area(d.geom)) / 1e6, 4) AS smallest_km2
+        FROM parts;
+        -- 9 parts, the smallest 0.0029 km2. DuckDB has no ST_GeometryN, use unnest.
+        ```
+
+        ## Related Collections
+
+        The upstream GeoPackage also carries the 342 municipalities
+        (gemeentegebied) and the national outline (landgebied), joined on the
+        code columns above. Within this catalog the other boundary Collections
+        connect only spatially. Converted from PDOK's GeoPackage with DuckDB
+        spatial into web-optimized GeoParquet 2.0, preserving the source CRS.
+        The mirrored ISO 19115 record is the metadata asset beside the data.
 
   # ------------------------------------------------------------------- mirror/
   - id: mirror/san-francisco-addresses
@@ -291,6 +1139,176 @@ collections:
     temporal: ["2018-10-12T00:00:00Z", null]
     derivatives: {pmtiles: true, thumbnail: true}
     style: {color: "#6a1b9a"}
+    blurb: >-
+      A fixed 5,000-record extract of San Francisco's 388,550-record master
+      address database, kept small on purpose for spec demonstration.
+    columns:
+      eas_fullid: Unique row identifier, base id, sub id, and parcel link id joined with dashes. The only column unique per row.
+      eas_baseid: Identifier of the base address, the building. Units share it, so count distinct eas_baseid for buildings.
+      eas_subid: Identifier of the sub-address, a unit or apartment, within its base.
+      address: Full address string, with the unit as a hash suffix when present.
+      address_number: Street number.
+      address_number_suffix: Street number suffix such as A, null for nearly all rows.
+      street_name: Parsed street name.
+      street_type: Parsed street type, ST or AVE. Null for streets like BROADWAY that have no type.
+      street_full_street_name: Street name and type together.
+      unit_number: Unit designator, null on base-address rows.
+      zip_code: Five-digit ZIP code as a string.
+      block: Assessor block number as a string.
+      lot: Assessor lot number as a string.
+      parcel_number: Assessor parcel number, block plus lot. Null on 32 percent of rows, a parcel join drops them silently.
+      cnn: Centerline Network Number, the street-segment key of the city basemap, joins to the DataSF street centerlines.
+      longitude: Longitude as text. Prefer the geometry column.
+      latitude: Latitude as text. Prefer the geometry column.
+      supervisor: Supervisor district number as a string.
+      nhood: DataSF analysis neighborhood name, joins to the Analysis Neighborhoods dataset by name.
+      complete_landmark_name: Landmark name for the few rows that carry one, Millennium Tower.
+      direct_source: Where the record entered the EAS, SF DBI, State of CA, or The Presidio Trust.
+      data_as_of: Snapshot timestamp of the upstream export, July 24, 2026 for every row here.
+      data_updated_at: Record update timestamp, with a 1970 epoch sentinel on never-updated rows.
+      data_loaded_at: When the portal loaded the record.
+      geom: Address point, WGS84 longitude and latitude. Units stack on their building's single point.
+      bbox: Per-feature bounding box struct, the GeoParquet covering.
+    docs:
+      readme: |
+        Five thousand records from the
+        [Enterprise Addressing System](https://data.sfgov.org/Geographic-Locations-and-Boundaries/Addresses-with-Units-Enterprise-Addressing-System/ramy-di5m),
+        San Francisco's master address database. Read this first, the full
+        layer holds 388,550 records and refreshes nightly, and this Collection
+        is deliberately a fixed 1.3 percent extract, the first 5,000 records
+        in the portal's internal order from the July 24, 2026 snapshot. It
+        exists to demonstrate the Portolan mirror pattern against a live
+        upstream at a size that keeps this reference catalog small. Query it
+        to learn the data's shape, then take real questions to the full layer.
+
+        The EAS is the city's operational address registry, aggregated from
+        the Department of Building Inspection, Planning, the Assessor's
+        Office, and the Department of Technology, and only DBI-approved
+        addresses enter it. Its rows have a grain worth understanding before
+        counting anything. One row is a base address, a unit, and a parcel
+        link, so a building appears once per unit and once per linked condo
+        parcel. The extract holds 4,488 distinct buildings under its 5,000
+        rows.
+
+        Agents, [AGENTS.md](./AGENTS.md) carries the row-grain rules and the
+        sentinel-value traps.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Getting the Real Thing
+
+        The full live layer is one request away, the Socrata API serves it as
+        GeoJSON, CSV, or JSON pages.
+
+        ```bash
+        curl 'https://data.sfgov.org/resource/ramy-di5m.json?$select=count(*)'
+        # 388550 as of July 2026
+        ```
+
+        ## Schema
+
+        {{schema}}
+
+        ## Suggested Uses
+
+        Demonstrating and testing address-data patterns, base-versus-unit
+        modeling, parcel joins on `parcel_number` to DataSF's parcels layer,
+        neighborhood rollups on `nhood`, at a size where every query is
+        instant. The upstream EAS itself feeds DBI permitting and the
+        Planning Department's Property Information Map.
+
+        ## Limitations
+
+        Wrong for any question about San Francisco itself. Geocoding against
+        it misses about 98.7 percent of the city's addresses, per-area counts
+        reflect sample order rather than density, and the snapshot ages while
+        upstream changes nightly. Points sit at building entrances, not
+        parcel centroids, and a third of rows carry no parcel link at all.
+        Presence of a unit record says nothing about occupancy or mail
+        deliverability.
+
+        {{provenance}}
+      agents: |
+        A fixed 5,000-row extract of a 388,550-row live address layer. Two
+        rules prevent most wrong answers. Never extrapolate counts or
+        densities from this sample to San Francisco. Never count rows when
+        you mean addresses, one row is a base address, a unit, and a parcel
+        link, so `count(*)` is 5,000 while distinct buildings are 4,488.
+
+        {{access}}
+
+        ## Quirks
+
+        - 327 Fulton St appears 18 times, identical address, 18 condo parcel
+          links. Count buildings with count(DISTINCT eas_baseid) and
+          addresses with count(DISTINCT eas_subid).
+        - Units carry their building's single point, every eas_baseid has
+          exactly one distinct geometry. Deduplicate by base before density
+          maps or clustering.
+        - parcel_number is null on 1,596 rows, mostly records sourced from
+          the State of CA, so a parcel join silently drops a third of the
+          extract.
+        - data_updated_at holds the epoch sentinel 1970-01-01 on 2,378 rows,
+          meaning never updated, not 1970. Filter before temporal analysis.
+        - Nearly every column is text, including latitude, longitude,
+          supervisor, and zip_code. Cast before arithmetic, and read
+          coordinates from geom instead.
+        - numbertext spells out the supervisor district, not the address
+          number, and supname holds the 2026 incumbents, which dates the
+          snapshot.
+
+        ## CRS
+
+        EPSG:4326 degrees, so ST_Distance returns degrees. Use
+        ST_Distance_Sphere for meters, or transform to EPSG:26910 for planar
+        work.
+
+        ## Tested Queries
+
+        The grain, records against buildings against units.
+
+        ```sql
+        SELECT count(*) AS record_count,
+               count(DISTINCT eas_baseid) AS buildings,
+               count(*) FILTER (unit_number IS NOT NULL) AS unit_records
+        FROM read_parquet('san-francisco-addresses.parquet');
+        -- 5000, 4488, 2060.
+        ```
+
+        Addresses within 250 meters of a point, metric distance done right.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT address,
+               round(ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237))) AS meters
+        FROM read_parquet('san-francisco-addresses.parquet')
+        WHERE ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237)) < 250
+        ORDER BY meters LIMIT 5;
+        -- 512 Van Ness Ave #415 at 104 meters leads.
+        ```
+
+        Buildings with the most sampled units.
+
+        ```sql
+        SELECT any_value(address_number) AS num,
+               any_value(street_full_street_name) AS street,
+               count(DISTINCT unit_number) AS units
+        FROM read_parquet('san-francisco-addresses.parquet')
+        WHERE unit_number IS NOT NULL
+        GROUP BY eas_baseid ORDER BY units DESC LIMIT 3;
+        -- 1000 Pine St with 17 sampled units, 601 Van Ness Ave with 11.
+        ```
+
+        ## Related Collections
+
+        Nothing joins inside this catalog, the EAS keys point outward.
+        parcel_number joins DataSF's Parcels layer on blklot, cnn joins the
+        street centerlines, nhood joins Analysis Neighborhoods by name. The
+        upstream is a live Socrata endpoint, referenced by URL only. This
+        extract was converted to GeoParquet 2.0 with DuckDB spatial and dates
+        itself, every row carries data_as_of July 24, 2026.
 
   # ------------------------------------------------------------------- raster/
   - id: raster/sample-cog
@@ -298,11 +1316,15 @@ collections:
     title: Sample Raster COG
     description: >-
       A small 3-band Cloud Optimized GeoTIFF used to exercise the raster path
-      end to end. Optimized to a COG with per-band statistics, minimum, maximum,
-      mean, and standard deviation, embedded in the header. From the rasterio
-      test fixtures, a 3-band raster in UTM zone 18N (EPSG:32618).
+      end to end, rasterio's RGB.byte.tif test fixture, derived from USGS
+      Landsat 7 imagery over Andros Island in the Bahamas. Optimized to a COG
+      with per-band statistics, minimum, maximum, mean, and standard deviation,
+      embedded in the header, in UTM zone 18N (EPSG:32618).
     keywords: [raster, cog, sample, rgb, geotiff]
-    license: BSD-3-Clause
+    # rasterio's tests/data README dedicates the test images themselves to CC0
+    # 1.0, distinct from the repo's BSD-3-Clause code license, and the
+    # underlying Landsat imagery is US public domain.
+    license: CC0-1.0
     source:
       url: https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif
       media_type: image/tiff
@@ -313,8 +1335,125 @@ collections:
     provenance:
       via: https://github.com/rasterio/rasterio/blob/main/tests/data/RGB.byte.tif
       updated: "2026-07-21T00:00:00Z"
-    temporal: ["2020-01-01T00:00:00Z", null]
+    # The acquisition date is unrecorded upstream. Landsat 7 launched on April
+    # 15, 1999, so that is the honest lower bound, stated in the docs too.
+    temporal: ["1999-04-15T00:00:00Z", null]
     derivatives: {thumbnail: true}
+    blurb: >-
+      A 1 MB Landsat-derived reference COG for learning and testing
+      cloud-optimized raster access, not for analysis.
+    docs:
+      readme: |
+        A 791 by 718 pixel, 3-band, 8-bit image at roughly 300 meter
+        resolution whose georeferencing places it over Andros Island in the
+        Bahamas, the shallow Great Bahama Bank to its west and the deep Tongue
+        of the Ocean along its east coast. It is
+        [rasterio's](https://github.com/rasterio/rasterio) RGB.byte.tif test
+        fixture, derived from USGS Landsat 7 imagery per the project's
+        [test data notes](https://github.com/rasterio/rasterio/blob/main/tests/data/README.rst),
+        in the repository since rasterio's first tests in November 2013 and
+        the workhorse image of its README and topic guides ever since. Anyone
+        who has learned rasterio has seen this picture.
+
+        Here it exercises the Portolan raster path end to end, a Cloud
+        Optimized GeoTIFF with internal tiling, an overview level, and
+        per-band statistics embedded in both the STAC metadata and the GeoTIFF
+        header.
+
+        Agents, [AGENTS.md](./AGENTS.md) covers the nodata trap and windowed
+        reads.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Why a COG, Watching the Range Reads
+
+        A Cloud Optimized GeoTIFF serves partial reads over HTTP. Opening the
+        published copy with GDAL's debug output on shows it, a 64 pixel window
+        costs two range requests of roughly 0.4 MB, not the whole file.
+
+        ```bash
+        CPL_DEBUG=ON gdal_translate -srcwin 0 0 64 64 \
+          /vsicurl/https://data.source.coop/portolan/portolan-pipeline/portolan-reference/main/raster/sample-cog/sample-cog.tif \
+          /tmp/window.tif
+        # VSICURL: Downloading 0-16383 ... 229376-655359
+        ```
+
+        ## Suggested Uses
+
+        Learning and testing COG access patterns, windowed reads, overview
+        reads, HTTP range requests, at a size where experiments cost nothing.
+        Its familiarity is the feature, tutorials and bug reports written
+        against rasterio's docs transfer directly.
+
+        ## Limitations
+
+        Not an analytically useful dataset, and the documentation should be
+        the last place you learn that. The acquisition date and Landsat scene
+        id are unrecorded, the temporal extent here starts at the Landsat 7
+        launch in April 1999 only as an honest lower bound. Bands are
+        display-stretched 8-bit RGB, not calibrated reflectance, so no
+        conclusion about the Bahamas should be drawn from these pixels. About
+        a third of the image is a nodata collar from the rotated scene
+        footprint.
+
+        {{provenance}}
+      agents: |
+        A reference COG for exercising raster tooling, Landsat-derived RGB
+        over Andros Island in the Bahamas. Nothing here supports analysis, the
+        value is mechanical, a small well-formed COG with verified statistics.
+
+        {{access}}
+
+        ## Quirks
+
+        - Nodata is 0 and about 33 percent of pixels are the rotated-scene
+          collar. Valid data starts at 1, so always read with masking on,
+          treating 0 as a measurement skews every statistic.
+        - There is no acquisition timestamp anywhere. The collection temporal
+          start is the Landsat 7 launch date, a bound, not a date.
+        - Eastings run 101,985 to 339,315 meters, far west of the UTM zone 18
+          central meridian. Legal values, they just look odd.
+
+        ## CRS and Pixel Math
+
+        EPSG:32618, WGS84 UTM zone 18N, in meters. Pixels are 300.04 meters
+        square, so one pixel is about 9 hectares and pixel counts convert to
+        area by multiplying by 300.04 squared. Reproject bounds to EPSG:4326
+        before overlaying anything in longitude and latitude.
+
+        ## Tested Reads
+
+        Windowed read and an overview read with rasterio.
+
+        ```python
+        import rasterio
+        from rasterio.windows import Window
+
+        with rasterio.open("sample-cog.tif") as src:
+            window = src.read(window=Window(256, 256, 128, 128))
+            overview = src.read(1, out_shape=(src.height // 2, src.width // 2))
+            print(window.shape, overview.shape)
+        # (3, 128, 128) (359, 395), the second served from the embedded overview.
+        ```
+
+        Masked statistics with rioxarray.
+
+        ```python
+        import rioxarray
+
+        da = rioxarray.open_rasterio("sample-cog.tif", masked=True)
+        print(float(da.sel(band=3).mean()))
+        # 71.3, and blue > green > red across the scene, bright shallow water.
+        ```
+
+        ## Related Collections
+
+        None. This is the catalog's only raster and joins to nothing. The
+        upstream fixture is tagged on the source asset with its checksum, and
+        band statistics live in the STAC bands metadata and as GDAL
+        STATISTICS_* tags in the file header, written by the same build.
 
   # ------------------------------------------------------------------ tabular/
   - id: tabular/eurostat-electricity-prices
@@ -346,30 +1485,185 @@ collections:
     # Azores in the west to Georgia in the east, Crete in the south to Nordkapp.
     bbox: [-31.5, 34.0, 46.5, 71.5]
     # Geometry and attributes live in separate files, so the join is documented
-    # explicitly and a runnable example is emitted into the README.
+    # explicitly and a runnable example is emitted into the README. The target
+    # is ISO_A2_EH, not ISO_A2, which Natural Earth sets to -99 for France,
+    # Norway, and Kosovo. Proven by query, an ISO_A2 join silently drops them.
     join:
       column: geo
       target: reference/natural-earth-countries
-      target_column: ISO_A2
+      target_column: ISO_A2_EH
       target_file: ../../reference/natural-earth-countries/natural-earth-countries.parquet
       note: >-
         Eurostat uses NUTS-0 country codes, which match ISO 3166-1 alpha-2 for
         most countries but not all. Greece is EL rather than GR and the United
-        Kingdom is UK rather than GB, so remap those two before joining if you
-        need them.
+        Kingdom is UK rather than GB, so remap those two before joining. Malta
+        and Liechtenstein have no polygon in the 1:110m Natural Earth file, and
+        the EU27_2020 and EA aggregate rows never join.
     # SDMX dimension codes are unreadable without prose, and for a table the column
     # schema is the only semantic handle a consumer gets.
     columns:
-      DATAFLOW: Eurostat dataflow identifier, agency, table code, and version.
-      LAST UPDATE: Timestamp of the last update Eurostat published for this table.
-      freq: Observation frequency. S is semi-annual.
-      siec: Standard International Energy Product Classification code for the energy carrier, here electricity.
-      nrg_cons: Annual household electricity consumption band the price applies to.
-      unit: Unit of measure for the observed value, for example kilowatt hour.
-      tax: Tax and levy component, which taxes the quoted price includes or excludes.
-      currency: Currency of the observed value, euro, national currency, or purchasing power standard.
-      geo: Reporting country as a Eurostat NUTS-0 code. This is the join key to a geometry Collection.
-      TIME_PERIOD: Reference period, year and semester.
-      OBS_VALUE: The observed electricity price in the stated unit and currency.
-      OBS_FLAG: Observation status flag, for example p provisional, e estimated, d definition differs.
-      CONF_STATUS: Confidentiality status of the observation.
+      DATAFLOW: Eurostat dataflow identifier, the constant ESTAT nrg_pc_204 version 1.0.
+      LAST UPDATE: Frozen at one 2019 timestamp for every row of this snapshot while the data runs to 2025. Unreliable, do not derive freshness from it.
+      freq: Observation frequency, the constant S for semi-annual. S1 is January to June, S2 is July to December.
+      siec: Energy product code, the constant E7000 for electricity.
+      nrg_cons: Annual consumption band. KWH_LT1000, KWH1000-2499, KWH2500-4999 the headline household band, KWH5000-14999, KWH_GE15000, and TOT_KWH the weighted all-band average that exists only from 2017-S2.
+      unit: Unit of measure, the constant KWH. Prices are per kilowatt-hour.
+      tax: Tax level. X_TAX excludes all taxes and levies, X_VAT excludes VAT and recoverable taxes, I_TAX includes everything a household pays.
+      currency: EUR, NAC for national currency, or PPS purchasing power standard. NAC equals EUR in the euro area.
+      geo: Reporting country as a Eurostat NUTS-0 code, ISO 3166-1 alpha-2 except EL for Greece and UK for the United Kingdom, plus the aggregates EU27_2020 and EA. The join key to a geometry Collection.
+      TIME_PERIOD: Reference semester as a string, 2025-S2. Fixed format, so string ordering and MAX work.
+      OBS_VALUE: The observed electricity price in the stated currency per kilowatt-hour.
+      OBS_FLAG: Observation status, e estimated, p provisional, d definition differs, null for 98 percent of rows.
+      CONF_STATUS: Confidentiality status, entirely null in this snapshot.
+    blurb: >-
+      65,412 semi-annual household electricity prices for 41 European
+      countries from 2007 on, the official record of the 2022 energy crisis.
+    docs:
+      readme: |
+        What households pay for electricity across Europe, semester by
+        semester since 2007. This is Eurostat table
+        [nrg_pc_204](https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_204/default/table),
+        65,412 observations covering 41 countries and territories plus the
+        EU27 and euro area aggregates, collected under
+        [Regulation (EU) 2016/1952](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32016R1952)
+        as consumption-weighted national average prices per six-month period.
+        New semesters land each April and October, and Eurostat's own
+        [price statistics article](https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Electricity_price_statistics)
+        is written from this table. It is the official record of the 2022
+        energy crisis, Germany's all-tax price for a typical household rose
+        from 0.33 to a 0.41 euro per kilowatt-hour peak in the first half of
+        2023.
+
+        Agents, [AGENTS.md](./AGENTS.md) decodes every dimension and carries
+        the aggregate-row trap.
+
+        ## Quick Start
+
+        {{quickstart}}
+
+        ## Reading a Price Correctly
+
+        Every price is qualified by four dimensions, and comparisons only mean
+        something within a fixed combination. The band, how much the household
+        consumes per year, where KWH2500-4999 is the band Eurostat headlines.
+        The tax level, X_TAX before taxes, X_VAT before VAT, I_TAX what a
+        household actually pays. The currency, where EUR is nominal, NAC is
+        national currency, and PPS adjusts for price levels, Bulgaria's 2025-S2
+        price is 0.14 EUR but 0.22 PPS, and the gap is the point. And the
+        semester string, 2025-S2 meaning July to December 2025.
+
+        ## Schema
+
+        {{schema}}
+
+        ## Join to Geometry
+
+        This table carries no geometry. The `geo` codes join to the Natural
+        Earth countries Collection in this catalog on `ISO_A2_EH`, after
+        remapping Eurostat's two non-ISO codes. Greece is EL and the United
+        Kingdom is UK. The raw ISO_A2 column would silently drop France,
+        Norway, and Kosovo, Natural Earth stores -99 there.
+
+        ```sql
+        INSTALL spatial; LOAD spatial;
+        SELECT n.NAME, e.OBS_VALUE AS eur_per_kwh, n.geom
+        FROM read_parquet('eurostat-electricity-prices.parquet') e
+        JOIN read_parquet('../../reference/natural-earth-countries/natural-earth-countries.parquet') n
+          ON (CASE e.geo WHEN 'EL' THEN 'GR' WHEN 'UK' THEN 'GB' ELSE e.geo END) = n.ISO_A2_EH
+        WHERE e.TIME_PERIOD = '2025-S2' AND e.nrg_cons = 'KWH2500-4999'
+          AND e.tax = 'I_TAX' AND e.currency = 'EUR'
+        ORDER BY eur_per_kwh DESC;
+        ```
+
+        Malta and Liechtenstein stay unmatched, the 1:110m basemap has no
+        polygon for them, and the EU27_2020 and EA aggregates have no
+        geometry by nature.
+
+        ## Limitations
+
+        These are averages over suppliers and six months, not offers, Eurostat
+        itself notes there is no single price for electricity. One number per
+        country per semester, nothing sub-national. Values from the second
+        half of 2021 onward embed government subsidies and caps, so 2022 to
+        2024 understate underlying costs in heavily supported countries, and
+        Romania's 59 percent jump in late 2025 is a cap ending, not a market
+        shock. Data before 2007 lives in a separate, methodologically
+        incompatible table, never splice them.
+
+        {{provenance}}
+      agents: |
+        Semi-annual household electricity prices, one row per combination of
+        consumption band, tax level, currency, country, and semester, verified
+        unique on those five. Filter all five dimensions before comparing
+        anything. The headline combination is nrg_cons = 'KWH2500-4999',
+        tax = 'I_TAX', currency = 'EUR'.
+
+        {{access}}
+
+        ## Quirks
+
+        - EU27_2020 and EA sit in geo alongside countries, so unfiltered
+          rankings place the EU average mid-table as if it were a country.
+          Exclude them for country-level analysis.
+        - The LAST UPDATE column is frozen at one 2019 timestamp on all 65,412
+          rows of this snapshot while data runs to 2025-S2. It also has a space
+          in its name, quote it as "LAST UPDATE".
+        - The panel is ragged. The UK stops after 2020-S1, Ukraine after
+          2021-S1, Iceland lags a semester, and 2007-S1 has only 8 reporters.
+        - TOT_KWH is itself a weighted average of the five bands and exists
+          only from 2017-S2. Never mix it into a band aggregate.
+        - For euro-area countries NAC duplicates EUR, so counting rows across
+          currencies triple-counts observations.
+        - About 2 percent of rows carry flags, e estimated, p provisional, d
+          definition differs, and provisional values are revised in later
+          snapshots, so this fixed copy can disagree with the live API on
+          recent semesters.
+
+        ## Tested Queries
+
+        Latest prices ranked, aggregates excluded.
+
+        ```sql
+        SELECT geo, OBS_VALUE AS eur_per_kwh
+        FROM read_parquet('eurostat-electricity-prices.parquet')
+        WHERE nrg_cons = 'KWH2500-4999' AND tax = 'I_TAX' AND currency = 'EUR'
+          AND TIME_PERIOD = (SELECT max(TIME_PERIOD) FROM read_parquet('eurostat-electricity-prices.parquet'))
+          AND geo NOT IN ('EU27_2020', 'EA')
+        ORDER BY eur_per_kwh DESC;
+        -- Ireland 0.4042, Germany 0.3869, Belgium 0.3499, down to Turkey 0.0636.
+        ```
+
+        A time series with real dates from the semester strings.
+
+        ```sql
+        SELECT TIME_PERIOD,
+               make_date(CAST(TIME_PERIOD[1:4] AS INT),
+                         CASE WHEN TIME_PERIOD LIKE '%S1' THEN 1 ELSE 7 END, 1) AS period_start,
+               OBS_VALUE AS eur_per_kwh
+        FROM read_parquet('eurostat-electricity-prices.parquet')
+        WHERE geo = 'DE' AND nrg_cons = 'KWH2500-4999' AND tax = 'I_TAX'
+          AND currency = 'EUR'
+        ORDER BY TIME_PERIOD;
+        -- 38 semesters, 0.2025 in 2007-S1, peaking at 0.4125 in 2023-S1.
+        ```
+
+        The tax ladder, what levies add.
+
+        ```sql
+        SELECT tax, OBS_VALUE
+        FROM read_parquet('eurostat-electricity-prices.parquet')
+        WHERE geo = 'EU27_2020' AND TIME_PERIOD = '2025-S2'
+          AND nrg_cons = 'KWH2500-4999' AND currency = 'EUR'
+        ORDER BY OBS_VALUE;
+        -- X_TAX 0.2059, X_VAT 0.2456, I_TAX 0.2896, all matching Eurostat's
+        -- published article to four decimals.
+        ```
+
+        ## Related Collections
+
+        `reference/natural-earth-countries` is the geometry partner, join
+        recipe in the README of this Collection. Sibling Eurostat tables
+        outside this catalog, nrg_pc_205 for non-household prices and
+        nrg_pc_204_c for price components, share the same dimension scheme.
+        Converted from Eurostat's SDMX-CSV API output, a live endpoint, to
+        Parquet with DuckDB on July 21, 2026.

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -29,7 +29,7 @@ from the modules beside them, so they stay runnable on their own.
 | `validate.py` | Thin adapter over rashid, the canonical validator. Runs its metadata, structural, schema, and data passes over the built catalog |
 | `check_catalogs.py` | Entrypoint. Runs rashid over every committed catalog with the data pass on, reading the rashid pin out of `build.py`'s PEP 723 header |
 | `publish_catalogs.py` | Entrypoint. Uploads a built catalog to Source Cooperative, and tears a pull request's preview down |
-| `tests/` | Standalone `uv run` checks, `check_compliance.py`, `check_web_output.py`, `check_validate.py`, `check_tiles.py`, `check_thumb_geoms.py`, `check_thumbnails.py`, `check_cog.py`, `check_fetch.py`, and `check_styles.py`, plus `run_all.py` which runs the lot |
+| `tests/` | Standalone `uv run` checks, `check_compliance.py`, `check_web_output.py`, `check_validate.py`, `check_tiles.py`, `check_thumb_geoms.py`, `check_thumbnails.py`, `check_cog.py`, `check_docs.py`, `check_fetch.py`, and `check_styles.py`, plus `run_all.py` which runs the lot |
 
 Inputs and outputs live under `examples/`, not here.
 
@@ -45,7 +45,15 @@ Inputs and outputs live under `examples/`, not here.
 uv run examples/tools/build.py                                # build every manifest
 uv run examples/tools/build.py --catalog portolan-reference   # one manifest by stem
 uv run examples/tools/build.py --only boundaries/us-counties  # one Collection, skips validation
+uv run examples/tools/build.py --docs-only                    # regenerate README/AGENTS only
 ```
+
+`--docs-only` rewrites every README.md and AGENTS.md from the manifest against
+the committed tree, refreshes the manifest-owned collection.json fields (title,
+description, license, keywords, temporal, `table:columns` descriptions, and the
+mirrored metadata asset), and fetches nothing else. Documentation iterates far
+more often than data, and a full rebuild refetches the live upstream endpoints,
+churning binary assets under a prose change.
 
 `uv` reads the PEP 723 header at the top of `build.py` and resolves the Python
 deps (pyyaml, duckdb, jsonschema, pyarrow, rasterio, rio-cogeo, and the pinned
@@ -65,9 +73,20 @@ uv run examples/tools/tests/check_tiles.py
 uv run examples/tools/tests/check_thumb_geoms.py
 uv run examples/tools/tests/check_thumbnails.py
 uv run examples/tools/tests/check_cog.py
+uv run examples/tools/tests/check_docs.py
 uv run examples/tools/tests/check_fetch.py
 uv run examples/tools/tests/check_styles.py
 ```
+
+`check_docs.py` executes every ```sql and ```python fence in the committed
+README.md and AGENTS.md files with the doc's own directory as the working
+directory, which makes the best-practices rule that every example be run
+before publishing mechanical. Blocks that reference a URL are skipped so the
+suite stays offline, and fences in other languages are illustration. When
+authoring a recipe in the manifest, include `INSTALL spatial; LOAD spatial;`
+in every spatial SQL block, each block runs in a fresh connection, and never
+state an output in a comment without having run the query, the check proves
+blocks execute, not that quoted numbers are true.
 
 Publishing a built catalog to Source Cooperative needs `s5cmd` on PATH as well,
 and credentials for the Portolan repository in the environment or an AWS
@@ -94,7 +113,8 @@ Top level of each file in `manifests/`.
 - `id`, `title`, `description`. Root Catalog identity.
 - `schema_uri`. Must equal the pinned v0.1.0 URI. `load_manifest` asserts this.
 - `host`. `{name, url, email}`. Appended as the `host`-role provider on mirror Collections.
-- `catalogs`. Map from the first id segment to `{title, description}` for each nested Catalog.
+- `catalogs`. Map from the first id segment to `{title, description, readme?, agents?}` for each nested Catalog. The optional `readme` and `agents` are markdown templates like the per-collection `docs` below.
+- `docs?`. `{readme?, agents?}` markdown templates for the root Catalog sidecars. Catalog-level templates may use `{{collections}}` (the table of contents the best-practices page asks for), `{{sources}}` (licenses, provenance, upstream list), and `{{agents_index}}` (per-child pointers to each AGENTS.md). Without a template a default skeleton with those blocks is emitted.
 - `thumbnails`. `{size, ocean_color, pad_vector?, pad_raster?, basemap: {url, attribution?}}`. The basemap is an XYZ raster tile URL template with `{z}/{x}/{y}` placeholders, CARTO light by default.
 - `output_crs?`. Optional output CRS for the canonical assets, for example `EPSG:4326`. Source-preserving by default, set at the top level for the whole catalog, or per collection to override just that one.
 - `collections`. The list below.
@@ -113,9 +133,12 @@ Each entry in `collections`.
 - `thumbnail_bbox?`. `[minx, miny, maxx, maxy]`. Frames the preview only, not the data. Use it for antimeridian-spanning data.
 - `derivatives`. `{pmtiles, thumbnail}`. Booleans that toggle the PMTiles and thumbnail outputs.
 - `style?`. Per-Collection paint, `{color, outline, opacity, palette?, category_field?, label_field?, graduated_field?, variants?}`. Drives both the MapLibre styles and the thumbnail paint. `category_field` colours by category from the shared palette, `graduated_field` interpolates a numeric ramp, `label_field` adds labels, and `variants` lists which style files to author. The FIRST variant is the default style and is what the thumbnail renders.
-- `columns?`. `{column_name: description}`. Merged into `table:columns` by `describe_columns`. A Parquet footer carries names and types but no semantics, so the prose has to come from the manifest. Required in spirit for `tabular`, where the column schema is the only semantic handle a consumer gets.
+- `columns?`. `{column_name: description}`. Merged into `table:columns` by `describe_columns`. A Parquet footer carries names and types but no semantics, so the prose has to come from the manifest. Required in spirit for `tabular`, where the column schema is the only semantic handle a consumer gets. Also feeds the `{{schema}}` table in the README, one authored description generates both surfaces.
 - `bbox?`. Tabular only. The area of interest the table pertains to, which core.md asks for in place of a geometric footprint. Absent, the fallback is the whole world, correct only for a genuinely global table.
 - `join?`. Tabular only. `{column, target, target_column, target_file, note?}`. Emits the README join section and a runnable DuckDB example, which formats.md requires whenever geometry and attributes live in separate files. `target_file` is relative to the Collection directory.
+- `blurb?`. One line for the catalog-level collections tables. Falls back to the first sentence of `description`.
+- `metadata?`. `{url, media_type, title, standard?, filename?}`. Mirrors an upstream machine-readable metadata record, for example an ISO 19115 record from a GeoNetwork registry, into the Collection directory and attaches it as a `metadata`-role asset with real `file:size` and `file:checksum`. Mirrored rather than linked because a registry regenerates its XML and a checksum pinned to bytes the catalog does not control rots, the live-endpoint rule again. The fetch happens once, an existing local copy is reused.
+- `docs?`. `{readme?, agents?}`. Markdown templates for the Collection sidecars, the heart of the golden-example documentation. Each is near-final markdown whose structure and voice the manifest author controls per collection, with `{{placeholder}}` lines expanding to generated blocks that cannot drift from the built assets. README templates may use `{{quickstart}}` (the one tested open-it snippet, chosen by kind), `{{schema}}` (a table of the described columns from `table:columns`), `{{join}}` (the tabular join section), and `{{provenance}}` (the license and provenance block core.md requires, appended automatically when the template omits it). AGENTS templates may use `{{access}}` (the one-line access guidance). An unknown placeholder fails the build, a typo would otherwise publish literally. Without templates a minimal default skeleton is emitted, so a bare manifest still builds a conformant catalog.
 
 ## Provenance is derived, not declared
 

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -47,7 +47,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from stacio import load_manifest, build_catalog
+from stacio import load_manifest, build_catalog, regen_docs
 from validate import validate
 
 
@@ -69,6 +69,10 @@ def main() -> int:
     ap.add_argument("--only", default=None, help="build only this collection id")
     ap.add_argument("--schema", default=root / "stac/json-schema/v0.1.0/schema.json", type=Path)
     ap.add_argument("--no-validate", action="store_true")
+    ap.add_argument("--docs-only", action="store_true",
+                    help="regenerate README/AGENTS sidecars and table:columns "
+                         "descriptions from the manifest against the committed "
+                         "catalog, no fetch, no conversion")
     args = ap.parse_args()
 
     files = sorted(p for p in args.manifests.glob("*.yaml"))
@@ -82,6 +86,9 @@ def main() -> int:
         print(f"=== manifest {mf.name} ===", file=sys.stderr)
         manifest = load_manifest(mf)
         cat_out = args.out / mf.stem
+        if args.docs_only:
+            regen_docs(manifest, cat_out, args.cache)
+            continue
         build_catalog(manifest, cat_out, args.cache, args.only)
         if not args.no_validate and not args.only:
             validate(cat_out, args.schema)

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -116,6 +116,28 @@ def source_asset(local: Path, spec_source: dict) -> dict:
             "file:size": filesize(local), "file:checksum": multihash(local)}
 
 
+def add_metadata_asset(assets: dict, spec: dict, coll_dir: Path, cache: Path) -> None:
+    """Mirror an upstream machine-readable metadata record beside the data.
+
+    core.md's Metadata section asks collections to ship machine-readable
+    metadata where it exists. The record is mirrored into the collection rather
+    than referenced by URL, because a registry regenerates its XML, and a
+    checksum pinned to bytes the catalog does not control is guaranteed to rot,
+    the same reasoning that keeps live endpoints out of the source assets. The
+    fetch happens once, an existing local copy is reused."""
+    meta = spec.get("metadata")
+    if not meta:
+        return
+    dest = coll_dir / meta.get("filename", "iso19115.xml")
+    if not dest.exists():
+        import shutil
+        local = fetch(meta["url"], cache, stable=True)
+        shutil.copyfile(local, dest)
+    roles = ["metadata"] + ([meta["standard"]] if meta.get("standard") else [])
+    assets["metadata"] = asset(dest, meta.get("media_type", "application/xml"),
+                               roles, meta["title"])
+
+
 def add_source_asset(assets: dict, local: Path, spec_source: dict) -> None:
     """Attach the `source` Asset, but only for a stable upstream download.
 
@@ -162,7 +184,7 @@ def join_section(join: dict) -> list[str]:
     if not join:
         return []
     lines = [
-        "## Join to geometry",
+        "## Join to Geometry",
         "",
         f"This table carries no geometry. Join it to `{join['target']}` to map it.",
         "",
@@ -184,18 +206,12 @@ def join_section(join: dict) -> list[str]:
     return lines
 
 
-def open_snippet(kind: str, data_name: str) -> tuple[list[str], str]:
-    """Return (readme_markdown_lines, agents_line) with runnable code for opening
-    the cloud-native data asset, chosen by kind. The README block shows a couple
-    of common tools, the agents line names the one an agent should reach for."""
+def quickstart_block(kind: str, data_name: str) -> list[str]:
+    """The one runnable snippet that opens the cloud-native data asset, chosen by
+    kind. One tested snippet beats four aspirational ones, so the README gets a
+    single Quick Start and the agent guide carries the deeper query patterns."""
     if kind == "vector":
-        lines = [
-            "## Open the data",
-            "",
-            "The `data` asset is GeoParquet 2.0 with a native geometry type and a "
-            "covering bbox column for fast web-client pruning. Read it with a recent "
-            "GeoPandas built on pyarrow 24 or newer.",
-            "",
+        return [
             "```python",
             "import geopandas as gpd",
             "",
@@ -203,22 +219,14 @@ def open_snippet(kind: str, data_name: str) -> tuple[list[str], str]:
             "print(gdf.head())",
             "```",
             "",
-            "Or query it in place with a recent DuckDB spatial.",
-            "",
-            "```sql",
-            "INSTALL spatial; LOAD spatial;",
-            f"SELECT * FROM read_parquet('{data_name}') LIMIT 5;",
-            "```",
+            "The `data` asset is GeoParquet 2.0 with a native geometry type and a "
+            "covering bbox column, so it needs a GeoPandas built on pyarrow 24 or "
+            "newer. DuckDB spatial queries the same file in place, see "
+            "[AGENTS.md](./AGENTS.md) for those patterns. Paths are relative to "
+            "this directory, and the same code works against the published URL.",
         ]
-        agents = f'Read the GeoParquet `data` asset with GeoPandas, gpd.read_parquet("{data_name}").'
-        return lines, agents
     if kind == "raster":
-        lines = [
-            "## Open the data",
-            "",
-            "The `data` asset is a Cloud Optimized GeoTIFF. Open it as an xarray "
-            "array with rioxarray.",
-            "",
+        return [
             "```python",
             "import rioxarray",
             "",
@@ -226,24 +234,12 @@ def open_snippet(kind: str, data_name: str) -> tuple[list[str], str]:
             "print(da)",
             "```",
             "",
-            "Or read bands and metadata with rasterio.",
-            "",
-            "```python",
-            "import rasterio",
-            "",
-            f'with rasterio.open("{data_name}") as src:',
-            "    print(src.profile)",
-            "    band1 = src.read(1)",
-            "```",
+            "The `data` asset is a Cloud Optimized GeoTIFF, so the same call "
+            "against the published URL streams only the bytes it needs over HTTP "
+            "range requests. Pass masked=True so nodata reads as NaN.",
         ]
-        agents = f'Read the COG `data` asset with rioxarray.open_rasterio("{data_name}") for xarray, or rasterio.'
-        return lines, agents
     # tabular
-    lines = [
-        "## Open the data",
-        "",
-        "The `data` asset is Parquet. Open it with pandas.",
-        "",
+    return [
         "```python",
         "import pandas as pd",
         "",
@@ -251,14 +247,175 @@ def open_snippet(kind: str, data_name: str) -> tuple[list[str], str]:
         "print(df.head())",
         "```",
         "",
-        "Or query it in place with DuckDB.",
-        "",
-        "```sql",
-        f"SELECT * FROM read_parquet('{data_name}') LIMIT 5;",
-        "```",
+        "The `data` asset is plain Parquet, so pandas, DuckDB, and Polars all "
+        "read it directly. Paths are relative to this directory, and the same "
+        "code works against the published URL.",
     ]
-    agents = f'Read the Parquet `data` asset with pandas, pd.read_parquet("{data_name}").'
-    return lines, agents
+
+
+def access_line(kind: str, data_name: str, has_visual: bool, has_thumb: bool) -> str:
+    """The one-line access guidance for AGENTS.md, chosen by kind."""
+    if kind == "vector":
+        line = ("Query the GeoParquet `data` asset in place with DuckDB spatial, "
+                f"read_parquet('{data_name}'), or load it with GeoPandas. It streams "
+                "over HTTP range requests, so query the published URL directly "
+                "rather than downloading first.")
+    elif kind == "raster":
+        line = (f'Read the COG `data` asset with rioxarray.open_rasterio("{data_name}", '
+                "masked=True) or rasterio. It serves windowed reads and overviews "
+                "over HTTP range requests, so read the window you need rather than "
+                "the whole file.")
+    else:
+        line = (f"Query the Parquet `data` asset in place with DuckDB, "
+                f"read_parquet('{data_name}'), or load it with pandas.")
+    if has_visual:
+        line += " For rendering use the visual PMTiles asset with its MapLibre styles."
+    elif has_thumb:
+        line += " For a quick preview use the thumbnail asset."
+    return line
+
+
+def schema_block(cols: list[dict]) -> list[str]:
+    """A schema table of the described columns, generated from the same
+    `table:columns` the data asset carries, so prose and metadata cannot drift."""
+    described = [c for c in cols if c.get("description")]
+    if not described:
+        return []
+    lines = ["| Column | Type | Description |", "|---|---|---|"]
+    for c in described:
+        lines.append(f"| `{c['name']}` | {c['type']} | {c['description']} |")
+    lines.append("")
+    if len(described) < len(cols):
+        lines.append(f"The table has {len(cols)} columns in all. The full list "
+                     "with types lives in `table:columns` on the `data` asset.")
+    else:
+        lines.append("The same descriptions live in `table:columns` on the "
+                     "`data` asset, so tools that read STAC see them too.")
+    return lines
+
+
+def provenance_block(spec: dict, providers: list[dict], facts: dict) -> list[str]:
+    """The license and provenance block core.md requires in every README."""
+    src = facts["src"]
+    attribution = spec.get("attribution")
+    lines = [
+        "## Provenance and License",
+        "",
+        f"License, {spec['license']}."
+        + (f" Attribution, {attribution}." if attribution else ""),
+        f"Providers, {_providers_sentence(providers)}.",
+        f"Original source, {src['url']} .",
+    ]
+    kind = facts["kind"]
+    if kind == "vector":
+        lines.append(f"Features, {facts['n']:,}. Cloud-native asset, "
+                     f"{facts['data_name']} (GeoParquet 2.0).")
+    elif kind == "raster":
+        lines.append(f"Bands, {len(facts['bands'])}. CRS, {facts['crs']}. "
+                     f"Cloud-native asset, {facts['data_name']} (COG).")
+    else:
+        lines.append(f"Rows, {facts['n']:,}. Columns, {len(facts['cols'])}. "
+                     f"Cloud-native asset, {facts['data_name']} (Parquet).")
+        aoi = facts.get("aoi")
+        lines.append("Non-geospatial table, the bounding box is the area of "
+                     "interest the data pertains to"
+                     + (f", {aoi}." if aoi else " and defaults to the whole world."))
+    if not src.get("stable", True):
+        lines.append("The upstream source is a live endpoint, so it is referenced "
+                     "by URL only and not archived as a source asset.")
+    return lines
+
+
+# Doc templates in the manifest are markdown with {{placeholder}} lines. Each
+# placeholder expands to a block the generator computes from the built assets,
+# so the numbers, schema tables, and open-it code in the docs cannot drift from
+# the catalog they describe. An unknown placeholder is an error, a typo would
+# otherwise publish literally.
+DOC_PLACEHOLDER = re.compile(r"^\{\{([a-z_]+)\}\}$")
+
+
+def render_template(template: str, blocks: dict[str, list[str]], where: str) -> list[str]:
+    out: list[str] = []
+    for raw in template.strip("\n").rstrip().splitlines():
+        m = DOC_PLACEHOLDER.match(raw.strip())
+        if not m:
+            out.append(raw)
+            continue
+        name = m.group(1)
+        if name not in blocks:
+            raise ValueError(
+                f"{where} uses unknown placeholder {{{{{name}}}}}, "
+                f"available are {sorted(blocks)}")
+        out.extend(blocks[name])
+    return out
+
+
+def _first_sentence(text: str) -> str:
+    t = " ".join(text.strip().split())
+    m = re.match(r"(.+?\.)(\s|$)", t)
+    return m.group(1) if m else t
+
+
+def blurb(spec: dict) -> str:
+    """One line for catalog collection tables, authored or first sentence."""
+    return spec.get("blurb") or _first_sentence(spec["description"])
+
+
+def collection_readme_extra(spec: dict, facts: dict) -> list[str]:
+    """Everything after the title and description in a collection README.
+
+    A manifest `docs.readme` template drives the structure, so each collection
+    reads differently while the generated blocks keep the facts honest. Without
+    a template the default skeleton is emitted. The provenance block core.md
+    requires is appended whenever the template does not place it itself."""
+    docs = spec.get("docs") or {}
+    blocks = {
+        "quickstart": quickstart_block(facts["kind"], facts["data_name"]),
+        "schema": schema_block(facts["cols"]),
+        "provenance": provenance_block(spec, facts["providers"], facts),
+        "join": join_section(facts.get("join") or {}),
+    }
+    template = (docs.get("readme") or "").strip()
+    if not template:
+        template = "## Quick Start\n\n{{quickstart}}"
+        if schema_block(facts["cols"]):
+            template += "\n\n## Schema\n\n{{schema}}"
+        if facts.get("join"):
+            template += "\n\n{{join}}"
+        template += "\n\n{{provenance}}"
+    lines = render_template(template, blocks, f"{spec['id']} docs.readme")
+    if "## Provenance and License" not in lines:
+        lines += [""] + blocks["provenance"]
+    return lines
+
+
+def collection_agents_lines(spec: dict, facts: dict) -> list[str]:
+    """The body of a collection AGENTS.md.
+
+    A manifest `docs.agents` template carries the dataset-specific guidance,
+    join keys, quirks, CRS consequences, and tested queries. The generated
+    access block is available as {{access}}. Without a template a minimal
+    fallback is emitted so a bare manifest still builds a conformant catalog."""
+    docs = spec.get("docs") or {}
+    access = access_line(facts["kind"], facts["data_name"],
+                         facts["has_visual"], facts["has_thumb"])
+    template = (docs.get("agents") or "").strip()
+    if not template:
+        src = facts["src"]
+        lines = [f"This collection holds {spec['title']}.", access,
+                 f"License is {spec['license']}."]
+        lines.append(
+            f"The original upstream source is {src['url']} , "
+            + ("tagged on the source-role asset." if src.get("stable", True)
+               else "a live endpoint referenced by URL only."))
+        join = facts.get("join")
+        if join:
+            lines.append(
+                f"This table has no geometry. Join column {join['column']} to "
+                f"{join['target']} on {join['target_column']} to map it, see the README.")
+        return lines
+    return render_template(template, {"access": [access]},
+                           f"{spec['id']} docs.agents")
 
 
 def readme_md(title: str, description: str, extra_lines: list[str]) -> str:
@@ -269,7 +426,7 @@ def readme_md(title: str, description: str, extra_lines: list[str]) -> str:
 
 
 def agents_md(title: str, guidance: list[str]) -> str:
-    body = [f"# Agent guidance, {title}", ""]
+    body = [f"# Agent Guidance, {title}", ""]
     body += guidance
     body.append("")
     return "\n".join(body)
@@ -349,7 +506,7 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
                      "default_variant": (st.get("variants") or ["default"])[0]}
             make_thumbnail_vector(norm, th, tbbox, style, thumb)
             assets["thumbnail"] = asset(th, MEDIA["png"], ["thumbnail"], _thumb_desc(thumb))
-        extra_readme = [f"Features, {n}.", f"Cloud-native asset, {data_pq.name} (GeoParquet)."]
+        bands, code = [], canon_crs
         norm.unlink(missing_ok=True)
 
     elif kind == "raster":
@@ -371,8 +528,7 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
             tbbox = spec.get("thumbnail_bbox") or bbox
             make_thumbnail_raster(cog, th, tbbox, thumb)
             assets["thumbnail"] = asset(th, MEDIA["png"], ["thumbnail"], _thumb_desc(thumb))
-        extra_readme = [f"Bands, {len(bands)}.", f"CRS, {code}.",
-                        f"Cloud-native asset, {cog.name} (COG)."]
+        cols = []
 
     elif kind == "tabular":
         data_pq = coll_dir / f"{stem}.parquet"
@@ -386,14 +542,11 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
                                {"table:columns": cols, "table:row_count": n})
         add_source_asset(assets, local, src)
         exts.append(TABLE_EXT)
-        aoi = spec.get("bbox")
-        extra_readme = [f"Rows, {n}.", f"Columns, {len(cols)}.",
-                        "Non-geospatial table, spatial requirements relaxed. The "
-                        + ("bounding box is the area of interest the data pertains to, "
-                           f"{aoi}, not a geometry footprint." if aoi else
-                           "data is global, so the bounding box is the whole world.")]
+        bands, code = [], None
     else:
         raise ValueError(f"unknown kind {kind}")
+
+    add_metadata_asset(assets, spec, coll_dir, cache)
 
     # structural + provenance links
     root_href = "../" * depth + "catalog.json"
@@ -449,45 +602,50 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
 
     (coll_dir / "collection.json").write_text(json.dumps(coll, indent=2) + "\n")
 
-    # sidecars, with format-specific open-it-in-code guidance
-    open_lines, open_agents = open_snippet(kind, data_name)
-    attribution = spec.get("attribution")
-    readme_extra = [
-        f"License, {spec['license']}." + (f" Attribution, {attribution}." if attribution else ""),
-        f"Providers, {_providers_sentence(providers)}.",
-        f"Original source, {src['url']} .",
-    ] + extra_readme
-    if not src.get("stable", True):
-        readme_extra.append("Note, the upstream source is a live endpoint, so it is "
-                            "referenced by URL only and not archived as a source asset.")
-    readme_extra += [""] + open_lines
+    # sidecars, structure and prose from the manifest docs templates
     join = dict(spec.get("join") or {})
     if join:
         join["this_file"] = data_name
-        readme_extra += [""] + join_section(join)
-    agents = [
-        f"This collection holds {spec['title']}.",
-        open_agents,
-        ("For rendering use the visual PMTiles asset or the thumbnail."
-         if assets.get("visual") else "For a quick preview use the thumbnail asset."),
-        f"License is {spec['license']}."
-        + (f" Attribute as {attribution}." if attribution else ""),
-        f"The original upstream source is {src['url']} , "
-        + ("tagged on the source-role asset."
-           if src.get("stable", True) else "a live endpoint referenced by URL only."),
-    ]
-    if join:
-        agents.append(
-            f"This table has no geometry. Join column {join['column']} to "
-            f"{join['target']} on {join['target_column']} to map it, see the README.")
-    write_sidecars(coll_dir, spec["title"], spec["description"].strip(), readme_extra, agents)
+    facts = {
+        "kind": kind, "data_name": data_name, "n": n, "cols": cols,
+        "bands": bands, "crs": code, "aoi": spec.get("bbox"),
+        "has_visual": bool(assets.get("visual")),
+        "has_thumb": bool(assets.get("thumbnail")),
+        "src": src, "providers": providers, "join": join,
+    }
+    write_sidecars(coll_dir, spec["title"], spec["description"].strip(),
+                   collection_readme_extra(spec, facts),
+                   collection_agents_lines(spec, facts))
 
     return {"id": cid, "seg": seg, "title": spec["title"], "updated": prov.get("updated"),
-            "license": spec["license"], "is_mirror": is_mirror, "source": src["url"]}
+            "license": spec["license"], "is_mirror": is_mirror, "source": src["url"],
+            "kind": kind, "geometry": spec.get("geometry"), "n": n,
+            "bands": len(bands), "blurb": blurb(spec)}
 
 
 # --------------------------------------------------------------- catalog build
-def _catalog_prose(colls: list[dict]) -> list[str]:
+def _contents_label(c: dict) -> str:
+    """Feature count and geometry in one cell, per the best-practices table."""
+    if c["kind"] == "vector":
+        return f"{c['n']:,} {c.get('geometry') or 'feature'}s"
+    if c["kind"] == "raster":
+        return f"{c['bands']}-band raster"
+    return f"{c['n']:,} rows"
+
+
+def collections_table(colls: list[dict], nested: bool) -> list[str]:
+    """The table of contents the best-practices page asks catalog READMEs to be,
+    title, feature count and geometry, one-line description. `nested` links
+    through the group directory for the root catalog."""
+    lines = ["| Collection | Contents | Description |", "|---|---|---|"]
+    for c in colls:
+        path = "/".join(c["seg"]) if nested else c["seg"][-1]
+        lines.append(f"| [{c['title']}](./{path}/README.md) "
+                     f"| {_contents_label(c)} | {c['blurb']} |")
+    return lines
+
+
+def sources_block(colls: list[dict]) -> list[str]:
     """License and provenance lines for a catalog-level README.
 
     core.md requires every README, on catalogs as well as collections, to carry a
@@ -510,6 +668,40 @@ def _catalog_prose(colls: list[dict]) -> list[str]:
     ]
     lines += [f"- {c['title']}, {c['source']}" for c in colls]
     return lines
+
+
+def agents_index(colls: list[dict], nested: bool) -> list[str]:
+    """Child pointers for a catalog-level AGENTS.md, each with its own guide."""
+    lines = []
+    for c in colls:
+        path = "/".join(c["seg"]) if nested else c["seg"][-1]
+        lines.append(f"- {c['title']}, {_contents_label(c)}, guide at "
+                     f"./{path}/AGENTS.md")
+    return lines
+
+
+def catalog_sidecar_bodies(title: str, description: str, colls: list[dict],
+                           nested: bool, templates: dict,
+                           where: str) -> tuple[list[str], list[str]]:
+    """README and AGENTS bodies for a catalog node, template-driven like the
+    collections, with {{collections}}, {{sources}}, and {{agents_index}} blocks."""
+    blocks = {
+        "collections": collections_table(colls, nested),
+        "sources": sources_block(colls),
+        "agents_index": agents_index(colls, nested),
+    }
+    readme_tpl = (templates.get("readme") or "").strip() or (
+        "## Collections\n\n{{collections}}\n\n"
+        "## Where the Data Comes From\n\n{{sources}}")
+    readme = render_template(readme_tpl, blocks, f"{where} readme")
+    if "Licenses," not in "\n".join(readme):
+        readme += [""] + sources_block(colls)
+    agents_tpl = (templates.get("agents") or "").strip() or (
+        f"This catalog groups {len(colls)} Collections. Each carries its own "
+        "AGENTS.md with join keys, quirks, and tested queries, so follow the "
+        "per-collection guides below.\n\n{{agents_index}}")
+    agents = render_template(agents_tpl, blocks, f"{where} agents")
+    return readme, agents
 
 
 def _group_meta(manifest: dict, seg: str) -> tuple[str, str]:
@@ -617,10 +809,11 @@ def build_catalog(manifest: dict, out: Path, cache: Path, only: str | None) -> N
         if gupdates:
             cat["updated"] = max(gupdates)
         (gdir / "catalog.json").write_text(json.dumps(cat, indent=2) + "\n")
-        write_sidecars(gdir, gtitle, gdesc,
-                       [f"Collections, {len(colls)}."] + _catalog_prose(colls),
-                       [f"This catalog groups {len(colls)} Collections under {gtitle}.",
-                        "Follow the child links to each Collection."])
+        templates = (manifest.get("catalogs", {}) or {}).get(gseg, {}) or {}
+        readme, agents = catalog_sidecar_bodies(
+            gtitle, gdesc, colls, nested=False, templates=templates,
+            where=f"catalogs.{gseg}")
+        write_sidecars(gdir, gtitle, gdesc, readme, agents)
 
     # root catalog (only rebuild fully when not filtering to one collection)
     if not only:
@@ -638,10 +831,86 @@ def build_catalog(manifest: dict, out: Path, cache: Path, only: str | None) -> N
         if catalog_updated:
             root["updated"] = catalog_updated
         (out / "catalog.json").write_text(json.dumps(root, indent=2) + "\n")
+        readme, agents = catalog_sidecar_bodies(
+            manifest["title"], manifest["description"].strip(), built,
+            nested=True, templates=manifest.get("docs") or {}, where="docs")
         write_sidecars(out, manifest["title"], manifest["description"].strip(),
-                       [f"Collections, {len(built)}.",
-                        f"Nested Catalogs, {len(groups)}."] + _catalog_prose(built),
-                       [f"This is {manifest['title']}.",
-                        "Follow the child links to each nested Catalog and Collection.",
-                        "Every Collection carries a cloud-native data asset and cites its "
-                        "original upstream source with a real checksum."])
+                       readme, agents)
+
+
+# --------------------------------------------------------------- docs-only regen
+def _facts_from_collection(spec: dict, coll: dict) -> dict:
+    """Rebuild the sidecar facts from a committed collection.json."""
+    assets = coll["assets"]
+    data = assets["data"]
+    data_name = data["href"].removeprefix("./")
+    cols = describe_columns(data.get("table:columns", []), spec.get("columns") or {})
+    join = dict(spec.get("join") or {})
+    if join:
+        join["this_file"] = data_name
+    return {
+        "kind": spec["kind"], "data_name": data_name,
+        "n": data.get("table:row_count", 0), "cols": cols,
+        "bands": data.get("bands", []), "crs": data.get("proj:code"),
+        "aoi": spec.get("bbox"),
+        "has_visual": "visual" in assets, "has_thumb": "thumbnail" in assets,
+        "src": spec["source"], "providers": coll["providers"], "join": join,
+    }
+
+
+def regen_docs(manifest: dict, out: Path, cache: Path) -> None:
+    """Regenerate every README.md and AGENTS.md from the manifest against the
+    already-built tree, no fetch, no conversion.
+
+    Documentation iterates far more often than data, and a full rebuild refetches
+    the live upstream endpoints, churning binary assets under a prose change.
+    This path reads each committed collection.json for the built facts. It also
+    merges the manifest column descriptions back into `table:columns` and
+    refreshes the identity fields the manifest owns, so the metadata surface the
+    docs generate from cannot drift from the manifest that generated the docs."""
+    check_collection_ids(manifest["collections"])
+    built = []
+    for spec in manifest["collections"]:
+        seg = spec["id"].split("/")
+        coll_dir = out.joinpath(*seg)
+        coll_path = coll_dir / "collection.json"
+        coll = json.loads(coll_path.read_text())
+        data = coll["assets"]["data"]
+        if data.get("table:columns"):
+            data["table:columns"] = describe_columns(
+                data["table:columns"], spec.get("columns") or {})
+        coll["title"] = spec["title"]
+        coll["description"] = spec["description"].strip()
+        coll["license"] = spec["license"]
+        coll["keywords"] = spec.get("keywords", [])
+        if spec.get("temporal"):
+            coll.setdefault("extent", {})["temporal"] = {"interval": [spec["temporal"]]}
+        add_metadata_asset(coll["assets"], spec, coll_dir, cache)
+        coll_path.write_text(json.dumps(coll, indent=2) + "\n")
+        facts = _facts_from_collection(spec, coll)
+        write_sidecars(coll_dir, spec["title"], spec["description"].strip(),
+                       collection_readme_extra(spec, facts),
+                       collection_agents_lines(spec, facts))
+        _, is_mirror = resolve_providers(spec, manifest["host"])
+        prov = spec.get("provenance", {}) or {}
+        built.append({"id": spec["id"], "seg": seg, "title": spec["title"],
+                      "updated": prov.get("updated"), "license": spec["license"],
+                      "is_mirror": is_mirror, "source": spec["source"]["url"],
+                      "kind": spec["kind"], "geometry": spec.get("geometry"),
+                      "n": facts["n"], "bands": len(facts["bands"]),
+                      "blurb": blurb(spec)})
+    groups: dict[str, list[dict]] = {}
+    for b in built:
+        groups.setdefault(b["seg"][0], []).append(b)
+    for gseg, colls in groups.items():
+        gtitle, gdesc = _group_meta(manifest, gseg)
+        templates = (manifest.get("catalogs", {}) or {}).get(gseg, {}) or {}
+        readme, agents = catalog_sidecar_bodies(
+            gtitle, gdesc, colls, nested=False, templates=templates,
+            where=f"catalogs.{gseg}")
+        write_sidecars(out / gseg, gtitle, gdesc, readme, agents)
+    readme, agents = catalog_sidecar_bodies(
+        manifest["title"], manifest["description"].strip(), built,
+        nested=True, templates=manifest.get("docs") or {}, where="docs")
+    write_sidecars(out, manifest["title"], manifest["description"].strip(),
+                   readme, agents)

--- a/examples/tools/tests/check_docs.py
+++ b/examples/tools/tests/check_docs.py
@@ -1,0 +1,93 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "duckdb>=1.5.5",
+#   "pandas>=2.2",
+#   "pyarrow>=25",
+#   "geopandas>=1.1",
+#   "rioxarray>=0.17",
+#   "rasterio>=1.5",
+# ]
+# ///
+"""Run every fenced code block in the committed catalog docs.
+
+The documentation best-practices page asks that every example be run before
+publishing, because a broken Quick Start costs more trust than no Quick Start,
+and the most common defect in otherwise strong catalogs is prose that drifted
+from the data. This check makes that rule mechanical. It walks every README.md
+and AGENTS.md under examples/catalog/, extracts the ```sql and ```python
+fences, and executes each one with the doc's own directory as the working
+directory, exactly as a reader following along would.
+
+Blocks that reference a URL are skipped so the suite stays offline and
+deterministic, the weekly upstream workflow covers the network. Other
+languages (bash, json) are skipped as illustration.
+
+Run: uv run examples/tools/tests/check_docs.py
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import duckdb
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CATALOGS = ROOT / "examples/catalog"
+
+FENCE = re.compile(r"^```(\w+)\n(.*?)^```", re.MULTILINE | re.DOTALL)
+RUNNABLE = {"sql", "python"}
+
+
+def blocks(md: Path) -> list[tuple[str, str]]:
+    return [(m.group(1), m.group(2)) for m in FENCE.finditer(md.read_text())]
+
+
+def run_sql(code: str, cwd: Path) -> str | None:
+    con = duckdb.connect()
+    try:
+        con.execute(f"SET file_search_path = '{cwd}'")
+        con.execute(code)
+        return None
+    except Exception as e:  # noqa: BLE001 - report every failure mode the same way
+        return str(e)
+    finally:
+        con.close()
+
+
+def run_python(code: str, cwd: Path) -> str | None:
+    r = subprocess.run([sys.executable, "-c", code], cwd=cwd,
+                       capture_output=True, text=True, timeout=120)
+    return None if r.returncode == 0 else (r.stderr.strip() or r.stdout.strip())
+
+
+def main() -> int:
+    docs = sorted(list(CATALOGS.rglob("README.md")) + list(CATALOGS.rglob("AGENTS.md")))
+    if not docs:
+        print("FAIL no docs found under examples/catalog/")
+        return 1
+    ran = skipped = 0
+    failures: list[str] = []
+    for md in docs:
+        for i, (lang, code) in enumerate(blocks(md), start=1):
+            where = f"{md.relative_to(ROOT)} block {i} ({lang})"
+            if lang not in RUNNABLE or "http://" in code or "https://" in code:
+                skipped += 1
+                continue
+            err = run_sql(code, md.parent) if lang == "sql" else run_python(code, md.parent)
+            ran += 1
+            if err:
+                first = next((ln for ln in err.splitlines() if ln.strip()), err)
+                failures.append(f"{where}\n    {first}")
+    for f in failures:
+        print(f"FAIL {f}")
+    print(f"docs code blocks, {ran} ran, {skipped} skipped as illustrative, "
+          f"{len(failures)} failed")
+    if not failures and ran == 0:
+        print("FAIL nothing ran, the docs carry no runnable blocks at all")
+        return 1
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this changes

Rewrites every README.md and AGENTS.md in the golden example catalog  to better reflect our guidance in `specs/best-practices/documentation.md`, resolving #81. Upgrading the agents / readme's I haven't hand reviewed every file yet, but I looked at 50%+ and I think they're good enough to get in and then we can continue to iterate. Netherlands provinces now mirrors its upstream ISO 19115 record as a metadata-role asset.

## Why

The best-practices page describes narrative READMEs and dataset-specific agent guides, but the examples were generated boilerplate. Research on each dataset also surfaced drift: the Eurostat join example joined on `ISO_A2` and silently dropped France, Norway, and Kosovo, sample-cog claimed BSD-3-Clause though rasterio dedicates its test images to CC0, and the Natural Earth temporal extents postdated their May 2022 releases.

## Verification

Every SQL and Python block in the generated docs runs against the committed data in `examples/catalog/portolan-reference/`, all eight collections:

```
$ uv run examples/tools/tests/check_docs.py
docs code blocks, 36 ran, 2 skipped as illustrative, 0 failed

-- the corrected Eurostat join (2025-S2, KWH2500-4999, I_TAX, EUR), rows the
-- old ISO_A2 join dropped, run against eurostat-electricity-prices.parquet
-- joined to natural-earth-countries.parquet:
Greece 0.2378 | France 0.2561 | Norway 0.1922 | Kosovo 0.0877  eur_per_kwh

-- local runs of check_cog.py and check_validate.py fail identically on a
-- clean main checkout (rasterio/PROJ environment issue on this machine).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GpjMvzar8Rpo3pcV6WoJb

