### PR TITLE
docs: name the STAC-GeoParquet item mirror in full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Changed
 
+- **"Item mirror" is now spelled out wherever it appears** (PORTO-FMT-040,
+  PORTO-FMT-041, PORTO-FMT-043): the stac-geoparquet copy of a collection's items
+  is named "item mirror" or "STAC-GeoParquet mirror" in every sentence that
+  mentions it, so bare "mirror" keeps its provenance meaning of a catalog
+  republishing data it did not produce. Wording only; no requirement changes
+  force, and the upstream role value `collection-mirror` is untouched (#99).
 - **Assets** (PORTO-CORE-028): `file:size` and `file:checksum` drop from MUST to
   SHOULD. A catalog that describes data it does not host often cannot produce a
   checksum, so the old MUST left it a choice between failing conformance and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Changed
 
-- **"Item mirror" is now spelled out wherever it appears** (PORTO-FMT-040,
-  PORTO-FMT-041, PORTO-FMT-043): the stac-geoparquet copy of a collection's items
-  is named "item mirror" or "STAC-GeoParquet mirror" in every sentence that
-  mentions it, so bare "mirror" keeps its provenance meaning of a catalog
-  republishing data it did not produce. Wording only; no requirement changes
-  force, and the upstream role value `collection-mirror` is untouched (#99).
+- **"Item mirror" is now used consistently** (PORTO-FMT-040, PORTO-FMT-041,
+  PORTO-FMT-043). The STAC-GeoParquet copy of a collection's items is now always
+  referred to as an **item mirror** or **STAC-GeoParquet mirror**, leaving the
+  unqualified term **mirror** to its longstanding provenance meaning: a catalog
+  republishing data it did not produce. This is a wording-only change. The
+  requirements are unchanged, and the upstream role value `collection-mirror` is
+  unaffected (#99).
 - **Assets** (PORTO-CORE-028): `file:size` and `file:checksum` drop from MUST to
   SHOULD. A catalog that describes data it does not host often cannot produce a
   checksum, so the old MUST left it a choice between failing conformance and

--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -14,4 +14,4 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
-| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; a collection mirror still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |
+| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; STAC-GeoParquet mirrors of collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -14,4 +14,4 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
-| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; mirroring collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |
+| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; a collection mirror still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/stac-geoparquet.md
+++ b/specs/incubating/stac-geoparquet.md
@@ -1,35 +1,39 @@
 # Incubating — STAC-GeoParquet Beyond Raster Items
 
-**Status: maturing convention, may become required.**
+**Status: Maturing convention; may become required.**
 
-The item mirror for raster collections is ratified. See [Raster § Item
-mirror](../portolan/formats.md#raster). It graduated first because
-[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) tooling already
-writes and reads `items.parquet`, and because scene collections are where
-per-item JSON fetches hurt most.
+The **item mirror** for raster collections is now ratified. See [Raster § Item
+mirror](../portolan/formats.md#raster).
 
-Both senses of *mirror* on this page are STAC-GeoParquet mirrors: Parquet copies
-of STAC metadata. Neither is the provenance mirror of [Source
-Provenance](../portolan/core.md#source-provenance), where a mirror is a catalog
-republishing data it did not produce.
+An item mirror is a STAC-GeoParquet file containing a collection's items. It is
+**not** the provenance meaning of *mirror* used elsewhere in Portolan, where a
+mirror is a catalog republishing data it did not produce. See [Source
+Provenance](../portolan/core.md#source-provenance).
 
-Two extensions of the idea are still open.
+Raster item mirrors graduated first because existing `stac-geoparquet` tooling
+already reads and writes `items.parquet`, and because raster scene collections
+benefit most from avoiding large numbers of per-item JSON requests.
 
-## A STAC-GeoParquet mirror of collections themselves
+Two extensions remain incubating.
 
-One construct should cover every collection a catalog holds, whatever the data
-underneath — COGs, vector, point clouds. A Parquet mirror of the collections
-would let a client search across a catalog in one read, as `items.parquet` does
-within one collection, and would carry the same terms to collection types that
-today publish no item mirror at all.
+## STAC-GeoParquet Mirrors of Collections
 
-The encoding is unsettled. Collection extents are ranges rather than footprints,
-summaries vary in shape, and no tooling reads such a file today.
+An item mirror indexes the items in a single collection. A complementary
+construct could index the collections in an entire catalog, regardless of
+whether they contain COGs, vector data, or point clouds. Like `items.parquet`
+within a collection, such a file would let clients search every collection in a
+catalog with a single read. It would also provide the same capability for
+collection types that do not currently publish item mirrors.
 
-## A whole STAC catalog in Parquet
+The encoding is still unsettled. Collection extents are ranges rather than
+footprints, summaries have no standard representation, and no existing tooling
+reads such a file.
 
-Beyond an item mirror or a collection mirror, the longer-term goal is a Parquet
-representation complete enough to reconstruct a catalog: catalogs, collections,
-items, and links in one queryable set of files. That work belongs upstream in
-`stac-geoparquet` first. Portolan should adopt the convention once it exists
-there, rather than invent a parallel one.
+## Complete STAC Catalogs in GeoParquet
+
+The longer-term goal is a STAC-GeoParquet representation that can reconstruct an
+entire catalog: catalogs, collections, items, and links stored in a queryable
+set of Parquet files.
+
+That work belongs upstream in `stac-geoparquet`. Portolan should adopt the
+upstream convention once it exists rather than defining its own.

--- a/specs/incubating/stac-geoparquet.md
+++ b/specs/incubating/stac-geoparquet.md
@@ -8,22 +8,27 @@ mirror](../portolan/formats.md#raster). It graduated first because
 writes and reads `items.parquet`, and because scene collections are where
 per-item JSON fetches hurt most.
 
+Both senses of *mirror* on this page are STAC-GeoParquet mirrors: Parquet copies
+of STAC metadata. Neither is the provenance mirror of [Source
+Provenance](../portolan/core.md#source-provenance), where a mirror is a catalog
+republishing data it did not produce.
+
 Two extensions of the idea are still open.
 
-## Mirroring collections themselves
+## A STAC-GeoParquet mirror of collections themselves
 
 One construct should cover every collection a catalog holds, whatever the data
 underneath — COGs, vector, point clouds. A Parquet mirror of the collections
 would let a client search across a catalog in one read, as `items.parquet` does
 within one collection, and would carry the same terms to collection types that
-today publish no mirror at all.
+today publish no item mirror at all.
 
 The encoding is unsettled. Collection extents are ranges rather than footprints,
 summaries vary in shape, and no tooling reads such a file today.
 
 ## A whole STAC catalog in Parquet
 
-Beyond mirroring items or collections, the longer-term goal is a Parquet
+Beyond an item mirror or a collection mirror, the longer-term goal is a Parquet
 representation complete enough to reconstruct a catalog: catalogs, collections,
 items, and links in one queryable set of files. That work belongs upstream in
 `stac-geoparquet` first. Portolan should adopt the convention once it exists

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -168,13 +168,15 @@ Compliance is defined by the tag contents, not by use of GDAL.
 collection's item metadata, in place of one HTTP fetch per scene. Clients can search a large
 scene collection, or assemble it into a data cube, without a STAC API server.
 
-An item mirror is a Parquet copy of one collection's items. It is a different thing from the
-provenance sense of *mirror* used elsewhere in Portolan, where a mirror is a catalog
-republishing data it did not produce. See [Source Provenance](core.md#source-provenance).
-Always name this one in full.
+An **item mirror** is a Parquet copy of a collection's items. This is distinct from
+Portolan's provenance meaning of *mirror*, where a mirror is a catalog republishing data it
+did not produce. See [Source Provenance](core.md#source-provenance).
 
-No item-count threshold applies. Tooling generates the item mirror from the item JSON, and
-the saved fetches add up at any size.
+Always refer to this construct as an **item mirror** or **STAC-GeoParquet mirror**, never
+simply **mirror**.
+
+No item-count threshold applies. Tooling generates the item mirror directly from the item
+JSON, and avoiding repeated JSON fetches provides a benefit even for small collections.
 
 A published item mirror MUST be registered as a collection-level asset carrying media type
 `application/vnd.apache.parquet` and the role `collection-mirror`, per [Referencing STAC
@@ -182,19 +184,21 @@ Geoparquet Collections in STAC Collection
 JSON](https://radiantearth.github.io/stac-geoparquet-spec/latest/#referencing-a-stac-geoparquet-collections-in-a-stac-collection-json).
 That single registration is the whole requirement; no `rel: "items"` link is needed.
 
-The item JSON stays normative and the Parquet mirrors it, so the file MUST reproduce the
-collection's items exactly at publish time — one row per item, each row carrying that
-item's fields. An item mirror that lags its items answers queries wrongly, and the client
-reading it cannot tell.
+The item JSON remains the normative representation. An item mirror is a derived Parquet copy
+and MUST exactly reproduce the collection's items at publication time: one row per item,
+with every row containing that item's fields.
 
-The GeoParquet requirements above bind the item mirror as they bind vector data: rows MUST
-be spatially ordered, the file MUST carry per-row-group spatial statistics, and row groups
-MUST hold no more than 150,000 rows. An item index is queried by extent like any other
-spatial table, and readers prune it the same way.
+An item mirror that falls out of sync with its source items produces incorrect query
+results, and clients have no reliable way to detect the mismatch.
 
-A collection holding a single COG has no items and publishes no item mirror. Item mirrors
-for other collection types, and a STAC-GeoParquet mirror of a whole catalog's collections,
-remain incubating. See
+The GeoParquet requirements above apply to item mirrors exactly as they apply to vector
+datasets. Rows MUST be spatially ordered, the file MUST include per-row-group spatial
+statistics, and row groups MUST contain no more than 150,000 rows. Clients query an item
+mirror spatially just as they query any other GeoParquet dataset.
+
+A collection containing only a single COG has no items and therefore publishes no item
+mirror. Item mirrors for other collection types, and STAC-GeoParquet mirrors covering an
+entire catalog's collections, remain incubating. See
 [`specs/incubating/stac-geoparquet.md`](../incubating/stac-geoparquet.md).
 
 Raster styling (colormaps, legends, continuous vs. categorical vs. multiband) is

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -163,15 +163,20 @@ The exact on-disk encoding (the TIFF `GDAL_METADATA` tag and its XML layout, and
 Compliance is defined by the tag contents, not by use of GDAL.
 
 **Item mirror.** A raster collection that models scenes as items SHOULD also publish a
-[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) mirror of those items at
+[stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) item mirror at
 `items.parquet` in the collection root. One range request then returns the whole
 collection's item metadata, in place of one HTTP fetch per scene. Clients can search a large
 scene collection, or assemble it into a data cube, without a STAC API server.
 
-No item-count threshold applies. Tooling generates the mirror from the item JSON, and the
-saved fetches add up at any size.
+An item mirror is a Parquet copy of one collection's items. It is a different thing from the
+provenance sense of *mirror* used elsewhere in Portolan, where a mirror is a catalog
+republishing data it did not produce. See [Source Provenance](core.md#source-provenance).
+Always name this one in full.
 
-A published mirror MUST be registered as a collection-level asset carrying media type
+No item-count threshold applies. Tooling generates the item mirror from the item JSON, and
+the saved fetches add up at any size.
+
+A published item mirror MUST be registered as a collection-level asset carrying media type
 `application/vnd.apache.parquet` and the role `collection-mirror`, per [Referencing STAC
 Geoparquet Collections in STAC Collection
 JSON](https://radiantearth.github.io/stac-geoparquet-spec/latest/#referencing-a-stac-geoparquet-collections-in-a-stac-collection-json).
@@ -179,16 +184,17 @@ That single registration is the whole requirement; no `rel: "items"` link is nee
 
 The item JSON stays normative and the Parquet mirrors it, so the file MUST reproduce the
 collection's items exactly at publish time — one row per item, each row carrying that
-item's fields. A mirror that lags its items answers queries wrongly, and the client reading
-it cannot tell.
+item's fields. An item mirror that lags its items answers queries wrongly, and the client
+reading it cannot tell.
 
-The GeoParquet requirements above bind the mirror as they bind vector data: rows MUST be
-spatially ordered, the file MUST carry per-row-group spatial statistics, and row groups
+The GeoParquet requirements above bind the item mirror as they bind vector data: rows MUST
+be spatially ordered, the file MUST carry per-row-group spatial statistics, and row groups
 MUST hold no more than 150,000 rows. An item index is queried by extent like any other
 spatial table, and readers prune it the same way.
 
-A collection holding a single COG has no items and publishes no mirror. Mirroring other
-collection types, and mirroring a whole catalog's collections, remain incubating. See
+A collection holding a single COG has no items and publishes no item mirror. Item mirrors
+for other collection types, and a STAC-GeoParquet mirror of a whole catalog's collections,
+remain incubating. See
 [`specs/incubating/stac-geoparquet.md`](../incubating/stac-geoparquet.md).
 
 Raster styling (colormaps, legends, continuous vs. categorical vs. multiband) is

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -1026,15 +1026,15 @@ requirements:
     file: specs/portolan/formats.md
     quote: >-
       A raster collection that models scenes as items SHOULD also publish a
-      [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) mirror
-      of those items at `items.parquet` in the collection root.
+      [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) item
+      mirror at `items.parquet` in the collection root.
 
   - id: PORTO-FMT-041
     severity: MUST
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      A published mirror MUST be registered as a collection-level asset
+      A published item mirror MUST be registered as a collection-level asset
       carrying media type `application/vnd.apache.parquet` and the role
       `collection-mirror`
 
@@ -1051,9 +1051,10 @@ requirements:
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      The GeoParquet requirements above bind the mirror as they bind vector
-      data: rows MUST be spatially ordered, the file MUST carry per-row-group
-      spatial statistics, and row groups MUST hold no more than 150,000 rows.
+      The GeoParquet requirements above bind the item mirror as they bind
+      vector data: rows MUST be spatially ordered, the file MUST carry
+      per-row-group spatial statistics, and row groups MUST hold no more than
+      150,000 rows.
 
 exclusions:
   # RFC 2119 preamble: keyword mentions, not requirements.

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -1043,18 +1043,19 @@ requirements:
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      the file MUST reproduce the collection's items exactly at publish time —
-      one row per item, each row carrying that item's fields.
+      An item mirror is a derived Parquet copy and MUST exactly reproduce the
+      collection's items at publication time: one row per item, with every row
+      containing that item's fields.
 
   - id: PORTO-FMT-043
     severity: MUST
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      The GeoParquet requirements above bind the item mirror as they bind
-      vector data: rows MUST be spatially ordered, the file MUST carry
-      per-row-group spatial statistics, and row groups MUST hold no more than
-      150,000 rows.
+      The GeoParquet requirements above apply to item mirrors exactly as they
+      apply to vector datasets. Rows MUST be spatially ordered, the file MUST
+      include per-row-group spatial statistics, and row groups MUST contain no
+      more than 150,000 rows.
 
 exclusions:
   # RFC 2119 preamble: keyword mentions, not requirements.


### PR DESCRIPTION
## What this changes

References to the STAC-Geoparquet copy of a collection's items now consistently call it an **item mirror** or **STAC-Geoparquet mirror**. The unqualified term **mirror** retains its longstanding provenance meaning: a catalog republishing data it did not produce.

`formats.md` and the incubating specification each gained a note pointing readers to the other use of the term. No identifiers changed, and the upstream role value `collection-mirror` remains unchanged.

## Why

Resolves #99. Commit `935bcab` adopted *mirror* for the STAC-Geoparquet item rollup, but the term already meant a provenance mirror in roughly forty locations, including `core.md` and the `is_mirror` variable in `stacio.py`. Because both meanings are normative, a reader encountering *mirror* in `formats.md` could not determine which concept was intended.

Renaming is not practical. The provenance meaning is deeply established, and `collection-mirror` is an upstream STAC-Geoparquet role value. Qualifying the newer meaning leaves the original usage untouched.

This is a wording-only change, so it is a PATCH under the bump policy. PORTO-FMT-040, PORTO-FMT-041, and PORTO-FMT-043 are unchanged.

## Verification

The requirements manifest quotes `formats.md` verbatim, so any divergence fails the requirements check. It passes, and the profile examples continue to validate.

Data read: `specs/portolan/`, `stac/examples/`.

```text
$ python3 specs/tools/check_requirements.py
OK: 115 requirements anchored; all keyword occurrences covered.

$ cd stac && npm test
Files: 4
Valid: 4
Invalid: 0
✓ catalog.json
✓ vector-collection.json
✓ vector-partitioned-collection.json
✓ vector-partitioned-item.json
```
