### PR TITLE
docs: state the CRS in the populated places AGENTS.md

### DIFF
--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
@@ -23,6 +23,13 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('na
 - 59 places carry POP_MAX below 1,000, mostly stations and outposts, so
   population filters silently drop real capitals of small territories.
 
+## CRS
+
+EPSG:4326, WGS84 longitude and latitude in degrees, the same CRS as the
+countries Collection, so the two overlay without a transform. `ST_Distance`
+returns degrees, use `ST_Distance_Sphere` for meters, and `ST_Transform`
+any layer in another CRS before comparing it to these points.
+
 ## Tested Queries
 
 Capitals per continent, with the country join done correctly.

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -458,6 +458,13 @@ collections:
         - 59 places carry POP_MAX below 1,000, mostly stations and outposts, so
           population filters silently drop real capitals of small territories.
 
+        ## CRS
+
+        EPSG:4326, WGS84 longitude and latitude in degrees, the same CRS as the
+        countries Collection, so the two overlay without a transform. `ST_Distance`
+        returns degrees, use `ST_Distance_Sphere` for meters, and `ST_Transform`
+        any layer in another CRS before comparing it to these points.
+
         ## Tested Queries
 
         Capitals per continent, with the country join done correctly.


### PR DESCRIPTION
## What this changes

Adds a `## CRS` section to the populated places AGENTS.md, naming EPSG:4326 and what it means in practice for distance and for overlaying the countries Collection.

The prose lives in `examples/manifests/portolan-reference.yaml`. The AGENTS.md is regenerated from it, never hand edited.

## Why

Resolves #138. The file discussed coordinates "by up to 0.22 degrees" but never named the datum, so an agent could not safely reproject or join it against another layer.

There is also a trap. Line 22's "a projection" refers to the POP2050 population forecast, not a CRS, so anyone skimming for CRS information hits a false positive.

## Verification

Data read, `examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json`, which declares `"proj:code": "EPSG:4326"` at line 652. Cross checked against `natural-earth-countries/collection.json` line 779, also EPSG:4326, which the new sentence claims.

```console
$ uv run examples/tools/build.py --docs-only --catalog portolan-reference
=== manifest portolan-reference.yaml ===
done

$ git status --porcelain examples/catalog/
 M examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md

$ grep -in "epsg" examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
28:EPSG:4326, WGS84 longitude and latitude in degrees, the same CRS as the

$ uv run examples/tools/tests/check_docs.py
docs code blocks, 36 ran, 2 skipped as illustrative, 0 failed
```

Exactly one generated file changed, and the docs check matches the `main` baseline.
