### PR TITLE
docs(incubating): specify metadata.legend for MapLibre GL styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+### Added
+
+- **Legend metadata for MapLibre styles**
+  ([`specs/incubating/maplibre-legend.md`](specs/incubating/maplibre-legend.md)): a
+  new incubating document specifying `layers[].metadata.legend`, the object that
+  carries a legend's block title and its display labels. It adopts the shape read by
+  [maplibre-legend](https://github.com/mvt-proj/maplibre-legend) 0.5.1 rather than
+  defining a `portolan:` variant, and is written to stand alone outside Portolan.
+  Nothing is normative. `core.md`, `formats.md`, `specs/best-practices/styling.md`,
+  `specs/incubating/raster-styling.md`, and `stac/README.md` gain pointers to it
+  (#118).
+
 ### Changed
 
 - **"Item mirror" is now used consistently** (PORTO-FMT-040, PORTO-FMT-041,

--- a/specs/best-practices/styling.md
+++ b/specs/best-practices/styling.md
@@ -16,5 +16,10 @@ requires. These are recommendations, not requirements.
   `match`, `case`, and `step` to encode data into color, and include a
   `description` explaining what the colors represent.
 
+- **Name the legend entries.** A `match` or `step` expression gives a client the
+  colors but not the wording, so a legend derived from it shows raw field values.
+  Carry the block title and the display labels in `layers[].metadata.legend`, per
+  [`specs/incubating/maplibre-legend.md`](../incubating/maplibre-legend.md).
+
 - **Consider labels.** For collections with named features (roads, monuments, admin
   areas), include a label layer or a dedicated "with labels" style variant.

--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -12,6 +12,7 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 | Doc | Status |
 |-----|--------|
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
+| [`maplibre-legend.md`](maplibre-legend.md) | Proposed — legend titles and labels in a MapLibre style's `metadata.legend`, adopted from a shipped implementation ([#118](https://github.com/portolan-sdi/portolan-spec/issues/118)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
 | [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; STAC-GeoParquet mirrors of collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |

--- a/specs/incubating/maplibre-legend.md
+++ b/specs/incubating/maplibre-legend.md
@@ -1,0 +1,181 @@
+# Incubating — Legend Metadata for MapLibre GL Styles
+
+**Status: proposed, adopted from a shipped implementation ([#118](https://github.com/portolan-sdi/portolan-spec/issues/118)).**
+
+A MapLibre GL style encodes a thematic classification as one data-driven paint
+expression. The expression holds every class color and every raw field value, so a
+client can derive a legend from it without extra metadata. What the expression does
+not hold is wording. A `match` on a `class` column yields entries labelled `res` and
+`ind`, and the layer has no title beyond its `id`.
+
+Styled Layer Descriptor has no equivalent gap, because there each class is a `Rule`
+with its own `Title` and `Filter`. The legend falls out of the rule list, which is why
+WMS can offer `GetLegendGraphic`. MapLibre collapses those rules into a single
+expression, and the titles have nowhere to go.
+
+This document specifies `metadata.legend`, a small object on a style layer that
+carries the title and the display labels. It matches
+[maplibre-legend](https://github.com/mvt-proj/maplibre-legend), the Rust crate that
+already reads this key, so a style following this document renders in an existing
+tool rather than one written for Portolan.
+
+## The Unprefixed Key
+
+The MapLibre GL style specification defines `metadata` as free-form on `$root` and on
+each layer, and advises prefixing properties to avoid collisions. This convention uses
+the bare `legend` key anyway, because maplibre-legend 0.5.1 reads that key today and a
+second prefixed key would split a convention that has one implementation.
+
+The cost is a genuine collision risk. Any other producer writing `metadata.legend`
+under a different shape will break a reader that expects this one. Resolving that is a
+condition of leaving incubation.
+
+## Scope
+
+This applies to a MapLibre GL style document following style specification v8. It
+defines no new top-level fields and needs no change to MapLibre GL JS, which ignores
+`metadata` entirely. Nothing below is specific to Portolan, and the document is written
+so it can move to a repository of its own.
+
+## Where the Legend Object Lives
+
+The object sits at `layers[*].metadata.legend`. Every field in it is optional. This
+document defines nothing on the style's root `metadata`.
+
+```json
+{
+  "id": "land-use",
+  "type": "fill",
+  "source": "data",
+  "source-layer": "parcels",
+  "metadata": {
+    "legend": {
+      "label": "Land use",
+      "default": "Other",
+      "custom-labels": ["Residential", "Commercial", "Industrial"]
+    }
+  },
+  "paint": {
+    "fill-color": [
+      "match", ["get", "class"],
+      "res", "#e41a1c",
+      "com", "#377eb8",
+      "ind", "#4daf4a",
+      "#cccccc"
+    ]
+  }
+}
+```
+
+That layer renders as a block titled "Land use" holding four entries: Residential,
+Commercial, Industrial, and Other against the fallback gray.
+
+## Fields
+
+| Field | Type | Applies to | When absent |
+| ----- | ---- | ---------- | ----------- |
+| `label` | string | the layer's legend block, as its title | falls back to `layer.id` |
+| `default` | string | the fallback entry of a `match` or `case` expression | falls back to `layer.id` |
+| `custom-labels` | array of string | the generated entries, in order | each entry keeps its derived label |
+
+A `legend` member that is present but not a JSON object is an error, not something to
+ignore. The hyphen in `custom-labels` is not a house convention. It is the key the
+reference implementation reads.
+
+## How Labels Are Assigned
+
+A reader walks the layer's color expression and produces an ordered list of entries,
+each one a color and a label. It holds a single index that starts at zero and advances
+by one per entry. The entry at index *i* takes `custom-labels[i]` where that index
+exists, and its derived label otherwise. Where the expression has a fallback arm, that
+entry comes last and consumes the next index.
+
+A shorter array is legal. Entries past its end fall back to derived labels, so a
+publisher can name the first few classes and leave the rest.
+
+The array is positional and carries no keys, which makes it fragile in one specific
+way. Inserting a stop into the paint expression shifts every later label onto the wrong
+entry, and nothing in the document reports the mismatch. Re-check the array in the same
+commit that edits an expression.
+
+## Derived Labels by Expression
+
+| Expression | One entry per | Derived label | Fallback entry |
+| ---------- | ------------- | ------------- | -------------- |
+| `match` | value arm | the arm's value, stringified | yes, labelled from `default` |
+| `case` | condition arm | the condition as text, such as `has height`, `without height`, or `class == res` | only when the array length is even |
+| `interpolate` | stop | `{field} ≥ {stop}` | none |
+| `step` | stop | `{field} < {first}`, then `{lower} ≤ {field} < {upper}`, and `{field} ≥ {last}` for the last | none |
+| `coalesce` | delegated | the first argument that is one of the four above and yields more than one entry | as delegated |
+| `literal` | one | the layer label | none |
+
+A paint value that is a plain string, number, or boolean produces one entry carrying
+the layer label.
+
+Three constraints follow from the reference implementation and are worth stating,
+because a style can be valid MapLibre and still fail to produce a legend:
+
+- A `match` arm takes a single string or number. An arm listing several values as an
+  array is rejected.
+- `interpolate` and `step` read the field name from their input expression, which has
+  to be `["get", "<field>"]`.
+- `match` and `interpolate` need at least four elements. `step` needs at least three,
+  and an even length above three is rejected as an incomplete threshold-color pair.
+
+## Which Paint Property Is Read
+
+| Layer type | Property read | Notes |
+| ---------- | ------------- | ----- |
+| `fill` | `fill-color` | also reads `fill-opacity` and `fill-outline-color` for the swatch |
+| `line` | `line-color` | |
+| `circle` | `circle-color` | also reads `circle-stroke-color` |
+| `fill-extrusion` | `fill-extrusion-color` | |
+| `background` | `background-color` | also reads `background-opacity` |
+| `symbol` | layout `icon-image` and `text-field` | |
+| `heatmap` | none | one entry carrying the layer label |
+| `raster` | none | one entry carrying the layer label |
+| any other type | none | one gray entry carrying the layer label |
+
+`fill`, `line`, and `circle` require a `paint` object, and a reader errors without one.
+For `fill-extrusion` and `background`, a missing `paint` falls back to the single gray
+entry.
+
+Only the types that read a color expression make use of `custom-labels` and `default`.
+On the rest, `label` is the sole field that changes anything.
+
+## Conformance
+
+A producer:
+
+- SHOULD set `label` on every layer meant to appear in a legend.
+- SHOULD set `custom-labels` wherever the derived labels would be raw field values.
+- MUST order `custom-labels` to match the entry order the expression produces.
+- MUST NOT expect `default` to do anything on an `interpolate` or `step` expression,
+  neither of which produces a fallback entry.
+
+A reader:
+
+- MUST fall back to `layer.id` for `label` and for `default` when either is absent.
+- MUST apply `custom-labels` positionally, and fall back to the derived label for any
+  entry past the end of the array.
+- SHOULD ignore any member of `legend` it does not recognize.
+
+## Reference Implementation
+
+[maplibre-legend](https://github.com/mvt-proj/maplibre-legend) renders SVG legends from
+a style document. It is a Rust crate under BSD-3-Clause, and version 0.5.1 is the
+behavior described here. Every rule above was read from `src/common.rs` and the
+per-layer modules on `main` in August 2026. It is the only shipped tool known to read
+`metadata.legend`.
+
+## Relationship to Portolan
+
+Portolan requires a MapLibre GL style asset for every collection publishing PMTiles
+(see [Visualization Styles](../portolan/core.md#visualization-styles) and
+[`formats.md`](../portolan/formats.md)). Nothing in this document is required. A
+collection whose styles carry `metadata.legend` gets a titled, labelled legend in a
+client that reads the key, and behaves exactly as before in one that does not.
+
+Graduating this into `formats.md` needs a decision on the unprefixed key and a second
+independent implementation. Discussion is in
+[#118](https://github.com/portolan-sdi/portolan-spec/issues/118).

--- a/specs/incubating/raster-styling.md
+++ b/specs/incubating/raster-styling.md
@@ -12,7 +12,10 @@ Open questions:
 - **Colormaps** — how a continuous raster's color ramp is declared so a client can
   colorize it at draw time (e.g. via the STAC `render` extension and the required
   min/max statistics).
-- **Legends** — how a categorical raster maps pixel values to labels and colors.
+- **Legends** — how a categorical raster maps pixel values to labels and colors. The
+  vector side has a proposed answer in
+  [`maplibre-legend.md`](maplibre-legend.md), which a raster convention could follow
+  or deliberately diverge from.
 - **Continuous vs. categorical vs. multiband** — whether these need distinct style
   representations, and how a client tells them apart.
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -475,4 +475,6 @@ default the same way everywhere.
 The concrete style format is defined per data format in [`formats.md`](formats.md):
 for vector (PMTiles) it is a MapLibre GL style file, while raster styling is still
 under discussion (see
-[`specs/incubating/raster-styling.md`](../incubating/raster-styling.md)).
+[`specs/incubating/raster-styling.md`](../incubating/raster-styling.md)). Legend
+titles and labels for a MapLibre style are a separate open convention, in
+[`specs/incubating/maplibre-legend.md`](../incubating/maplibre-legend.md).

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -72,6 +72,9 @@ media type `application/vnd.mapbox.style+json`, a complete, self-contained JSON
 loadable directly by MapLibre GL JS. By convention such a file sets `version` 8, a
 human-readable `name`, `sources.data.url` as the relative path from `styles/` to the
 PMTiles file (typically `../filename.pmtiles`), and `layers[].source` to `"data"`.
+How such a style carries its legend titles and labels, under
+`layers[].metadata.legend`, is an open convention described in
+[`specs/incubating/maplibre-legend.md`](../incubating/maplibre-legend.md).
 
 ### Partitioned Collections
 

--- a/stac/README.md
+++ b/stac/README.md
@@ -136,6 +136,7 @@ Hosting requirements (HTTP Range support, CORS on all metadata and asset files) 
 Tracked in the specification and deliberately **not** settled by this schema:
 
 1. **Raster styling** — how raster styles are expressed (colormaps, legends, continuous vs. categorical vs. multiband) is under discussion in [`specs/incubating/raster-styling.md`](../specs/incubating/raster-styling.md); the MapLibre style requirements are vector-only for now.
+2. **Legend metadata** — how a MapLibre style carries its legend titles and labels, under `layers[].metadata.legend`, is a proposed convention in [`specs/incubating/maplibre-legend.md`](../specs/incubating/maplibre-legend.md). It lives inside the style file, so this schema neither checks it nor needs to.
 
 ## Examples
 


### PR DESCRIPTION
> **Agent-drafted, not yet human-reviewed.** A human must approve this diff and body before review, per the [AI policy](https://github.com/portolan-sdi/portolan-ops/blob/main/policies/AI_POLICY.md).

I'm not yet happy with this, but wanted to see a draft in proposed language. I do think it's a better direction to have explicit legend metadata. And I _think_ it makes sense to embed that in the style, though I could be open to have it in STAC or somewhere else? But the spec doesn't read nearly as well as I'd like, so I'll continue to refine it.

## What this changes

Adds `specs/incubating/maplibre-legend.md`, a standalone spec for the `metadata.legend` object on a MapLibre style layer. It defines the three fields and their fallbacks, the positional rule mapping `custom-labels` onto entries, the derived label for each of six expressions, and the paint property read per layer type. `core.md`, `formats.md`, `styling.md`, `raster-styling.md`, and `stac/README.md` gain pointers.

## Why

A style holds every class color in one paint expression but no wording, so a derived legend shows raw field values under the layer id (#118). Rather than mint `portolan:legend`, this documents the shape [maplibre-legend](https://github.com/mvt-proj/maplibre-legend) 0.5.1 already reads. The unprefixed key carries a collision risk, called out in the doc as a condition of graduating.

## Verification

Nothing is normative. Every rule was read from maplibre-legend `src/common.rs` and its per-layer modules on `main`. The manifest still anchors, the two `specs/portolan/` additions introducing no RFC 2119 keywords.

```console
$ uv run specs/tools/check_requirements.py
OK: 115 requirements anchored; all keyword occurrences covered.

$ cd stac && npx remark README.md --frail
README.md: no issues found
```

- [x] This change does not alter behavior, so no new evidence is required.
