### PR TITLE
docs: scope the Data Storage HTTP MUSTs to hosted assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   republishing data it did not produce. This is a wording-only change. The
   requirements are unchanged, and the upstream role value `collection-mirror` is
   unaffected (#99).
+- **Data Storage** (PORTO-CORE-043, PORTO-CORE-044, PORTO-CORE-045): the HTTP
+  requirements now name whose servers they bind. Range support, `206 Partial
+  Content`, `Accept-Ranges`, `Content-Length`, and CORS apply to the servers
+  hosting the catalog's own cloud-native assets. Upstream originals hosted by a
+  third party are exempt, and a validator leaves those hosts unprobed. The
+  requirements are unchanged in force; only their scope is now stated, matching
+  what reis already does (#89).
 - **Data Storage** (PORTO-CORE-045): the CORS requirement now names the header
   set a browser actually needs. Allowed request headers add `If-Match`,
   `If-Modified-Since`, `If-None-Match`, and `If-Unmodified-Since` next to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+### Added
+
+- **Data Storage** (PORTO-CORE-073): a validator MUST probe the servers hosting
+  the catalog's own cloud-native assets and MUST NOT require upstream servers to
+  satisfy the section's requirements. This writes down the carve-out reis
+  already applies to `source` and `alternate` assets (#89).
+
 ### Changed
 
 - **"Item mirror" is now used consistently** (PORTO-FMT-040, PORTO-FMT-041,
@@ -18,13 +25,13 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   republishing data it did not produce. This is a wording-only change. The
   requirements are unchanged, and the upstream role value `collection-mirror` is
   unaffected (#99).
-- **Data Storage** (PORTO-CORE-043, PORTO-CORE-044, PORTO-CORE-045): the HTTP
-  requirements now name whose servers they bind. Range support, `206 Partial
-  Content`, `Accept-Ranges`, `Content-Length`, and CORS apply to the servers
-  hosting the catalog's own cloud-native assets. Upstream originals hosted by a
-  third party are exempt, and a validator leaves those hosts unprobed. The
-  requirements are unchanged in force; only their scope is now stated, matching
-  what reis already does (#89).
+- **Data Storage** (PORTO-CORE-043, PORTO-CORE-044, PORTO-CORE-045): clarifies
+  that the HTTP requirements apply to servers hosting the catalog's own
+  cloud-native assets. This includes range support, `206 Partial Content`,
+  `Accept-Ranges`, `Content-Length`, and CORS. Upstream originals hosted by
+  third parties are out of scope, and validators do not probe those hosts. The
+  requirements themselves are unchanged; this change only makes their scope
+  explicit, matching the behavior already implemented in reis (#89).
 - **Data Storage** (PORTO-CORE-045): the CORS requirement now names the header
   set a browser actually needs. Allowed request headers add `If-Match`,
   `If-Modified-Since`, `If-None-Match`, and `If-Unmodified-Since` next to
@@ -42,7 +49,7 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   enforcement moves from `process` to `validator`, since a data pass can check it.
 - **Assets** (PORTO-CORE-029): reworded to govern a `file:checksum` where one is
   present. Multihash encoding is still required, unchanged in force.
-- **Requirements manifest**: still 115 requirements, now 84 MUST, 17 SHOULD, and
+- **Requirements manifest**: 116 requirements, now 85 MUST, 17 SHOULD, and
   14 MAY.
 - **Default style is identified by a `default` role**
   ([`specs/portolan/core.md`](specs/portolan/core.md)): a collection with more than

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -316,29 +316,28 @@ Items SHOULD carry an explicit `datetime` (or a `start_datetime` /
 
 ## Data Storage
 
-Cloud-native formats depend on clients being able to retrieve only the bytes
-they need. Portolan catalogs therefore assume that cloud-native assets are
-available from object storage over HTTP range requests, whether or not the
-storage is S3-compatible.
+Cloud-native formats depend on clients fetching only the bytes they need, so
+Portolan catalogs assume data is hosted in cloud object storage reachable over
+HTTP range requests (S3-compatible or otherwise).
 
 The requirements in this section apply to servers hosting the catalog's own
 cloud-native assets: the copies of the data that the publisher has uploaded and
 controls. They do not apply to upstream sources hosted by third parties.
 
-A server hosting the catalog's cloud-native assets MUST support range requests:
-honor the `Range` header, return `206 Partial Content`, and advertise
+A server hosting the catalog's cloud-native assets MUST support range
+requests: honor the `Range` header, return `206 Partial Content`, and advertise
 `Accept-Ranges: bytes`; HEAD requests MUST return an accurate `Content-Length`.
-The server MUST support HTTP/1.1 or later; HTTP/2 or HTTP/3 is RECOMMENDED.
-Endpoints that compress or transform responses in ways that break range
-semantics are not conformant.
+The server MUST support HTTP/1.1 or greater; HTTP/2 or /3 is RECOMMENDED. Endpoints
+that compress or transform responses in ways that break range semantics are not
+conformant.
 
 To let browser clients read data directly, a server hosting the catalog's
-cloud-native assets MUST also enable CORS on all metadata and asset files:
-`Access-Control-Allow-Origin: *` (or an equivalent read-permitting policy),
-allowed methods including `GET` and `HEAD`, allowed request headers including
-`Range`, `If-Match`, `If-Modified-Since`, `If-None-Match`, and
-`If-Unmodified-Since` (via `Access-Control-Allow-Headers`), and exposed
-response headers including
+cloud-native assets MUST also enable CORS on all
+metadata and asset files: `Access-Control-Allow-Origin: *` (or an equivalent
+read-permitting policy), allowed methods including `GET` and `HEAD`, allowed
+request headers including `Range`, `If-Match`, `If-Modified-Since`,
+`If-None-Match`, and `If-Unmodified-Since` (via
+`Access-Control-Allow-Headers`), and exposed response headers including
 `Content-Type`, `Content-Length`, `Content-Range`, `Accept-Ranges`, and `ETag`
 (via `Access-Control-Expose-Headers`).
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -318,16 +318,20 @@ Items SHOULD carry an explicit `datetime` (or a `start_datetime` /
 
 Cloud-native formats depend on clients fetching only the bytes they need, so
 Portolan catalogs assume data is hosted in cloud object storage reachable over
-HTTP range requests (S3-compatible or otherwise). Servers MUST support range
-requests: honor the `Range` header, return `206 Partial Content`, and advertise
-`Accept-Ranges: bytes`; HEAD requests MUST return an accurate `Content-Length`.
-Servers MUST support HTTP/1.1 or greater; HTTP/2 or /3 is RECOMMENDED. Endpoints
-that compress or transform responses in ways that break range semantics are not
-conformant.
+HTTP range requests (S3-compatible or otherwise). The rules below govern the
+servers hosting the catalog's own cloud-native assets, the copies the publisher
+uploaded and controls.
 
-To let browser clients read data directly, servers MUST also enable CORS on all
-metadata and asset files: `Access-Control-Allow-Origin: *` (or an equivalent
-read-permitting policy), allowed methods including `GET` and `HEAD`, allowed
+A server hosting those assets MUST support range requests: honor the `Range`
+header, return `206 Partial Content`, and advertise `Accept-Ranges: bytes`; HEAD
+requests MUST return an accurate `Content-Length`. That server MUST support
+HTTP/1.1 or greater; HTTP/2 or /3 is RECOMMENDED. Endpoints that compress or
+transform responses in ways that break range semantics are not conformant.
+
+To let browser clients read data directly, a server hosting those assets MUST
+also enable CORS on all metadata and asset files:
+`Access-Control-Allow-Origin: *` (or an equivalent read-permitting policy),
+allowed methods including `GET` and `HEAD`, allowed
 request headers including `Range`, `If-Match`, `If-Modified-Since`,
 `If-None-Match`, and `If-Unmodified-Since` (via
 `Access-Control-Allow-Headers`), and exposed response headers including
@@ -339,6 +343,14 @@ of refetching it, which keeps tile and range readers cheap on repeat views.
 Provider-specific headers such as `x-amz-*` and `x-goog-*` fall outside this
 requirement, since reading a public catalog takes no signed request. Portolan
 leaves cloud-specific configuration to separate guidance.
+
+A catalog also points at bytes the publisher does not host: the upstream source
+a mirror complements, and any original file an asset carries over from it. Those
+servers answer to a third party who never agreed to serve Portolan, so the rules
+above do not reach them. A validator probes the assets the publisher hosts and
+leaves upstream hosts alone. An upstream server that ignores `Range` or omits
+CORS headers is a limit on what clients can do with that copy, not a conformance
+failure of the catalog pointing at it.
 
 ## Providers
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -316,25 +316,29 @@ Items SHOULD carry an explicit `datetime` (or a `start_datetime` /
 
 ## Data Storage
 
-Cloud-native formats depend on clients fetching only the bytes they need, so
-Portolan catalogs assume data is hosted in cloud object storage reachable over
-HTTP range requests (S3-compatible or otherwise). The rules below govern the
-servers hosting the catalog's own cloud-native assets, the copies the publisher
-uploaded and controls.
+Cloud-native formats depend on clients being able to retrieve only the bytes
+they need. Portolan catalogs therefore assume that cloud-native assets are
+available from object storage over HTTP range requests, whether or not the
+storage is S3-compatible.
 
-A server hosting those assets MUST support range requests: honor the `Range`
-header, return `206 Partial Content`, and advertise `Accept-Ranges: bytes`; HEAD
-requests MUST return an accurate `Content-Length`. That server MUST support
-HTTP/1.1 or greater; HTTP/2 or /3 is RECOMMENDED. Endpoints that compress or
-transform responses in ways that break range semantics are not conformant.
+The requirements in this section apply to servers hosting the catalog's own
+cloud-native assets: the copies of the data that the publisher has uploaded and
+controls. They do not apply to upstream sources hosted by third parties.
 
-To let browser clients read data directly, a server hosting those assets MUST
-also enable CORS on all metadata and asset files:
+A server hosting the catalog's cloud-native assets MUST support range requests:
+honor the `Range` header, return `206 Partial Content`, and advertise
+`Accept-Ranges: bytes`; HEAD requests MUST return an accurate `Content-Length`.
+The server MUST support HTTP/1.1 or later; HTTP/2 or HTTP/3 is RECOMMENDED.
+Endpoints that compress or transform responses in ways that break range
+semantics are not conformant.
+
+To let browser clients read data directly, a server hosting the catalog's
+cloud-native assets MUST also enable CORS on all metadata and asset files:
 `Access-Control-Allow-Origin: *` (or an equivalent read-permitting policy),
-allowed methods including `GET` and `HEAD`, allowed
-request headers including `Range`, `If-Match`, `If-Modified-Since`,
-`If-None-Match`, and `If-Unmodified-Since` (via
-`Access-Control-Allow-Headers`), and exposed response headers including
+allowed methods including `GET` and `HEAD`, allowed request headers including
+`Range`, `If-Match`, `If-Modified-Since`, `If-None-Match`, and
+`If-Unmodified-Since` (via `Access-Control-Allow-Headers`), and exposed
+response headers including
 `Content-Type`, `Content-Length`, `Content-Range`, `Accept-Ranges`, and `ETag`
 (via `Access-Control-Expose-Headers`).
 
@@ -344,13 +348,16 @@ Provider-specific headers such as `x-amz-*` and `x-goog-*` fall outside this
 requirement, since reading a public catalog takes no signed request. Portolan
 leaves cloud-specific configuration to separate guidance.
 
-A catalog also points at bytes the publisher does not host: the upstream source
-a mirror complements, and any original file an asset carries over from it. Those
-servers answer to a third party who never agreed to serve Portolan, so the rules
-above do not reach them. A validator probes the assets the publisher hosts and
-leaves upstream hosts alone. An upstream server that ignores `Range` or omits
-CORS headers is a limit on what clients can do with that copy, not a conformance
-failure of the catalog pointing at it.
+Catalogs also reference bytes that the publisher does not host, including
+upstream sources that a mirror complements and original files carried over from
+an upstream source. Because those servers are operated by third parties and are
+outside the publisher's control, the requirements above do not apply to them.
+
+A validator MUST probe the servers hosting the catalog's own cloud-native assets
+and MUST NOT require upstream servers to satisfy these requirements. An upstream
+server that does not support range requests or provide the required CORS headers
+limits the capabilities available to clients using that upstream copy, but does
+not make the catalog non-conformant.
 
 ## Providers
 

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -417,7 +417,7 @@ requirements:
     enforcement: process
     file: specs/portolan/core.md
     quote: >-
-      The server MUST support HTTP/1.1 or later; HTTP/2 or HTTP/3 is
+      The server MUST support HTTP/1.1 or greater; HTTP/2 or /3 is
       RECOMMENDED.
 
   - id: PORTO-CORE-045

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -407,9 +407,9 @@ requirements:
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      A server hosting those assets MUST support range requests: honor the
-      `Range` header, return `206 Partial Content`, and advertise
-      `Accept-Ranges: bytes`; HEAD requests MUST return an accurate
+      A server hosting the catalog's cloud-native assets MUST support range
+      requests: honor the `Range` header, return `206 Partial Content`, and
+      advertise `Accept-Ranges: bytes`; HEAD requests MUST return an accurate
       `Content-Length`.
 
   - id: PORTO-CORE-044
@@ -417,7 +417,7 @@ requirements:
     enforcement: process
     file: specs/portolan/core.md
     quote: >-
-      That server MUST support HTTP/1.1 or greater; HTTP/2 or /3 is
+      The server MUST support HTTP/1.1 or later; HTTP/2 or HTTP/3 is
       RECOMMENDED.
 
   - id: PORTO-CORE-045
@@ -425,9 +425,9 @@ requirements:
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      To let browser clients read data directly, a server hosting those
-      assets MUST also enable CORS on all metadata and asset files:
-      `Access-Control-Allow-Origin: *`
+      To let browser clients read data directly, a server hosting the
+      catalog's cloud-native assets MUST also enable CORS on all metadata and
+      asset files: `Access-Control-Allow-Origin: *`
       (or an equivalent read-permitting policy), allowed methods including
       `GET` and `HEAD`, allowed request headers including `Range`,
       `If-Match`, `If-Modified-Since`, `If-None-Match`, and
@@ -435,6 +435,18 @@ requirements:
       response headers including `Content-Type`, `Content-Length`,
       `Content-Range`, `Accept-Ranges`, and `ETag` (via
       `Access-Control-Expose-Headers`).
+
+  # Numbered after the last core requirement because it was added to the Data
+  # Storage section once the section's scope was stated; kept here in document
+  # order, where the sentence it anchors lives.
+  - id: PORTO-CORE-073
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/core.md
+    quote: >-
+      A validator MUST probe the servers hosting the catalog's own
+      cloud-native assets and MUST NOT require upstream servers to satisfy
+      these requirements.
 
   - id: PORTO-CORE-046
     severity: MUST

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -407,24 +407,27 @@ requirements:
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      Servers MUST support range requests: honor the `Range` header, return
-      `206 Partial Content`, and advertise `Accept-Ranges: bytes`; HEAD
-      requests MUST return an accurate `Content-Length`.
+      A server hosting those assets MUST support range requests: honor the
+      `Range` header, return `206 Partial Content`, and advertise
+      `Accept-Ranges: bytes`; HEAD requests MUST return an accurate
+      `Content-Length`.
 
   - id: PORTO-CORE-044
     severity: MUST
     enforcement: process
     file: specs/portolan/core.md
     quote: >-
-      Servers MUST support HTTP/1.1 or greater; HTTP/2 or /3 is RECOMMENDED.
+      That server MUST support HTTP/1.1 or greater; HTTP/2 or /3 is
+      RECOMMENDED.
 
   - id: PORTO-CORE-045
     severity: MUST
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      To let browser clients read data directly, servers MUST also enable
-      CORS on all metadata and asset files: `Access-Control-Allow-Origin: *`
+      To let browser clients read data directly, a server hosting those
+      assets MUST also enable CORS on all metadata and asset files:
+      `Access-Control-Allow-Origin: *`
       (or an equivalent read-permitting policy), allowed methods including
       `GET` and `HEAD`, allowed request headers including `Range`,
       `If-Match`, `If-Modified-Since`, `If-None-Match`, and


### PR DESCRIPTION
## What this changes

Data Storage now states whose servers its HTTP requirements apply to: those
hosting the catalog's own cloud-native assets, the copies the publisher uploaded
and controls. PORTO-CORE-043, 044, and 045 carry that subject. New
PORTO-CORE-073 says a validator probes those servers and holds no upstream
server to them. Companion-PR: portolan-sdi/rashid#106

## Why

Resolves #89. The requirements read "Servers", unqualified, so a mirror citing
eight upstreams was measured against hosts it does not run, none of which
complies in full. reis already exempts source and alternate assets, making the
validator more lenient than the text authorized. The requirements themselves are
unchanged. Checksums on upstream assets stay with #112.

## Verification

The manifest check reads `specs/portolan/core.md` and
`specs/portolan/requirements.yaml`, confirming every quote still anchors
verbatim and that no RFC 2119 keyword, including the two in PORTO-CORE-073,
escapes a requirement.

```
$ uv run specs/tools/check_requirements.py
OK: 116 requirements anchored; all keyword occurrences covered.
```
