### PR TITLE
docs: scope the PORTO-FMT-006 row-group tests to five or more groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,18 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 - **GeoParquet** (PORTO-FMT-006): the low-overlap and high-locality tests now
   apply only to files of five or more row groups. Both measure a fraction over
   the row groups themselves, so below five the fraction has nowhere useful to
-  land: an average box under 25% of the extent is out of reach on two or three
-  row groups however well the rows are sorted, and a spatially ordered
-  four-row-group file was failing on that alone. The thresholds are unchanged,
-  as is the rule that rows MUST be spatially ordered. The 50% skip rate for a
-  10% query window now reads as the reason the threshold sits at 25% rather
-  than as a second test a validator runs (#127).
+  land, and a spatially ordered four-row-group file was failing on that alone.
+  The rule that rows MUST be spatially ordered is unchanged and still binds
+  every file, whatever its row-group layout. The 50% skip rate for a 10% query
+  window now reads as the reason for the threshold rather than as a second test
+  a validator runs (#127).
+- **GeoParquet** (PORTO-FMT-006): the high-locality threshold moves from about
+  25% of the file extent to about 30%. Measured over Hilbert-sorted points, the
+  ordering producers actually reach for, row-group boxes average 0.263 to 0.274
+  of the extent at five row groups and 0.250 to 0.270 at six, so 25% rejected
+  well-sorted data for its row-group count rather than its ordering. Seven
+  groups and above already cleared 25%. The low-overlap threshold is unchanged
+  at 30% of consecutive pairs (#127).
 - **"Item mirror" is now used consistently** (PORTO-FMT-040, PORTO-FMT-041,
   PORTO-FMT-043). The STAC-GeoParquet copy of a collection's items is now always
   referred to as an **item mirror** or **STAC-GeoParquet mirror**, leaving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Added
 
-- **GeoParquet** (PORTO-FMT-044): a validator MUST NOT fault a file for missing
-  a spatial-ordering threshold its row-group count cannot express, and MAY
-  measure ordering another way when the row-group tests do not apply. This
-  covers the row-level measurement reis already performs on a single-row-group
-  file by partitioning its rows (#127).
+- **GeoParquet** (PORTO-FMT-044): a validator MUST NOT fail a file for missing a
+  spatial-ordering threshold that its row-group count puts out of reach. Row
+  ordering is a separate rule and is not waived along with those thresholds, so
+  a file with fewer than five row groups is still checked on its rows (#127).
 - **Data Storage** (PORTO-CORE-073): a validator MUST probe the servers hosting
   the catalog's own cloud-native assets and MUST NOT require upstream servers to
   satisfy the section's requirements. This writes down the carve-out reis
@@ -23,21 +22,20 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Changed
 
-- **GeoParquet** (PORTO-FMT-006): the low-overlap and high-locality tests now
-  apply only to files of five or more row groups. Both measure a fraction over
-  the row groups themselves, so below five the fraction has nowhere useful to
-  land, and a spatially ordered four-row-group file was failing on that alone.
-  The rule that rows MUST be spatially ordered is unchanged and still binds
-  every file, whatever its row-group layout. The 50% skip rate for a 10% query
-  window now reads as the reason for the threshold rather than as a second test
-  a validator runs (#127).
-- **GeoParquet** (PORTO-FMT-006): the high-locality threshold moves from about
-  25% of the file extent to about 30%. Measured over Hilbert-sorted points, the
-  ordering producers actually reach for, row-group boxes average 0.263 to 0.274
-  of the extent at five row groups and 0.250 to 0.270 at six, so 25% rejected
-  well-sorted data for its row-group count rather than its ordering. Seven
-  groups and above already cleared 25%. The low-overlap threshold is unchanged
-  at 30% of consecutive pairs (#127).
+- **GeoParquet** (PORTO-FMT-006): the low-overlap and high-locality checks now
+  apply only to files with five or more row groups, and the high-locality limit
+  moves from about 25% of the file extent to about 30%. Both checks measure a
+  percentage across the row groups, so with fewer than five groups the
+  percentage cannot land on a useful value, and a well-ordered four-row-group
+  file was failing for that reason alone. The 30% limit comes from measuring
+  Hilbert-sorted data, which is how producers usually sort: boxes cover 0.263 to
+  0.274 of the extent at five row groups and 0.250 to 0.270 at six, so the old
+  25% failed those files for having few row groups rather than for their
+  ordering. Files with seven or more groups already passed at 25%. The
+  low-overlap limit is unchanged, as is the rule that rows MUST be spatially
+  ordered, which still applies to every file. The 50% skip rate for a 10% query
+  window now reads as the benefit the limit delivers, not as a second check
+  (#127).
 - **"Item mirror" is now used consistently** (PORTO-FMT-040, PORTO-FMT-041,
   PORTO-FMT-043). The STAC-GeoParquet copy of a collection's items is now always
   referred to as an **item mirror** or **STAC-GeoParquet mirror**, leaving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Added
 
+- **GeoParquet** (PORTO-FMT-044): a validator MUST NOT fault a file for missing
+  a spatial-ordering threshold its row-group count cannot express, and MAY
+  measure ordering another way when the row-group tests do not apply. This
+  covers the row-level measurement reis already performs on a single-row-group
+  file by partitioning its rows (#127).
 - **Data Storage** (PORTO-CORE-073): a validator MUST probe the servers hosting
   the catalog's own cloud-native assets and MUST NOT require upstream servers to
   satisfy the section's requirements. This writes down the carve-out reis
@@ -18,6 +23,15 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Changed
 
+- **GeoParquet** (PORTO-FMT-006): the low-overlap and high-locality tests now
+  apply only to files of five or more row groups. Both measure a fraction over
+  the row groups themselves, so below five the fraction has nowhere useful to
+  land: an average box under 25% of the extent is out of reach on two or three
+  row groups however well the rows are sorted, and a spatially ordered
+  four-row-group file was failing on that alone. The thresholds are unchanged,
+  as is the rule that rows MUST be spatially ordered. The 50% skip rate for a
+  10% query window now reads as the reason the threshold sits at 25% rather
+  than as a second test a validator runs (#127).
 - **"Item mirror" is now used consistently** (PORTO-FMT-040, PORTO-FMT-041,
   PORTO-FMT-043). The STAC-GeoParquet copy of a collection's items is now always
   referred to as an **item mirror** or **STAC-GeoParquet mirror**, leaving the

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -27,37 +27,39 @@ Distributing GeoParquet](https://guide.cloudnativegeo.org/geoparquet/) so it can
 queried without a server. Files SHOULD be compressed to stay small, with `zstd`
 RECOMMENDED.
 
-Rows MUST be spatially ordered so nearby features are nearby in the file. This binds
-every file, whatever its row-group layout. A validator measures it over the rows
-themselves: partition them into the groups a conforming writer would have emitted,
-then check that those cluster.
+Rows MUST be spatially ordered so nearby features are nearby in the file. This rule
+applies to every file, no matter how many row groups it has. A validator checks it
+by looking at the rows themselves. It splits them into the groups a conforming
+writer would have produced, then checks that each of those groups covers a small
+part of the file.
 
-A file of five or more row groups is tested on its actual row groups as well, which
-a reader can judge from footer metadata without touching the data. It passes on
-either of:
+A file with five or more row groups gets a second check, using the row groups it
+actually has. A reader can run this one from the file footer alone, without reading
+any data. The file passes if either of these is true:
 
-- **low overlap** — fewer than 30% of consecutive row-group pairs have
-  interior-intersecting bounding boxes; or
-- **high locality** — row-group boxes average under about 30% of the file extent.
+- **low overlap** — fewer than 30% of consecutive row-group pairs have bounding
+  boxes that overlap on their interiors; or
+- **high locality** — row-group bounding boxes cover, on average, less than about
+  30% of the file's total extent.
 
-Boxes that small let a reader skip roughly half the row groups for a query window
-covering 10% of the extent. That payoff is why the threshold sits where it does. It
-is not a further test to run.
+Boxes that small let a reader skip about half the row groups when querying a window
+covering 10% of the extent. That is the benefit the 30% figure is meant to deliver,
+not a separate test to run.
 
-The figure is set from what a Hilbert sort actually achieves, the ordering producers
-reach for. Hilbert-sorted data lands near 27% of the extent at five row groups and
-falls away quickly as groups are added, so 30% admits it with a little room. A file
-divided into five groups gives each about a fifth of the extent before any slop, and
-a threshold tighter than that rejects well-sorted data for its row-group count
-rather than its ordering.
+The 30% figure comes from measuring Hilbert-sorted data, which is how producers
+usually sort. With five row groups, Hilbert-sorted boxes cover about 27% of the
+extent, and that number drops as row groups are added. Five row groups divide the
+extent five ways, so each box covers about a fifth of it before any overlap is
+counted. A stricter limit would fail well-sorted files for having few row groups.
 
-Neither row-group test applies below five. Both measure a fraction over the row
-groups themselves, and too few groups leave that fraction nowhere useful to land.
-Three groups can only overlap on 0%, 50%, or 100% of consecutive pairs. An average
-box under 30% of the extent is out of reach on two or three however well the rows
-are sorted. A validator MUST NOT fault a file for missing a threshold its row-group
-count cannot express. Row ordering is a separate property and is not exempted with
-them, so a file below five row groups is still judged on its rows.
+Neither of these two checks applies to a file with fewer than five row groups. Both
+measure a percentage across the row groups, and with only a few groups the
+percentage cannot land on a useful value. Three row groups can only produce an
+overlap of 0%, 50%, or 100%. Two or three boxes cannot average less than 30% of the
+extent, however well the rows are sorted. A validator MUST NOT fail a file for
+missing a threshold that its row-group count puts out of reach. Row ordering is a
+separate rule and is not waived here, so a file with fewer than five row groups is
+still checked on its rows.
 
 Files MUST provide per-row-group spatial statistics so readers can skip row groups
 from metadata alone — either:

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -27,14 +27,26 @@ Distributing GeoParquet](https://guide.cloudnativegeo.org/geoparquet/) so it can
 queried without a server. Files SHOULD be compressed to stay small, with `zstd`
 RECOMMENDED.
 
-Rows MUST be spatially ordered so nearby features are nearby in the file, tested
-either as:
+Rows MUST be spatially ordered so nearby features are nearby in the file. A file of
+five or more row groups is tested on either of:
 
 - **low overlap** — fewer than 30% of consecutive row-group pairs have
   interior-intersecting bounding boxes; or
-- **high locality** — row-group boxes average under about 25% of the file extent,
-  letting a reader skip at least 50% of row groups for a query window of 10% of the
-  extent.
+- **high locality** — row-group boxes average under about 25% of the file extent.
+
+Boxes that small let a reader skip at least half the row groups for a query window
+covering 10% of the extent. That payoff is why the threshold sits at 25%. It is not
+a further test to run.
+
+Neither test applies below five row groups. Both measure a fraction over the row
+groups themselves, and too few groups leave that fraction nowhere useful to land.
+Three groups can only overlap on 0%, 50%, or 100% of consecutive pairs. An average
+box under 25% of the extent is out of reach on two or three however well the rows
+are sorted. A validator MUST NOT fault a file for missing a threshold its row-group
+count cannot express. The ordering requirement itself still holds, so a validator
+MAY measure it another way, such as partitioning the rows of a single-row-group file
+into the groups a conforming writer would have emitted and applying the same two
+tests to those.
 
 Files MUST provide per-row-group spatial statistics so readers can skip row groups
 from metadata alone — either:

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -38,16 +38,23 @@ either of:
 
 - **low overlap** — fewer than 30% of consecutive row-group pairs have
   interior-intersecting bounding boxes; or
-- **high locality** — row-group boxes average under about 25% of the file extent.
+- **high locality** — row-group boxes average under about 30% of the file extent.
 
-Boxes that small let a reader skip at least half the row groups for a query window
-covering 10% of the extent. That payoff is why the threshold sits at 25%. It is not
-a further test to run.
+Boxes that small let a reader skip roughly half the row groups for a query window
+covering 10% of the extent. That payoff is why the threshold sits where it does. It
+is not a further test to run.
+
+The figure is set from what a Hilbert sort actually achieves, the ordering producers
+reach for. Hilbert-sorted data lands near 27% of the extent at five row groups and
+falls away quickly as groups are added, so 30% admits it with a little room. A file
+divided into five groups gives each about a fifth of the extent before any slop, and
+a threshold tighter than that rejects well-sorted data for its row-group count
+rather than its ordering.
 
 Neither row-group test applies below five. Both measure a fraction over the row
 groups themselves, and too few groups leave that fraction nowhere useful to land.
 Three groups can only overlap on 0%, 50%, or 100% of consecutive pairs. An average
-box under 25% of the extent is out of reach on two or three however well the rows
+box under 30% of the extent is out of reach on two or three however well the rows
 are sorted. A validator MUST NOT fault a file for missing a threshold its row-group
 count cannot express. Row ordering is a separate property and is not exempted with
 them, so a file below five row groups is still judged on its rows.

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -27,8 +27,14 @@ Distributing GeoParquet](https://guide.cloudnativegeo.org/geoparquet/) so it can
 queried without a server. Files SHOULD be compressed to stay small, with `zstd`
 RECOMMENDED.
 
-Rows MUST be spatially ordered so nearby features are nearby in the file. A file of
-five or more row groups is tested on either of:
+Rows MUST be spatially ordered so nearby features are nearby in the file. This binds
+every file, whatever its row-group layout. A validator measures it over the rows
+themselves: partition them into the groups a conforming writer would have emitted,
+then check that those cluster.
+
+A file of five or more row groups is tested on its actual row groups as well, which
+a reader can judge from footer metadata without touching the data. It passes on
+either of:
 
 - **low overlap** — fewer than 30% of consecutive row-group pairs have
   interior-intersecting bounding boxes; or
@@ -38,15 +44,13 @@ Boxes that small let a reader skip at least half the row groups for a query wind
 covering 10% of the extent. That payoff is why the threshold sits at 25%. It is not
 a further test to run.
 
-Neither test applies below five row groups. Both measure a fraction over the row
+Neither row-group test applies below five. Both measure a fraction over the row
 groups themselves, and too few groups leave that fraction nowhere useful to land.
 Three groups can only overlap on 0%, 50%, or 100% of consecutive pairs. An average
 box under 25% of the extent is out of reach on two or three however well the rows
 are sorted. A validator MUST NOT fault a file for missing a threshold its row-group
-count cannot express. The ordering requirement itself still holds, so a validator
-MAY measure it another way, such as partitioning the rows of a single-row-group file
-into the groups a conforming writer would have emitted and applying the same two
-tests to those.
+count cannot express. Row ordering is a separate property and is not exempted with
+them, so a file below five row groups is still judged on its rows.
 
 Files MUST provide per-row-group spatial statistics so readers can skip row groups
 from metadata alone — either:

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -729,25 +729,27 @@ requirements:
     file: specs/portolan/formats.md
     quote: >-
       Rows MUST be spatially ordered so nearby features are nearby in the
-      file. This binds every file, whatever its row-group layout. A validator
-      measures it over the rows themselves: partition them into the groups a
-      conforming writer would have emitted, then check that those cluster. A
-      file of five or more row groups is tested on its actual row groups as
-      well, which a reader can judge from footer metadata without touching the
-      data. It passes on either of: - **low overlap** — fewer than 30% of
-      consecutive row-group pairs have interior-intersecting bounding boxes;
-      or - **high locality** — row-group boxes average under about 30% of the
-      file extent.
+      file. This rule applies to every file, no matter how many row groups it
+      has. A validator checks it by looking at the rows themselves. It splits
+      them into the groups a conforming writer would have produced, then checks
+      that each of those groups covers a small part of the file. A file with
+      five or more row groups gets a second check, using the row groups it
+      actually has. A reader can run this one from the file footer alone,
+      without reading any data. The file passes if either of these is true: -
+      **low overlap** — fewer than 30% of consecutive row-group pairs have
+      bounding boxes that overlap on their interiors; or - **high locality** —
+      row-group bounding boxes cover, on average, less than about 30% of the
+      file's total extent.
 
   - id: PORTO-FMT-044
     severity: MUST
     enforcement: validator
     file: specs/portolan/formats.md
     quote: >-
-      A validator MUST NOT fault a file for missing a threshold its row-group
-      count cannot express. Row ordering is a separate property and is not
-      exempted with them, so a file below five row groups is still judged on
-      its rows.
+      A validator MUST NOT fail a file for missing a threshold that its
+      row-group count puts out of reach. Row ordering is a separate rule and is
+      not waived here, so a file with fewer than five row groups is still
+      checked on its rows.
 
   - id: PORTO-FMT-007
     severity: MUST

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -729,10 +729,15 @@ requirements:
     file: specs/portolan/formats.md
     quote: >-
       Rows MUST be spatially ordered so nearby features are nearby in the
-      file. A file of five or more row groups is tested on either of: - **low
-      overlap** — fewer than 30% of consecutive row-group pairs have
-      interior-intersecting bounding boxes; or - **high locality** — row-group
-      boxes average under about 25% of the file extent.
+      file. This binds every file, whatever its row-group layout. A validator
+      measures it over the rows themselves: partition them into the groups a
+      conforming writer would have emitted, then check that those cluster. A
+      file of five or more row groups is tested on its actual row groups as
+      well, which a reader can judge from footer metadata without touching the
+      data. It passes on either of: - **low overlap** — fewer than 30% of
+      consecutive row-group pairs have interior-intersecting bounding boxes;
+      or - **high locality** — row-group boxes average under about 25% of the
+      file extent.
 
   - id: PORTO-FMT-044
     severity: MUST
@@ -740,10 +745,9 @@ requirements:
     file: specs/portolan/formats.md
     quote: >-
       A validator MUST NOT fault a file for missing a threshold its row-group
-      count cannot express. The ordering requirement itself still holds, so a
-      validator MAY measure it another way, such as partitioning the rows of a
-      single-row-group file into the groups a conforming writer would have
-      emitted and applying the same two tests to those.
+      count cannot express. Row ordering is a separate property and is not
+      exempted with them, so a file below five row groups is still judged on
+      its rows.
 
   - id: PORTO-FMT-007
     severity: MUST

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -729,11 +729,21 @@ requirements:
     file: specs/portolan/formats.md
     quote: >-
       Rows MUST be spatially ordered so nearby features are nearby in the
-      file, tested either as: - **low overlap** — fewer than 30% of
-      consecutive row-group pairs have interior-intersecting bounding boxes;
-      or - **high locality** — row-group boxes average under about 25% of the
-      file extent, letting a reader skip at least 50% of row groups for a
-      query window of 10% of the extent.
+      file. A file of five or more row groups is tested on either of: - **low
+      overlap** — fewer than 30% of consecutive row-group pairs have
+      interior-intersecting bounding boxes; or - **high locality** — row-group
+      boxes average under about 25% of the file extent.
+
+  - id: PORTO-FMT-044
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/formats.md
+    quote: >-
+      A validator MUST NOT fault a file for missing a threshold its row-group
+      count cannot express. The ordering requirement itself still holds, so a
+      validator MAY measure it another way, such as partitioning the rows of a
+      single-row-group file into the groups a conforming writer would have
+      emitted and applying the same two tests to those.
 
   - id: PORTO-FMT-007
     severity: MUST

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -736,7 +736,7 @@ requirements:
       well, which a reader can judge from footer metadata without touching the
       data. It passes on either of: - **low overlap** — fewer than 30% of
       consecutive row-group pairs have interior-intersecting bounding boxes;
-      or - **high locality** — row-group boxes average under about 25% of the
+      or - **high locality** — row-group boxes average under about 30% of the
       file extent.
 
   - id: PORTO-FMT-044


### PR DESCRIPTION
## What this changes

PORTO-FMT-006's two row-group tests now apply at five or more row groups, and the
high-locality threshold moves from about 25% of the file extent to about 30%. The
rule that rows MUST be spatially ordered is unchanged and still applies to every file.
New PORTO-FMT-044 says a validator may not fault a file on a threshold its
row-group count cannot express, and that row ordering is not exempted with them.

## Why

The 25% figure was calibrated against Z-order. Producers sort by Hilbert, which
leaves row-group boxes at 0.263 to 0.274 of the extent at five row groups and
0.250 to 0.270 at six, so 25% rejected well-sorted files for their row-group count
rather than their ordering. Below five groups the fraction has nowhere useful to
land at all. Resolves #127.

Companion-PR: portolan-sdi/rashid#108

## Verification

The manifest check reads `specs/portolan/formats.md` and
`specs/portolan/requirements.yaml`.

```
$ uv run specs/tools/check_requirements.py
OK: 117 requirements anchored; all keyword occurrences covered.
```

Hilbert-sorted uniform points, 6300 rows, 10 seeds, measured in portolan-sdi/rashid#107:

```
groups   min    median   max
     5   0.263  0.265    0.274   <- 25% failed these; 30% passes them
     6   0.250  0.260    0.270   <- 25% failed these too
     7   0.190  0.195    0.208   <- already passed at 25%
```