### PR TITLE
docs: define the source and collection-mirror asset roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,23 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 - **Data Storage** (PORTO-CORE-073): a validator MUST probe the servers hosting
   the catalog's own cloud-native assets and MUST NOT require upstream servers to
   satisfy the section's requirements. This writes down the carve-out reis
-  already applies to `source` and `alternate` assets (#89).
+  already applies to upstream assets (#89).
+- **Assets**: the `source` and `collection-mirror` roles are defined where the
+  other roles are listed. `source` names the upstream original a cloud-native
+  asset was derived from, which PORTO-FMT-002 has asked a mirror to carry since
+  0.1.0; the role gives that asset a name and settles what carrying one costs.
+  It is a reference, satisfied by an href pointing at the upstream server, so no
+  publisher retains or rehosts an original to comply. `collection-mirror` is
+  already required on a published item mirror by PORTO-FMT-041; this documents
+  it rather than adding a requirement. Neither role is enumerated in the JSON
+  Schema, which still accepts any non-empty role string (#90).
+- **Formats** (PORTO-FMT-045): a validator MUST apply the format requirements to
+  the catalog's own cloud-native assets and MUST NOT fail an asset for its
+  format because that asset carries the `source` role. An upstream original is
+  a Shapefile or a GeoPackage as often as not, and judging it as a COG or a
+  GeoParquet was never intended. The role records provenance, not hosting;
+  which servers the Data Storage requirements reach is settled by
+  PORTO-CORE-073 (#90).
 
 ### Changed
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -234,6 +234,8 @@ are fine — use all that apply. The `style` role, used for MapLibre style files
 a Portolan-defined role rather than a standard STAC one (see [Visualization
 Styles](#visualization-styles)).
 
+The `source` role identifies an upstream original from which a cloud-native asset in this catalog was derived. For example, a publisher that converts an upstream Shapefile or GeoPackage to GeoParquet may include the original file as a `source` asset. PORTO-FMT-002 says that a mirror SHOULD include the original when it is directly downloadable rather than available only through an API. This means linking to the upstream file; the publisher does not need to retain, rehost, or redistribute it. A `source` asset is exempt from the format requirements because it represents the upstream original and may use a non-cloud-native format. A catalog that provides metadata for data that is already available upstream in a cloud-native format does not need a `source` asset; its `data` asset points directly to the upstream data. `collection-mirror` identifies the STAC-GeoParquet copy of a collection's items, as specified under Item mirror in formats.md.
+
 Portolan reuses existing extensions rather than restating their fields: `file` for
 `file:values`, `table` for schema and columns, `raster` and `vector` for band and
 layer detail, `license` for per-asset license, and `scientific` for citation or

--- a/specs/portolan/formats.md
+++ b/specs/portolan/formats.md
@@ -12,6 +12,10 @@ SHOULD reference alternate formats of data and metadata — for example an exist
 ISO 19115 file referenced as an asset with the `metadata` role — though new
 catalogs need not pre-produce them, since tooling should make translation easy.
 
+The requirements in this document apply to the catalog's own cloud-native assets: copies that the publisher derives and publishes. They do not apply to `source` assets, which represent the upstream originals from which those copies were derived and may use a non-cloud-native format.
+
+A validator MUST apply the format requirements in this document to the catalog's own cloud-native assets and MUST NOT fail an asset for its format because it carries the `source` role. The `source` role identifies provenance, not hosting. The Data Storage requirements in core.md apply according to who hosts the bytes, as specified there, regardless of the roles an asset carries.
+
 ## Vector
 
 Vector has no single complete cloud-native format yet, so Portolan pairs two strong

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -706,6 +706,18 @@ requirements:
       `metadata` role — though new catalogs need not pre-produce them, since
       tooling should make translation easy.
 
+  # Numbered after the last format requirement because it was added once the
+  # document's scope was stated; kept here in document order, where the
+  # sentence it anchors lives.
+  - id: PORTO-FMT-045
+    severity: MUST
+    enforcement: validator
+    file: specs/portolan/formats.md
+    quote: >-
+      A validator MUST apply the format requirements in this document to the
+      catalog's own cloud-native assets and MUST NOT fail an asset for its
+      format because it carries the `source` role.
+
   - id: PORTO-FMT-004
     severity: MUST
     enforcement: validator
@@ -1107,6 +1119,12 @@ exclusions:
       by structural validation; the Portolan-level guidance to carry an
       explicit `datetime` lives under [Temporal
       Metadata](#temporal-metadata) as a SHOULD.
+
+  # Cross-reference to PORTO-FMT-002, which carries the SHOULD itself.
+  - file: specs/portolan/core.md
+    quote: >-
+      PORTO-FMT-002 says that a mirror SHOULD include the original when it is
+      directly downloadable rather than available only through an API.
 
   # Statement about possible future spec evolution, not a conformance rule.
   - file: specs/portolan/formats.md

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asset carries either field rather than on every object with assets.
 - `PORTO-CORE-026`: `image/webp` is now a valid thumbnail media type alongside
   `image/png` and `image/jpeg`. No existing catalog breaks.
+- The media types and roles table lists the `source` and `collection-mirror`
+  roles, which catalogs already carry. The schema is unchanged: `roles` stays a
+  non-empty array of non-empty strings with no enumeration, so no previously
+  accepted value is removed.
 
 ## 0.1.0 - 2026-07-27
 

--- a/stac/README.md
+++ b/stac/README.md
@@ -109,8 +109,12 @@ Whether a catalog is official or a mirror is derived from its providers (produce
 | Thumbnail | `image/png`, `image/jpeg`, or `image/webp` | `thumbnail` |
 | Sidecar metadata | (format-specific) | `metadata`, `iso-19115` |
 | MapLibre style | `application/vnd.mapbox.style+json` | `style` (Portolan-defined role) |
+| STAC-GeoParquet item mirror | `application/vnd.apache.parquet` | `collection-mirror` (Portolan-defined role) |
+| Upstream original | (format-specific) | `source` (Portolan-defined role) |
 
 Styles are STAC assets: each style file is a collection-level asset with `roles: ["style"]`, discovered by filtering assets on that role — no separate manifest exists (spec: Visualization Styles).
+
+A `source` asset names the upstream original a cloud-native asset was derived from, so the format requirements do not reach it. A mirror should carry one when the original is a direct download, which means referencing it at the upstream href, not rehosting the file. `collection-mirror` is required on a published item mirror. Neither role is enumerated in the JSON Schema, which accepts any non-empty role string.
 
 ### Formats
 


### PR DESCRIPTION
## What this changes

This change adds the `source` role and the `collection-mirror` role to the list of roles in core.md. It adds the same two roles to the table in stac/README.md. The new requirement PORTO-FMT-045 limits the format requirements to the cloud-native assets of the catalog. A validator does not apply the COG rules to a `source` asset. The schema does not change.

## Why

This change closes issue #90. Catalogs use the two roles, but the specification does not list them. Each mirror collection in the reference catalog has a `source` asset. PORTO-FMT-041 made `collection-mirror` necessary in July 2026. The rashid validator applied the format exemption from July 2026 with no rule in the specification. PORTO-FMT-002 keeps its SHOULD, and the role gives a name to the asset in that rule. To include the original file means to make a link to it. The publisher does not copy or host the file.

## Verification

The manifest anchors all quotes, and the four profile examples are correct. The commands below read the reference catalog in `examples/catalog/portolan-reference`. The last two commands change the role of one asset. They show the limits of the exemption.

```console
$ uv run specs/tools/check_requirements.py
OK: 118 requirements anchored; all keyword occurrences covered.

$ cd stac && npm test
✓ catalog.json
✓ vector-collection.json
✓ vector-partitioned-collection.json
✓ vector-partitioned-item.json

$ rashid check examples/catalog/portolan-reference --data --data-scope all --summary
0 error(s), 0 warning(s), 8 info(s) across 14 files.

# the same catalog, with the source role removed from the plain GeoTIFF
3 error(s), 0 warning(s), 8 info(s) across 14 files.
error  PTL-DAT-004  asset 'source' raster is not a valid cloud-optimized COG:
       The file is greater than 512xH or 512xW, but is not tiled

# the same asset with the role "alternate", which gets no exemption
3 error(s), 0 warning(s), 8 info(s) across 14 files.
```

Companion-PR: portolan-sdi/rashid#109
