### PR TITLE
docs: add incubating spec for zarr

### DIFF
--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -13,5 +13,6 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 |-----|--------|
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
+| [`zarr.md`](zarr.md) | Open — multidimensional raster; awaiting Zarr convention stability and a reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
 | [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; STAC-GeoParquet mirrors of collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -13,6 +13,6 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 |-----|--------|
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
-| [`zarr.md`](zarr.md) | Open — multidimensional raster; awaiting Zarr convention stability and a reference implementation |
+| [`zarr.md`](zarr.md) | Open — multidimensional raster; awaiting Zarr convention stability and a reference implementation ([#132](https://github.com/portolan-sdi/portolan-spec/issues/132)) |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
 | [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; STAC-GeoParquet mirrors of collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/zarr.md
+++ b/specs/incubating/zarr.md
@@ -1,109 +1,109 @@
 # Incubating — Zarr
 
-**Status: open, awaiting convention stability and a reference implementation.**
+**Status: Open. Waiting for the Zarr conventions and a reference implementation to stabilize.**
 
-Portolan requires raster data as COG. That requirement holds for imagery and
-single-timestep rasters, and it will keep holding. Zarr addresses what COG cannot
-express: a multidimensional cube indexed by time, band, or depth as well as by x
-and y. Several large public datasets are already published this way, so Portolan
-needs a defined path for cataloging them.
+Portolan currently requires raster data to be published as COG. That remains the right format for imagery and single-timestep rasters.
 
-Two things must settle before that path becomes normative. The conventions Portolan
-would cite are pre-stable, and no validator can check them yet.
+Zarr is needed for a different use case: multidimensional raster data, such as data indexed by time, depth, or multiple bands as well as x/y. Several major public datasets already use Zarr, so Portolan needs a way to catalog these datasets eventually.
 
-## "GeoZarr" Does Not Name a Document
+We are not ready to make Zarr normative yet. The conventions Portolan would need to rely on are still experimental, and there is no validator that can check a complete Zarr dataset against them.
 
-The [geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has
-never released a version. Its README states the specification "will be produced once
-a set of mature conventions forms a coherent and recommended suite." Work moved to
-individual conventions published under the
-[zarr-conventions](https://github.com/zarr-conventions) organization.
+## There is no stable "GeoZarr" specification yet
 
-Three are under active development:
+The [geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has never released a specification. Its README says that a specification will be produced once the underlying conventions are mature enough to form a coherent suite.
 
-| Convention | Purpose | UUID |
-|------------|---------|------|
-| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids | `d35379db-88df-4056-af3a-620245f8e347` |
-| [proj](https://github.com/zarr-conventions/proj) | Coordinate reference system | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
-| [spatial](https://github.com/zarr-conventions/spatial) | Array index to x/y coordinate mapping | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
+The work has instead moved into separate conventions maintained by the [zarr-conventions](https://github.com/zarr-conventions) organization.
 
-CF in Zarr, DGGS in Zarr, and TileMatrixSet are under consideration and have no
-stable repository.
+The three relevant conventions currently under active development are:
 
-All three active conventions are at v0.1 with maturity "Pilot." Each warns that
-breaking changes should be expected before v1, anticipated before the end of 2026.
+| Convention                                                     | Purpose                                  | UUID                                   |
+| -------------------------------------------------------------- | ---------------------------------------- | -------------------------------------- |
+| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids                      | `d35379db-88df-4056-af3a-620245f8e347` |
+| [proj](https://github.com/zarr-conventions/proj)               | Coordinate reference system              | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
+| [spatial](https://github.com/zarr-conventions/spatial)         | Mapping array indices to x/y coordinates | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
 
-A convention declares itself through an entry in the `zarr_conventions` array in the
-store's attributes, carrying its UUID and a `schema_url` whose tag conveys the
-version. There is no separate version field. Portolan already treats a schema URI as
-the sole version signal, so the two models compose without translation.
+CF in Zarr, DGGS in Zarr, and TileMatrixSet are also being considered, but none currently has a stable repository.
 
-The practical consequence: a Portolan requirement must cite conventions and UUIDs,
-not "GeoZarr." A catalog claiming GeoZarr conformance today names no checkable
-document.
+All three active conventions are v0.1, with maturity marked as "Pilot." They explicitly warn that breaking changes are expected before v1.
 
-## Direction
+A Zarr store declares conventions through its `zarr_conventions` attribute. Each entry contains a convention UUID and a `schema_url` whose version tag identifies the version. There is no separate version field.
 
-Zarr raster data would be provided as a Zarr v3 store declaring all three
-conventions, with consolidated metadata at the store root so a reader retrieves the
-hierarchy in one request.
+This fits Portolan's existing model, where the schema URI is the version signal.
 
-Multiscales carries the weight. Without a resolution pyramid, a Zarr store performs
-in a browser the way a plain GeoTIFF does: usable only when the whole array fits in
-memory. With one, it approaches COG. This is the same requirement Portolan already
-imposes on COG, where internal overviews are raised from a validator warning to a
-conformance failure. The reasoning transfers directly.
+**For now, Portolan should therefore refer to specific Zarr conventions and UUIDs, not to "GeoZarr" as though it were a published specification.**
 
-Declaring the convention is weaker than satisfying it. The multiscales convention
-requires a `layout` array but sets no floor on how many levels it contains, so a
-single-level pyramid declares conformance while delivering nothing. Portolan's COG
-rule states the floor explicitly: overviews extend until the coarsest level spans one
-tile. Whether Portolan restates that floor for multiscales, or waits for the
-convention to define it, is open.
+## Proposed direction
 
-## Open Questions
+When Zarr support becomes normative, Portolan would require a Zarr v3 store declaring the relevant conventions and providing consolidated metadata at the store root.
 
-**Statistics.** Portolan requires every COG band to carry embedded minimum, maximum,
-mean, and standard deviation so a renderer can scale any data type without reading
-pixels. Zarr has no equivalent convention. Without one, a client cannot colorize a
-float array it has never opened. Nothing in the current suite fills this gap.
+The most important convention is `multiscales`.
 
-**Chunk sizing.** The COG rule caps internal tiles at roughly a screen viewport,
-512×512 by convention. Zarr chunks serve the same role, and v3 sharding lets many
-chunks share one object, which keeps stores from fragmenting into millions of keys.
-Neither has a stated target here.
+A Zarr array without a resolution pyramid has poor browser performance when the full-resolution array is too large to load into memory. A multiscale pyramid allows clients to request an appropriate resolution instead, which is the same basic reason Portolan requires overviews in COGs.
 
-**A store is not a file.** Portolan asset rules assume an href resolving to bytes.
-`file:size` and `file:checksum` MUST match the bytes the href resolves to, and a
-Zarr href points at a store root holding thousands of objects. Either these fields
-are undefined for Zarr assets, or Portolan defines what they cover.
+However, simply declaring `multiscales` is not enough. The current convention requires a `layout` array but does not specify a minimum number of pyramid levels. A one-level pyramid could therefore satisfy the convention without providing a useful overview.
 
-**STAC modeling.** The media type is `application/vnd.zarr`. Beyond that the ground
-is unsettled. The [xarray-assets](https://github.com/stac-extensions/xarray-assets)
-extension, which carried the reader hints most published Zarr assets use, was
-deprecated and archived in June 2025; its authors point to a `zarr` extension that
-does not yet exist. The [datacube](https://github.com/stac-extensions/datacube)
-extension (v2.3.0) describes dimensions and variables and is the likely vehicle for
-declaring cube structure, but whether Portolan requires it is undecided.
+Portolan's COG requirements already define an explicit minimum overview depth: the pyramid must continue until the coarsest level fits within one tile.
 
-**Styling.** Raster styling is unresolved for COG already
-([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see
-[`raster-styling.md`](raster-styling.md)). Zarr inherits that gap and widens it: a
-cube has no single band set to style.
+We need to decide whether Zarr conformance should impose an equivalent minimum, or whether Portolan should wait for the multiscales convention to define one.
 
-**Collection structure.** A COG scene collection models each scene as an item. One
-Zarr store often holds what would otherwise be thousands of scenes, so the item
-boundary has no obvious analogue. Whether a store is one collection-level asset, or
-items index slices of it, needs deciding.
+## Open questions
 
-**Transactional stores.** [Icechunk](https://icechunk.io/) adds versioning and
-transactions over Zarr and is in use for datasets that would otherwise be plain Zarr.
-Whether such a store can satisfy Portolan's browser-reachable access requirements is
-unexamined.
+### Statistics
 
-## Graduation
+Portolan requires COG bands to contain embedded minimum, maximum, mean, and standard deviation values. These let clients style data without first reading the pixels.
 
-This document graduates into `formats.md` when the three conventions reach v1, a
-statistics answer exists, and a validator can check convention declarations against
-store contents. Following the precedent set for point clouds, a reference
-implementation comes first.
+Zarr currently has no equivalent convention. We need to decide whether Portolan requires statistics for Zarr and, if so, where they come from.
+
+### Chunk sizing
+
+COG internal tiles are capped at roughly a screen-sized block, conventionally 512×512. Zarr chunks serve a similar purpose.
+
+Zarr v3 sharding can group many chunks into one object, avoiding a store containing millions of individual objects. Portolan does not yet have requirements for either chunk size or sharding.
+
+### A Zarr store is not a file
+
+Portolan's asset rules currently assume that an `href` resolves to a file. `file:size` and `file:checksum` describe the bytes at that location.
+
+A Zarr `href` instead points to a store containing many objects.
+
+We therefore need to decide whether these file properties are omitted for Zarr assets or whether Portolan defines what they mean for a store.
+
+### STAC modeling
+
+The media type for Zarr is `application/vnd.zarr`, but the STAC model is not settled.
+
+The [xarray-assets](https://github.com/stac-extensions/xarray-assets) extension was deprecated and archived in June 2025. Its authors pointed toward a future `zarr` extension that does not yet exist.
+
+The [datacube](https://github.com/stac-extensions/datacube) extension (v2.3.0) describes dimensions and variables and may provide the structure Portolan needs. Whether Portolan requires it remains open.
+
+### Styling
+
+Raster styling is already unresolved for COG ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see `raster-styling.md`).
+
+Zarr makes this more complicated because a cube may contain many dimensions and variables rather than a single fixed set of bands.
+
+### Collection structure
+
+A COG collection can naturally represent each scene as a STAC Item.
+
+A single Zarr store may instead contain data that would correspond to thousands of scenes. There is no obvious equivalent item boundary.
+
+We need to decide whether the store is represented as one collection-level asset or whether STAC Items index subsets of the store.
+
+### Transactional stores
+
+[Icechunk](https://icechunk.io/) provides versioning and transactions on top of Zarr and is already used for datasets that might otherwise be published as ordinary Zarr.
+
+We have not yet determined whether an Icechunk-backed store can meet Portolan's requirements for browser-accessible data.
+
+## When this becomes normative
+
+This document should move into `formats.md` once:
+
+1. the relevant Zarr conventions reach v1;
+2. Portolan has an answer for statistics;
+3. the STAC and asset model is defined;
+4. the remaining storage requirements, such as chunking, are resolved; and
+5. a validator and reference implementation can verify the resulting requirements.
+
+As with the point-cloud format, the reference implementation should be established before the format becomes normative.

--- a/specs/incubating/zarr.md
+++ b/specs/incubating/zarr.md
@@ -1,0 +1,109 @@
+# Incubating — Zarr
+
+**Status: open, awaiting convention stability and a reference implementation.**
+
+Portolan requires raster data as COG. That requirement holds for imagery and
+single-timestep rasters, and it will keep holding. Zarr addresses what COG cannot
+express: a multidimensional cube indexed by time, band, or depth as well as by x
+and y. Several large public datasets are already published this way, so Portolan
+needs a defined path for cataloging them.
+
+Two things must settle before that path becomes normative. The conventions Portolan
+would cite are pre-stable, and no validator can check them yet.
+
+## "GeoZarr" Does Not Name a Document
+
+The [geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has
+never released a version. Its README states the specification "will be produced once
+a set of mature conventions forms a coherent and recommended suite." Work moved to
+individual conventions published under the
+[zarr-conventions](https://github.com/zarr-conventions) organization.
+
+Three are under active development:
+
+| Convention | Purpose | UUID |
+|------------|---------|------|
+| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids | `d35379db-88df-4056-af3a-620245f8e347` |
+| [proj](https://github.com/zarr-conventions/proj) | Coordinate reference system | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
+| [spatial](https://github.com/zarr-conventions/spatial) | Array index to x/y coordinate mapping | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
+
+CF in Zarr, DGGS in Zarr, and TileMatrixSet are under consideration and have no
+stable repository.
+
+All three active conventions are at v0.1 with maturity "Pilot." Each warns that
+breaking changes should be expected before v1, anticipated before the end of 2026.
+
+A convention declares itself through an entry in the `zarr_conventions` array in the
+store's attributes, carrying its UUID and a `schema_url` whose tag conveys the
+version. There is no separate version field. Portolan already treats a schema URI as
+the sole version signal, so the two models compose without translation.
+
+The practical consequence: a Portolan requirement must cite conventions and UUIDs,
+not "GeoZarr." A catalog claiming GeoZarr conformance today names no checkable
+document.
+
+## Direction
+
+Zarr raster data would be provided as a Zarr v3 store declaring all three
+conventions, with consolidated metadata at the store root so a reader retrieves the
+hierarchy in one request.
+
+Multiscales carries the weight. Without a resolution pyramid, a Zarr store performs
+in a browser the way a plain GeoTIFF does: usable only when the whole array fits in
+memory. With one, it approaches COG. This is the same requirement Portolan already
+imposes on COG, where internal overviews are raised from a validator warning to a
+conformance failure. The reasoning transfers directly.
+
+Declaring the convention is weaker than satisfying it. The multiscales convention
+requires a `layout` array but sets no floor on how many levels it contains, so a
+single-level pyramid declares conformance while delivering nothing. Portolan's COG
+rule states the floor explicitly: overviews extend until the coarsest level spans one
+tile. Whether Portolan restates that floor for multiscales, or waits for the
+convention to define it, is open.
+
+## Open Questions
+
+**Statistics.** Portolan requires every COG band to carry embedded minimum, maximum,
+mean, and standard deviation so a renderer can scale any data type without reading
+pixels. Zarr has no equivalent convention. Without one, a client cannot colorize a
+float array it has never opened. Nothing in the current suite fills this gap.
+
+**Chunk sizing.** The COG rule caps internal tiles at roughly a screen viewport,
+512×512 by convention. Zarr chunks serve the same role, and v3 sharding lets many
+chunks share one object, which keeps stores from fragmenting into millions of keys.
+Neither has a stated target here.
+
+**A store is not a file.** Portolan asset rules assume an href resolving to bytes.
+`file:size` and `file:checksum` MUST match the bytes the href resolves to, and a
+Zarr href points at a store root holding thousands of objects. Either these fields
+are undefined for Zarr assets, or Portolan defines what they cover.
+
+**STAC modeling.** The media type is `application/vnd.zarr`. Beyond that the ground
+is unsettled. The [xarray-assets](https://github.com/stac-extensions/xarray-assets)
+extension, which carried the reader hints most published Zarr assets use, was
+deprecated and archived in June 2025; its authors point to a `zarr` extension that
+does not yet exist. The [datacube](https://github.com/stac-extensions/datacube)
+extension (v2.3.0) describes dimensions and variables and is the likely vehicle for
+declaring cube structure, but whether Portolan requires it is undecided.
+
+**Styling.** Raster styling is unresolved for COG already
+([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see
+[`raster-styling.md`](raster-styling.md)). Zarr inherits that gap and widens it: a
+cube has no single band set to style.
+
+**Collection structure.** A COG scene collection models each scene as an item. One
+Zarr store often holds what would otherwise be thousands of scenes, so the item
+boundary has no obvious analogue. Whether a store is one collection-level asset, or
+items index slices of it, needs deciding.
+
+**Transactional stores.** [Icechunk](https://icechunk.io/) adds versioning and
+transactions over Zarr and is in use for datasets that would otherwise be plain Zarr.
+Whether such a store can satisfy Portolan's browser-reachable access requirements is
+unexamined.
+
+## Graduation
+
+This document graduates into `formats.md` when the three conventions reach v1, a
+statistics answer exists, and a validator can check convention declarations against
+store contents. Following the precedent set for point clouds, a reference
+implementation comes first.

--- a/specs/incubating/zarr.md
+++ b/specs/incubating/zarr.md
@@ -68,21 +68,27 @@ A store MUST provide consolidated metadata at its root so a client can discover 
 
 Portolan requires a multiscale pyramid for large raster datasets for the same reason it requires internal overviews in COGs: a client should be able to display the dataset at lower zoom levels without fetching full-resolution pixels.
 
-The multiscales convention establishes the pyramid structure but does not currently define how deep a pyramid must be for this purpose. The required minimum depth is therefore still an open Portolan question.
+Portolan sets no minimum pyramid depth. The multiscales convention requires a non-empty `layout` and prescribes neither a level count nor a downsampling factor, and renderers follow it. The GeoZarr layout schema in [`@developmentseed/deck.gl-zarr`](https://github.com/developmentseed/deck.gl-raster/blob/main/packages/geozarr/src/schemas.ts) validates `layout` with `min(1)`, its tileset derives the available zoom range from `levels.length`, and [`zarr-viewer`](https://github.com/source-cooperative/zarr-viewer/blob/main/src/zarr/multiscale.ts) accepts a one-level layout, rejecting only an empty one. Published datasets vary widely: the Fields of The World global predictions carry fourteen levels and Meta CHM v2 carries seven, while renderers also handle stores that declare no pyramid at all, such as the AlphaEarth Foundations mosaic. Any fixed Portolan level count would be arbitrary, so depth stays with the producer.
 
-### Statistics
+### Storage layout
 
-Portolan requires COGs to carry minimum, maximum, mean, and standard deviation statistics so a renderer can scale data without reading the pixels. The same client-facing requirement should apply to Zarr variables or bands.
-
-No stable Zarr convention currently defines where these statistics should live. STAC metadata is the leading candidate for the initial profile, using the Raster extension where it provides the appropriate fields. The final representation remains an open question.
+Portolan sets no normative chunk or shard requirements. Chunk shape governs how a client reads an array, and Zarr v3 sharding groups chunks into one stored object to keep a store's object count manageable. Both are workload-dependent, and the [Cloud-Native Geospatial Formats Guide](https://guide.cloudnativegeo.org/zarr/intro.html) describes them without prescribing dimensions or byte sizes. Portolan follows that guidance: chunk and shard sizing belongs in conversion defaults and best-practice material, not in the conformance surface.
 
 ### STAC representation and media types
 
-A Zarr asset MUST follow the STAC Zarr best practices. Its `href` identifies the relevant Zarr group rather than an individual array, variables are exposed through the asset's metadata and `bands` where applicable, and the root of the store is identified through a link with `rel: "store"`.
+A Zarr asset follows the [STAC Zarr best practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md). Two points are requirements here: an asset `href` MUST identify a Zarr group rather than an individual array, and variables MUST be exposed through the asset's `bands` rather than as separate assets. The store root SHOULD carry a link with `rel: "store"`, which is the level the best practices set.
+
+That document is guidance rather than a specification, and it is still moving: it dates from the October 2025 STAC sprint, describes link templates rather than asset templates, and marks the media-type `profile` parameter as not yet official. Portolan states the requirements it depends on rather than deferring to the document wholesale.
 
 Zarr v3 assets use the media type `application/vnd.zarr; version=3`. A multiscale asset uses `application/vnd.zarr; version=3; profile=multiscales`.
 
-The Zarr STAC extension SHOULD be used to expose relevant store metadata, including `zarr:consolidated`, `zarr:node_type`, and `zarr:zarr_format`.
+Portolan requires individual STAC fields, not whole extensions. An extension is a container, and requiring all of one pulls in fields Portolan has no reason to demand.
+
+Which extensions are required, recommended, or optional is set by the [Portolan STAC Profile](../../stac/), not restated here. It lists Projection as MAY and Raster as MUST where band-level detail is provided. This profile adds no Zarr-specific override: the required `proj` convention already carries the CRS inside the store, so a STAC-side CRS requirement would be Portolan-wide policy rather than a Zarr one.
+
+`zarr:consolidated` and `zarr:node_type` SHOULD be present, because they tell a client whether the hierarchy is readable in one request and whether an href resolves to a group or an array. `zarr:zarr_format` is not required, since the media type already carries the format.
+
+Datacube fields describe dimensions and variables for stores that are datacubes. Neither Datacube nor the Zarr extension appears in the STAC Profile today, and listing them is a profile-level decision.
 
 Collection-versus-item modeling follows the STAC Zarr best practices. A store containing a dataset spanning multiple places or times may be represented at the collection level. A store representing a single scene or other logical unit may be represented at the item level.
 
@@ -100,11 +106,7 @@ The HTTP requirements for range requests, HEAD requests, and CORS therefore appl
 
 ## Open Questions
 
-* **Minimum pyramid depth.** Portolan's COG requirement requires internal overviews when a raster is larger than one internal tile. The analogous Zarr requirement is to provide enough multiscale levels for efficient zoomed-out access. The multiscales convention does not currently define that threshold, so Portolan needs to decide whether to define one or defer to the convention.
-
-* **Chunk and shard requirements.** Zarr chunks provide the basic unit of array access, while v3 sharding can group multiple chunks into a single stored object. Portolan needs to determine whether efficient browser access requires any normative limits on chunk dimensions, chunk size, or shard size, or whether these should remain implementation guidance.
-
-* **Required STAC extensions.** The Zarr, Datacube, Projection, and Raster extensions all provide useful metadata. Portolan needs to decide which are required for the initial profile and which remain recommendations. The statistics representation depends on this decision.
+* **Rendering metadata.** Portolan requires COGs to carry per-band statistics so a renderer can scale data without reading pixels. This profile states no equivalent Zarr requirement: no stable Zarr convention defines where such statistics live, and browser renderers already scale Zarr data without them. Whether any rendering metadata belongs in STAC for Zarr can be settled once a convention exists or a concrete rendering gap appears.
 
 * **Compression.** Compression is an implementation choice unless Portolan identifies a concrete interoperability or access requirement. If a default is useful, the CLI can recommend a codec in the Conversion Defaults guidance rather than making it a conformance requirement.
 
@@ -117,9 +119,8 @@ The HTTP requirements for range requests, HEAD requests, and CORS therefore appl
 This document moves into [`formats.md`](../portolan/formats.md) once:
 
 1. the `multiscales`, `spatial`, and `proj` conventions reach stable versions suitable for Portolan to depend on;
-2. the remaining Portolan-specific requirements are settled, in particular the minimum multiscale depth and required STAC extensions;
-3. a stable representation for the required statistics has been established; and
-4. a validator and reference implementation can verify the resulting requirements.
+2. the remaining open questions above are settled; and
+3. a validator and reference implementation can verify the resulting requirements.
 
 Implementation defaults such as chunking, sharding, compression, and multiscale construction parameters belong in the Portolan conversion and best-practices guidance unless they prove necessary for conformance.
 

--- a/specs/incubating/zarr.md
+++ b/specs/incubating/zarr.md
@@ -3,146 +3,124 @@
 ## Status
 
 Open, tracked in [#132](https://github.com/portolan-sdi/portolan-spec/issues/132).
-The direction below is settled; the open questions at the end are not. Zarr is not
-part of the conformance surface for the current Portolan version, and nothing here
-is normative until this document graduates into
-[`formats.md`](../portolan/formats.md).
+
+The direction below is settled; the open questions at the end are not. Zarr is not part of the conformance surface for the current Portolan version. Nothing in this document is normative until the profile graduates into [`formats.md`](../portolan/formats.md).
 
 ## Why Zarr
 
-Portolan requires raster data to be published as COG, which is the right format for
-imagery and single-timestep rasters. Zarr covers what COG cannot: multidimensional
-raster data indexed by time, depth, or band as well as x/y. Several large public
-datasets already publish as Zarr, so Portolan needs a way to catalog them.
+Portolan requires raster data to be published as COG, which is the right format for imagery and single-timestep rasters. Zarr supports raster datasets that COG does not represent naturally, particularly multidimensional data indexed by dimensions such as time or depth in addition to x/y.
+
+Several large public datasets already use Zarr, so Portolan needs a way to catalog these datasets while preserving the same cloud-native and browser-oriented access that motivates its COG requirements.
+
+The goal is not simply to recognize geospatial Zarr. Portolan should require a Zarr representation that provides the same basic web-access property that motivates its COG requirements: a client can display a large raster at different zoom levels without fetching the full-resolution dataset.
 
 ## Scope
 
-This profile covers spatial, multiscale, raster-like Zarr datasets — the Zarr
-analogue of a COG. Climate cubes organized primarily around time or depth, virtual
-Zarr stores (Kerchunk, VirtualiZarr), and [Icechunk](https://icechunk.io/) are out
-of scope for the initial profile. They are not excluded permanently; they need
-separate requirements, and settling the spatial case first keeps this section
-small enough to validate.
+This profile covers spatial, multiscale, raster-like Zarr datasets: the Zarr analogue of a COG.
+
+Climate cubes organized primarily around time or depth, virtual Zarr stores such as Kerchunk and VirtualiZarr, and transactional stores such as Icechunk are not addressed by the initial profile. They are not excluded permanently; they need separate requirements. Settling the spatial raster case first keeps this profile small enough to validate and implement.
 
 ## Existing Specifications and Conventions
 
-There is no published GeoZarr specification. The
-[geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has never
-released a document, and the work moved into separate conventions under the
-[zarr-conventions](https://github.com/zarr-conventions) organization. Portolan
-therefore refers to those conventions by name and UUID, never to "GeoZarr".
+There is no published GeoZarr specification. The [geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has not released a specification, and the work has moved into separate conventions under the [zarr-conventions](https://github.com/zarr-conventions) organization.
 
-Three conventions carry the geospatial semantics:
+Portolan therefore refers to the individual conventions rather than to "GeoZarr" as though it were a published specification.
 
-| Convention | Purpose | UUID |
-| ---------- | ------- | ---- |
-| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids | `d35379db-88df-4056-af3a-620245f8e347` |
-| [spatial](https://github.com/zarr-conventions/spatial) | Mapping array indices to x/y coordinates | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
-| [proj](https://github.com/zarr-conventions/proj) | Coordinate reference system | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
+Three conventions provide the geospatial semantics required by this profile:
 
-All three are v0.1 at "Pilot" maturity and warn that breaking changes are expected
-before v1. A store declares them through its `zarr_conventions` attribute, where
-each entry carries a convention UUID and a `schema_url` whose version tag identifies
-the version. That matches Portolan's existing model, in which the schema URI is the
-version signal.
+| Convention                                                     | Purpose                                  | UUID                                   |
+| -------------------------------------------------------------- | ---------------------------------------- | -------------------------------------- |
+| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids                      | `d35379db-88df-4056-af3a-620245f8e347` |
+| [spatial](https://github.com/zarr-conventions/spatial)         | Mapping array indices to x/y coordinates | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
+| [proj](https://github.com/zarr-conventions/proj)               | Coordinate reference system              | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
 
-On the STAC side, the [STAC Zarr best
-practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md)
-define how a Zarr store is represented in STAC: asset hrefs, the `rel: store` link,
-media types, and collection-vs-item modeling. The [Zarr
-extension](https://github.com/stac-extensions/zarr) (v1.1.0, Proposal maturity)
-supplies the asset fields a client needs to open a store. The
-[Datacube](https://github.com/stac-extensions/datacube),
-[Projection](https://github.com/stac-extensions/projection), and
-[Raster](https://github.com/stac-extensions/raster) extensions describe dimensions
-and variables, CRS and grid geometry, and per-band pixel detail respectively.
-Portolan builds on all of these rather than restating them.
+All three are currently v0.1 at "Pilot" maturity, and all warn that breaking changes are expected before v1. A store declares them through its `zarr_conventions` attribute. Each entry carries a convention UUID and a `schema_url` whose version identifies the convention version. This matches Portolan's existing model, in which a versioned schema URI is the version signal.
+
+The three conventions serve different purposes and are required together. `multiscales` describes the resolution pyramid, while `spatial` and `proj` tell a client how to interpret and place those arrays. A multiscale hierarchy without spatial and CRS information is not sufficient for a geospatial client to place, reproject, or overlay the data.
+
+On the STAC side, the [STAC Zarr best practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md) define how Zarr stores, groups, arrays, bands, and multiscale datasets are represented in STAC. They cover asset hrefs, the `rel: store` relationship, media types, and collection-versus-item modeling.
+
+The [STAC Zarr extension](https://github.com/stac-extensions/zarr) provides metadata about the Zarr store, including whether metadata is consolidated, whether an asset points to a group or array, and which Zarr format it uses. It is currently v1.1.0 at Proposal maturity.
+
+The [Datacube](https://github.com/stac-extensions/datacube), [Projection](https://github.com/stac-extensions/projection), and [Raster](https://github.com/stac-extensions/raster) extensions provide additional STAC metadata for multidimensional variables and dimensions, spatial reference and grid geometry, and raster data respectively.
+
+Portolan should build on these existing specifications and extensions rather than define parallel metadata models.
 
 ## Portolan Zarr Profile
 
 When Zarr support becomes normative, Portolan will require the following.
 
-**Zarr version.** Data MUST be provided as a Zarr v3 store. Zarr v2 stores do not
-conform.
+### Zarr version
 
-**Required conventions.** A store MUST declare the multiscales, spatial, and proj
-conventions in `zarr_conventions`. All three are required together: multiscales
-alone tells a client that pyramid levels exist but not what any index means on the
-ground, so a client cannot place, reproject, or overlay the data without spatial
-and proj.
+Data MUST be provided as a Zarr v3 store. Zarr v2 stores do not conform.
 
-**Consolidated metadata.** A store MUST provide consolidated metadata at its root,
-so a client can read the hierarchy in one request rather than walking it.
+### Required conventions
 
-**Multiscale depth.** A store whose full-resolution array exceeds one chunk MUST
-carry a resolution pyramid, for the same reason Portolan requires internal
-overviews in COGs. The exact minimum depth is an open question below.
+A store MUST declare the `multiscales`, `spatial`, and `proj` conventions in `zarr_conventions`. All three are required together.
 
-**Statistics.** Portolan requires the same statistics for Zarr that it requires for
-COG: a minimum, maximum, mean, and standard deviation per variable or band, so a
-renderer can scale any data type without reading the data. No stable Zarr convention
-for embedded statistics exists yet. Until one does, these SHOULD be carried in STAC
-metadata, through the Raster extension or an equivalent.
+`multiscales` provides the resolution pyramid needed for efficient zoomed-out access. `spatial` describes how array indices map to spatial coordinates, and `proj` identifies the coordinate reference system. Together they provide the information a client needs to interpret and display the dataset geographically.
 
-**STAC representation and media types.** A Zarr asset MUST follow the STAC Zarr best
-practices: its `href` references a group in the Zarr hierarchy rather than an
-individual array, variables surface through the asset's `bands` array, and the store
-root is identified by a link with `rel: "store"`. The base media type is
-`application/vnd.zarr; version=3`. A multiscale dataset uses
-`application/vnd.zarr; version=3; profile=multiscales`, which is what current STAC
-tooling, including STAC Browser, reads. Assets SHOULD carry the Zarr extension
-fields `zarr:consolidated`, `zarr:node_type`, and `zarr:zarr_format`.
+### Consolidated metadata
 
-Collection-vs-item modeling follows the same best practices. A store spanning many
-places or times is a collection-level asset. A store representing a single scene or
-other logical unit is an item-level asset, with each item pointing at its own store.
+A store MUST provide consolidated metadata at its root so a client can discover the Zarr hierarchy without walking the store's metadata objects individually.
 
-**Asset metadata.** `file:size` and `file:checksum` do not apply to Zarr assets.
-Both describe the bytes an `href` resolves to, and a Zarr href resolves to a group
-in a store of many objects rather than to a file. The [core asset
-rules](../portolan/core.md#assets) otherwise apply unchanged.
+### Multiscale access
 
-**HTTP and browser accessibility.** The [Data
-Storage](../portolan/core.md#data-storage) requirements apply in full. Every object
-in the store MUST be reachable over HTTP with range requests and CORS enabled, not
-only the metadata documents, because a browser client reads chunks directly.
+Portolan requires a multiscale pyramid for large raster datasets for the same reason it requires internal overviews in COGs: a client should be able to display the dataset at lower zoom levels without fetching full-resolution pixels.
+
+The multiscales convention establishes the pyramid structure but does not currently define how deep a pyramid must be for this purpose. The required minimum depth is therefore still an open Portolan question.
+
+### Statistics
+
+Portolan requires COGs to carry minimum, maximum, mean, and standard deviation statistics so a renderer can scale data without reading the pixels. The same client-facing requirement should apply to Zarr variables or bands.
+
+No stable Zarr convention currently defines where these statistics should live. STAC metadata is the leading candidate for the initial profile, using the Raster extension where it provides the appropriate fields. The final representation remains an open question.
+
+### STAC representation and media types
+
+A Zarr asset MUST follow the STAC Zarr best practices. Its `href` identifies the relevant Zarr group rather than an individual array, variables are exposed through the asset's metadata and `bands` where applicable, and the root of the store is identified through a link with `rel: "store"`.
+
+Zarr v3 assets use the media type `application/vnd.zarr; version=3`. A multiscale asset uses `application/vnd.zarr; version=3; profile=multiscales`.
+
+The Zarr STAC extension SHOULD be used to expose relevant store metadata, including `zarr:consolidated`, `zarr:node_type`, and `zarr:zarr_format`.
+
+Collection-versus-item modeling follows the STAC Zarr best practices. A store containing a dataset spanning multiple places or times may be represented at the collection level. A store representing a single scene or other logical unit may be represented at the item level.
+
+### Asset metadata
+
+`file:size` and `file:checksum` do not apply to Zarr group assets. Those fields describe the bytes an asset's `href` resolves to, whereas a Zarr asset href identifies a group within a store rather than a single file.
+
+The other Core asset rules apply unchanged.
+
+### HTTP and browser accessibility
+
+The [Core Data Storage requirements](../portolan/core.md#data-storage) apply in full. A Portolan Zarr store MUST be readable directly by browser-based clients over HTTP, including the metadata and chunk objects required to access the data.
+
+The HTTP requirements for range requests, HEAD requests, and CORS therefore apply to the Zarr objects that a client needs to read the store.
 
 ## Open Questions
 
-- **Minimum pyramid depth.** Portolan's COG requirement extends overviews until the
-  coarsest level spans one tile. The multiscales convention requires a `layout`
-  array but sets no minimum number of levels, so a one-level pyramid satisfies it.
-  Portolan needs to decide whether to impose the COG-analogous minimum itself or
-  wait for the convention to define one.
-- **Chunk and shard sizing.** COG internal tiles are conventionally 512×512, and
-  Zarr chunks serve a similar access-optimization purpose. Zarr v3 sharding breaks
-  the one-chunk-one-object relationship, so a chunk-dimension rule no longer implies
-  a request-size rule. Portolan needs to decide whether chunk dimensions or maximum
-  chunk byte size are normative requirements or implementation guidance.
-- **Required vs. recommended extensions.** The Zarr, Datacube, Projection, and
-  Raster extensions are all candidates. Portolan needs to decide which it mandates
-  and which it recommends. The statistics requirement above depends on this, since
-  it currently leans on Raster.
-- **Compression.** Portolan RECOMMENDS `zstd` for GeoParquet. Whether it should
-  require or recommend a codec for Zarr chunks is undecided.
-- **Styling.** Raster styling is unresolved for COG
-  ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see
-  [`raster-styling.md`](raster-styling.md)). A Zarr store may hold many variables and
-  dimensions rather than a fixed band set, which makes the question harder. This is
-  blocked on the COG answer.
-- **Out-of-scope formats.** Icechunk, virtual stores, and time-primary climate cubes
-  need their own treatment once the spatial profile is settled.
+* **Minimum pyramid depth.** Portolan's COG requirement requires internal overviews when a raster is larger than one internal tile. The analogous Zarr requirement is to provide enough multiscale levels for efficient zoomed-out access. The multiscales convention does not currently define that threshold, so Portolan needs to decide whether to define one or defer to the convention.
+
+* **Chunk and shard requirements.** Zarr chunks provide the basic unit of array access, while v3 sharding can group multiple chunks into a single stored object. Portolan needs to determine whether efficient browser access requires any normative limits on chunk dimensions, chunk size, or shard size, or whether these should remain implementation guidance.
+
+* **Required STAC extensions.** The Zarr, Datacube, Projection, and Raster extensions all provide useful metadata. Portolan needs to decide which are required for the initial profile and which remain recommendations. The statistics representation depends on this decision.
+
+* **Compression.** Compression is an implementation choice unless Portolan identifies a concrete interoperability or access requirement. If a default is useful, the CLI can recommend a codec in the Conversion Defaults guidance rather than making it a conformance requirement.
+
+* **Styling.** Raster styling remains unresolved for COG ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see `raster-styling.md`). Zarr can contain multiple variables and dimensions rather than a fixed set of bands, so its styling model may require additional work. Zarr-specific styling requirements should follow the resolution of the general raster styling question rather than being designed independently here.
+
+* **Out-of-scope stores and datasets.** Transactional and virtual Zarr stores, including Icechunk, Kerchunk, and VirtualiZarr, and climate cubes organized primarily around non-spatial dimensions need separate treatment. Their compatibility with the initial profile can be evaluated after the spatial raster case is settled.
 
 ## Path to Normative Status
 
 This document moves into [`formats.md`](../portolan/formats.md) once:
 
-1. the multiscales, spatial, and proj conventions reach v1;
-2. the open questions above are answered, in particular pyramid depth and the
-   required extension set;
-3. a stable home for statistics exists, whether a Zarr convention or a settled STAC
-   representation; and
+1. the `multiscales`, `spatial`, and `proj` conventions reach stable versions suitable for Portolan to depend on;
+2. the remaining Portolan-specific requirements are settled, in particular the minimum multiscale depth and required STAC extensions;
+3. a stable representation for the required statistics has been established; and
 4. a validator and reference implementation can verify the resulting requirements.
 
-As with the point-cloud format, the reference implementation comes before the format
-becomes normative.
+Implementation defaults such as chunking, sharding, compression, and multiscale construction parameters belong in the Portolan conversion and best-practices guidance unless they prove necessary for conformance.
+
+As with the other Portolan formats, the reference implementation should be established before the format becomes normative.

--- a/specs/incubating/zarr.md
+++ b/specs/incubating/zarr.md
@@ -1,109 +1,148 @@
 # Incubating — Zarr
 
-**Status: Open. Waiting for the Zarr conventions and a reference implementation to stabilize.**
+## Status
 
-Portolan currently requires raster data to be published as COG. That remains the right format for imagery and single-timestep rasters.
+Open, tracked in [#132](https://github.com/portolan-sdi/portolan-spec/issues/132).
+The direction below is settled; the open questions at the end are not. Zarr is not
+part of the conformance surface for the current Portolan version, and nothing here
+is normative until this document graduates into
+[`formats.md`](../portolan/formats.md).
 
-Zarr is needed for a different use case: multidimensional raster data, such as data indexed by time, depth, or multiple bands as well as x/y. Several major public datasets already use Zarr, so Portolan needs a way to catalog these datasets eventually.
+## Why Zarr
 
-We are not ready to make Zarr normative yet. The conventions Portolan would need to rely on are still experimental, and there is no validator that can check a complete Zarr dataset against them.
+Portolan requires raster data to be published as COG, which is the right format for
+imagery and single-timestep rasters. Zarr covers what COG cannot: multidimensional
+raster data indexed by time, depth, or band as well as x/y. Several large public
+datasets already publish as Zarr, so Portolan needs a way to catalog them.
 
-## There is no stable "GeoZarr" specification yet
+## Scope
 
-The [geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has never released a specification. Its README says that a specification will be produced once the underlying conventions are mature enough to form a coherent suite.
+This profile covers spatial, multiscale, raster-like Zarr datasets — the Zarr
+analogue of a COG. Climate cubes organized primarily around time or depth, virtual
+Zarr stores (Kerchunk, VirtualiZarr), and [Icechunk](https://icechunk.io/) are out
+of scope for the initial profile. They are not excluded permanently; they need
+separate requirements, and settling the spatial case first keeps this section
+small enough to validate.
 
-The work has instead moved into separate conventions maintained by the [zarr-conventions](https://github.com/zarr-conventions) organization.
+## Existing Specifications and Conventions
 
-The three relevant conventions currently under active development are:
+There is no published GeoZarr specification. The
+[geozarr-spec](https://github.com/zarr-developers/geozarr-spec) repository has never
+released a document, and the work moved into separate conventions under the
+[zarr-conventions](https://github.com/zarr-conventions) organization. Portolan
+therefore refers to those conventions by name and UUID, never to "GeoZarr".
 
-| Convention                                                     | Purpose                                  | UUID                                   |
-| -------------------------------------------------------------- | ---------------------------------------- | -------------------------------------- |
-| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids                      | `d35379db-88df-4056-af3a-620245f8e347` |
-| [proj](https://github.com/zarr-conventions/proj)               | Coordinate reference system              | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
-| [spatial](https://github.com/zarr-conventions/spatial)         | Mapping array indices to x/y coordinates | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
+Three conventions carry the geospatial semantics:
 
-CF in Zarr, DGGS in Zarr, and TileMatrixSet are also being considered, but none currently has a stable repository.
+| Convention | Purpose | UUID |
+| ---------- | ------- | ---- |
+| [multiscales](https://github.com/zarr-conventions/multiscales) | Resolution pyramids | `d35379db-88df-4056-af3a-620245f8e347` |
+| [spatial](https://github.com/zarr-conventions/spatial) | Mapping array indices to x/y coordinates | `689b58e2-cf7b-45e0-9fff-9cfc0883d6b4` |
+| [proj](https://github.com/zarr-conventions/proj) | Coordinate reference system | `f17cb550-5864-4468-aeb7-f3180cfb622f` |
 
-All three active conventions are v0.1, with maturity marked as "Pilot." They explicitly warn that breaking changes are expected before v1.
+All three are v0.1 at "Pilot" maturity and warn that breaking changes are expected
+before v1. A store declares them through its `zarr_conventions` attribute, where
+each entry carries a convention UUID and a `schema_url` whose version tag identifies
+the version. That matches Portolan's existing model, in which the schema URI is the
+version signal.
 
-A Zarr store declares conventions through its `zarr_conventions` attribute. Each entry contains a convention UUID and a `schema_url` whose version tag identifies the version. There is no separate version field.
+On the STAC side, the [STAC Zarr best
+practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md)
+define how a Zarr store is represented in STAC: asset hrefs, the `rel: store` link,
+media types, and collection-vs-item modeling. The [Zarr
+extension](https://github.com/stac-extensions/zarr) (v1.1.0, Proposal maturity)
+supplies the asset fields a client needs to open a store. The
+[Datacube](https://github.com/stac-extensions/datacube),
+[Projection](https://github.com/stac-extensions/projection), and
+[Raster](https://github.com/stac-extensions/raster) extensions describe dimensions
+and variables, CRS and grid geometry, and per-band pixel detail respectively.
+Portolan builds on all of these rather than restating them.
 
-This fits Portolan's existing model, where the schema URI is the version signal.
+## Portolan Zarr Profile
 
-**For now, Portolan should therefore refer to specific Zarr conventions and UUIDs, not to "GeoZarr" as though it were a published specification.**
+When Zarr support becomes normative, Portolan will require the following.
 
-## Proposed direction
+**Zarr version.** Data MUST be provided as a Zarr v3 store. Zarr v2 stores do not
+conform.
 
-When Zarr support becomes normative, Portolan would require a Zarr v3 store declaring the relevant conventions and providing consolidated metadata at the store root.
+**Required conventions.** A store MUST declare the multiscales, spatial, and proj
+conventions in `zarr_conventions`. All three are required together: multiscales
+alone tells a client that pyramid levels exist but not what any index means on the
+ground, so a client cannot place, reproject, or overlay the data without spatial
+and proj.
 
-The most important convention is `multiscales`.
+**Consolidated metadata.** A store MUST provide consolidated metadata at its root,
+so a client can read the hierarchy in one request rather than walking it.
 
-A Zarr array without a resolution pyramid has poor browser performance when the full-resolution array is too large to load into memory. A multiscale pyramid allows clients to request an appropriate resolution instead, which is the same basic reason Portolan requires overviews in COGs.
+**Multiscale depth.** A store whose full-resolution array exceeds one chunk MUST
+carry a resolution pyramid, for the same reason Portolan requires internal
+overviews in COGs. The exact minimum depth is an open question below.
 
-However, simply declaring `multiscales` is not enough. The current convention requires a `layout` array but does not specify a minimum number of pyramid levels. A one-level pyramid could therefore satisfy the convention without providing a useful overview.
+**Statistics.** Portolan requires the same statistics for Zarr that it requires for
+COG: a minimum, maximum, mean, and standard deviation per variable or band, so a
+renderer can scale any data type without reading the data. No stable Zarr convention
+for embedded statistics exists yet. Until one does, these SHOULD be carried in STAC
+metadata, through the Raster extension or an equivalent.
 
-Portolan's COG requirements already define an explicit minimum overview depth: the pyramid must continue until the coarsest level fits within one tile.
+**STAC representation and media types.** A Zarr asset MUST follow the STAC Zarr best
+practices: its `href` references a group in the Zarr hierarchy rather than an
+individual array, variables surface through the asset's `bands` array, and the store
+root is identified by a link with `rel: "store"`. The base media type is
+`application/vnd.zarr; version=3`. A multiscale dataset uses
+`application/vnd.zarr; version=3; profile=multiscales`, which is what current STAC
+tooling, including STAC Browser, reads. Assets SHOULD carry the Zarr extension
+fields `zarr:consolidated`, `zarr:node_type`, and `zarr:zarr_format`.
 
-We need to decide whether Zarr conformance should impose an equivalent minimum, or whether Portolan should wait for the multiscales convention to define one.
+Collection-vs-item modeling follows the same best practices. A store spanning many
+places or times is a collection-level asset. A store representing a single scene or
+other logical unit is an item-level asset, with each item pointing at its own store.
 
-## Open questions
+**Asset metadata.** `file:size` and `file:checksum` do not apply to Zarr assets.
+Both describe the bytes an `href` resolves to, and a Zarr href resolves to a group
+in a store of many objects rather than to a file. The [core asset
+rules](../portolan/core.md#assets) otherwise apply unchanged.
 
-### Statistics
+**HTTP and browser accessibility.** The [Data
+Storage](../portolan/core.md#data-storage) requirements apply in full. Every object
+in the store MUST be reachable over HTTP with range requests and CORS enabled, not
+only the metadata documents, because a browser client reads chunks directly.
 
-Portolan requires COG bands to contain embedded minimum, maximum, mean, and standard deviation values. These let clients style data without first reading the pixels.
+## Open Questions
 
-Zarr currently has no equivalent convention. We need to decide whether Portolan requires statistics for Zarr and, if so, where they come from.
+- **Minimum pyramid depth.** Portolan's COG requirement extends overviews until the
+  coarsest level spans one tile. The multiscales convention requires a `layout`
+  array but sets no minimum number of levels, so a one-level pyramid satisfies it.
+  Portolan needs to decide whether to impose the COG-analogous minimum itself or
+  wait for the convention to define one.
+- **Chunk and shard sizing.** COG internal tiles are conventionally 512×512, and
+  Zarr chunks serve a similar access-optimization purpose. Zarr v3 sharding breaks
+  the one-chunk-one-object relationship, so a chunk-dimension rule no longer implies
+  a request-size rule. Portolan needs to decide whether chunk dimensions or maximum
+  chunk byte size are normative requirements or implementation guidance.
+- **Required vs. recommended extensions.** The Zarr, Datacube, Projection, and
+  Raster extensions are all candidates. Portolan needs to decide which it mandates
+  and which it recommends. The statistics requirement above depends on this, since
+  it currently leans on Raster.
+- **Compression.** Portolan RECOMMENDS `zstd` for GeoParquet. Whether it should
+  require or recommend a codec for Zarr chunks is undecided.
+- **Styling.** Raster styling is unresolved for COG
+  ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see
+  [`raster-styling.md`](raster-styling.md)). A Zarr store may hold many variables and
+  dimensions rather than a fixed band set, which makes the question harder. This is
+  blocked on the COG answer.
+- **Out-of-scope formats.** Icechunk, virtual stores, and time-primary climate cubes
+  need their own treatment once the spatial profile is settled.
 
-### Chunk sizing
+## Path to Normative Status
 
-COG internal tiles are capped at roughly a screen-sized block, conventionally 512×512. Zarr chunks serve a similar purpose.
+This document moves into [`formats.md`](../portolan/formats.md) once:
 
-Zarr v3 sharding can group many chunks into one object, avoiding a store containing millions of individual objects. Portolan does not yet have requirements for either chunk size or sharding.
+1. the multiscales, spatial, and proj conventions reach v1;
+2. the open questions above are answered, in particular pyramid depth and the
+   required extension set;
+3. a stable home for statistics exists, whether a Zarr convention or a settled STAC
+   representation; and
+4. a validator and reference implementation can verify the resulting requirements.
 
-### A Zarr store is not a file
-
-Portolan's asset rules currently assume that an `href` resolves to a file. `file:size` and `file:checksum` describe the bytes at that location.
-
-A Zarr `href` instead points to a store containing many objects.
-
-We therefore need to decide whether these file properties are omitted for Zarr assets or whether Portolan defines what they mean for a store.
-
-### STAC modeling
-
-The media type for Zarr is `application/vnd.zarr`, but the STAC model is not settled.
-
-The [xarray-assets](https://github.com/stac-extensions/xarray-assets) extension was deprecated and archived in June 2025. Its authors pointed toward a future `zarr` extension that does not yet exist.
-
-The [datacube](https://github.com/stac-extensions/datacube) extension (v2.3.0) describes dimensions and variables and may provide the structure Portolan needs. Whether Portolan requires it remains open.
-
-### Styling
-
-Raster styling is already unresolved for COG ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41), see `raster-styling.md`).
-
-Zarr makes this more complicated because a cube may contain many dimensions and variables rather than a single fixed set of bands.
-
-### Collection structure
-
-A COG collection can naturally represent each scene as a STAC Item.
-
-A single Zarr store may instead contain data that would correspond to thousands of scenes. There is no obvious equivalent item boundary.
-
-We need to decide whether the store is represented as one collection-level asset or whether STAC Items index subsets of the store.
-
-### Transactional stores
-
-[Icechunk](https://icechunk.io/) provides versioning and transactions on top of Zarr and is already used for datasets that might otherwise be published as ordinary Zarr.
-
-We have not yet determined whether an Icechunk-backed store can meet Portolan's requirements for browser-accessible data.
-
-## When this becomes normative
-
-This document should move into `formats.md` once:
-
-1. the relevant Zarr conventions reach v1;
-2. Portolan has an answer for statistics;
-3. the STAC and asset model is defined;
-4. the remaining storage requirements, such as chunking, are resolved; and
-5. a validator and reference implementation can verify the resulting requirements.
-
-As with the point-cloud format, the reference implementation should be established before the format becomes normative.
+As with the point-cloud format, the reference implementation comes before the format
+becomes normative.

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -112,8 +112,9 @@ header ordered so a reader can find the data it needs in an early range request.
 This is the baseline that
 [`rio cogeo validate`](https://cogeotiff.github.io/rio-cogeo/CLI/#validate) and
 rasterio treat as a COG.
-(Formats such as GeoZarr are candidates for future support once default tooling can
-render and consume them.)
+COG covers imagery and single-timestep rasters. Multidimensional cubes indexed by
+time, band, or depth are not expressible as a COG; Zarr is the candidate for those
+and is not yet supported — see [`specs/incubating/zarr.md`](../incubating/zarr.md).
 How a raster collection is structured — one item per scene, with a single-COG
 collection handled as a single-file collection — is defined under [Raster
 Collections](core.md#raster-collections).

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -112,9 +112,7 @@ header ordered so a reader can find the data it needs in an early range request.
 This is the baseline that
 [`rio cogeo validate`](https://cogeotiff.github.io/rio-cogeo/CLI/#validate) and
 rasterio treat as a COG.
-COG covers imagery and single-timestep rasters. Multidimensional cubes indexed by
-time, band, or depth are not expressible as a COG; Zarr is the candidate for those
-and is not yet supported — see [`specs/incubating/zarr.md`](../incubating/zarr.md).
+COG covers imagery and single-timestep rasters. Zarr is the candidate format for multidimensional data, such as cubes indexed by time, band, or depth. Zarr support is not yet defined; see [`specs/incubating/zarr.md`](../incubating/zarr.md).
 How a raster collection is structured — one item per scene, with a single-COG
 collection handled as a single-file collection — is defined under [Raster
 Collections](core.md#raster-collections).


### PR DESCRIPTION
## What this changes

Adds `specs/incubating/zarr.md`, a draft Portolan Zarr profile, and links it from `formats.md` and the incubating index. Tracking issue: #132.

The profile now settles the main questions from the first draft:

* No minimum multiscale depth. The convention allows a single level, and real datasets vary widely.
* No Zarr statistics requirement. There is no stable convention for storing them, and browser renderers do not require them.
* No normative chunk or shard requirements. These depend on the workload and belong in conversion guidance.
* STAC requirements specify individual fields rather than requiring whole extensions. Extension requirements remain governed by the Portolan STAC Profile.
* The profile no longer requires the STAC Zarr best-practices document wholesale; it states the specific requirements it relies on.

Compression, styling, rendering metadata, and out-of-scope Zarr stores remain open questions.

## Verification

* [x] No conformance requirements changed. `specs/incubating/` is outside the conformance surface.

```text
$ uv run specs/tools/check_requirements.py
OK: 115 requirements anchored; all keyword occurrences covered.
```