### PR TITLE
feat(spec): allow image/webp for thumbnails

### DIFF
--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -223,7 +223,7 @@ The required media type for each core format is:
 | COG | `image/tiff; application=geotiff; profile=cloud-optimized` |
 | PMTiles | `application/vnd.pmtiles` |
 | COPC | `application/vnd.laszip+copc` |
-| Thumbnail | `image/png` or `image/jpeg` |
+| Thumbnail | `image/png`, `image/jpeg`, or `image/webp` |
 
 Roles describe what each asset is for. Portolan uses the standard STAC role names
 wherever they fit and requires at least one per asset: `data` for the primary

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -258,7 +258,7 @@ requirements:
       | COG | `image/tiff; application=geotiff; profile=cloud-optimized` |
       | PMTiles | `application/vnd.pmtiles` |
       | COPC | `application/vnd.laszip+copc` |
-      | Thumbnail | `image/png` or `image/jpeg` |
+      | Thumbnail | `image/png`, `image/jpeg`, or `image/webp` |
 
   - id: PORTO-CORE-027
     severity: MUST

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `PORTO-CORE-026`: `image/webp` is now a valid thumbnail media type alongside
+  `image/png` and `image/jpeg`. No existing catalog breaks.
+
 ## 0.1.0 - 2026-07-27
 
 First tagged release. The schema is published at

--- a/stac/README.md
+++ b/stac/README.md
@@ -106,7 +106,7 @@ Whether a catalog is official or a mirror is derived from its providers (produce
 | COG | `image/tiff; application=geotiff; profile=cloud-optimized` | `data` |
 | PMTiles | `application/vnd.pmtiles` | `visual` |
 | COPC | `application/vnd.laszip+copc` | `data` |
-| Thumbnail | `image/png` or `image/jpeg` | `thumbnail` |
+| Thumbnail | `image/png`, `image/jpeg`, or `image/webp` | `thumbnail` |
 | Sidecar metadata | (format-specific) | `metadata`, `iso-19115` |
 | MapLibre style | `application/vnd.mapbox.style+json` | `style` (Portolan-defined role) |
 


### PR DESCRIPTION
## What this changes

`PORTO-CORE-026` accepts `image/webp` for thumbnails alongside `image/png` and
`image/jpeg`. The media-type table in `core.md`, its quote in `requirements.yaml`, and
the asset table in `stac/README.md` all name the same three types.

## Why

Resolves #120. Upgrading the portolan-nl demo catalog, its PNG thumbnails came to
160 MB. They could be smaller as PNG, but WebP gives a good bit more on top of that.
Browser support is very broad — many CMSs emit WebP by default — and smaller files make
for faster loading. AVIF is worth considering later; I have seen less of it in the wild.

## Verification

The validator half is portolan-sdi/rashid#91. Against the publish tree of
https://data.source.coop/cholmes/portolan-nl, whose 32 collection thumbnails are WebP,
`PTL-VIZ-001` fired on every one before the change and on none after:

```
$ for ref in main feat/webp-thumbnails; do
    git checkout -q $ref
    printf "%-22s PTL-VIZ-001 findings: " "$ref"
    uv run --frozen rashid check ~/repos/portolan-nl-catalog/catalog --no-data --json \
      | jq '[.findings[] | select(.rule_id == "PTL-VIZ-001")] | length'
  done
main                   PTL-VIZ-001 findings: 32
feat/webp-thumbnails   PTL-VIZ-001 findings: 0
```

Companion-PR: portolan-sdi/rashid#91

## Related issues

Resolves #120
