### PR TITLE
docs: name the full CORS header set browsers need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   republishing data it did not produce. This is a wording-only change. The
   requirements are unchanged, and the upstream role value `collection-mirror` is
   unaffected (#99).
+- **Data Storage** (PORTO-CORE-045): the CORS requirement now names the header
+  set a browser actually needs. Allowed request headers add `If-Match`,
+  `If-Modified-Since`, `If-None-Match`, and `If-Unmodified-Since` next to
+  `Range`, and exposed response headers add `Content-Type`. Conditional requests
+  let a client revalidate a cached range instead of refetching it.
+  Provider-specific headers such as `x-amz-*` and `x-goog-*` stay out of scope,
+  as does versioning, which the specification does not yet define (#56).
 - **Assets** (PORTO-CORE-028): `file:size` and `file:checksum` drop from MUST to
   SHOULD. A catalog that describes data it does not host often cannot produce a
   checksum, so the old MUST left it a choice between failing conformance and

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -328,9 +328,17 @@ conformant.
 To let browser clients read data directly, servers MUST also enable CORS on all
 metadata and asset files: `Access-Control-Allow-Origin: *` (or an equivalent
 read-permitting policy), allowed methods including `GET` and `HEAD`, allowed
-request headers including `Range`, and exposed response headers including
-`Content-Range`, `Content-Length`, `Accept-Ranges`, and `ETag` (via
-`Access-Control-Expose-Headers`).
+request headers including `Range`, `If-Match`, `If-Modified-Since`,
+`If-None-Match`, and `If-Unmodified-Since` (via
+`Access-Control-Allow-Headers`), and exposed response headers including
+`Content-Type`, `Content-Length`, `Content-Range`, `Accept-Ranges`, and `ETag`
+(via `Access-Control-Expose-Headers`).
+
+The conditional-request headers let a browser revalidate a cached range instead
+of refetching it, which keeps tile and range readers cheap on repeat views.
+Provider-specific headers such as `x-amz-*` and `x-goog-*` fall outside this
+requirement, since reading a public catalog takes no signed request. Portolan
+leaves cloud-specific configuration to separate guidance.
 
 ## Providers
 

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -426,9 +426,12 @@ requirements:
       To let browser clients read data directly, servers MUST also enable
       CORS on all metadata and asset files: `Access-Control-Allow-Origin: *`
       (or an equivalent read-permitting policy), allowed methods including
-      `GET` and `HEAD`, allowed request headers including `Range`, and
-      exposed response headers including `Content-Range`, `Content-Length`,
-      `Accept-Ranges`, and `ETag` (via `Access-Control-Expose-Headers`).
+      `GET` and `HEAD`, allowed request headers including `Range`,
+      `If-Match`, `If-Modified-Since`, `If-None-Match`, and
+      `If-Unmodified-Since` (via `Access-Control-Allow-Headers`), and exposed
+      response headers including `Content-Type`, `Content-Length`,
+      `Content-Range`, `Accept-Ranges`, and `ETag` (via
+      `Access-Control-Expose-Headers`).
 
   - id: PORTO-CORE-046
     severity: MUST


### PR DESCRIPTION
Companion-PR: portolan-sdi/rashid#105

## What this changes

Updates PORTO-CORE-045 in `specs/portolan/core.md` to specify the CORS headers required for browser access. Browsers may send these request headers when accessing cloud-hosted assets: `Range`, `If-Match`, `If-Modified-Since`, `If-None-Match`, `If-Unmodified-Since`. The server must also expose `Content-Type` in its CORS response headers.

The manifest quote and `CHANGELOG.md` have been updated to match. Resolves #56.

## Why

The previous requirement was sufficient for an initial range request, but not for browser cache revalidation. When a browser has a cached range and wants to check whether it is still valid, it can send one of the `If-*` conditional request headers. If the server does not allow those headers, the browser cannot revalidate the cached data and may have to download it again. This change adds the missing headers explicitly.

The requirement follows the actual CORS distinction between:

* **Allowed request headers:** `Range` and the `If-*` headers.
* **Exposed response headers:** `Content-Type`.

Provider-specific headers and provider-specific versioning mechanisms remain out of scope.

## Verification

The manifest and prose agree, and the requirements are correctly anchored:

```text
$ uv run specs/tools/check_requirements.py
OK: 115 requirements anchored; all keyword occurrences covered.
```
