### PR TITLE
docs: write catalog README sources as prose

### DIFF
--- a/examples/catalog/portolan-reference/README.md
+++ b/examples/catalog/portolan-reference/README.md
@@ -29,16 +29,15 @@ the joins between Collections.
 
 ## Where the Data Comes From
 
-Licenses, CC-BY-4.0, CC0-1.0, PDDL-1.0.
-Provenance, 8 mirror Collections.
+All 8 Collections here are mirrors, so this catalog hosts copies of data produced elsewhere.
 
-Upstream sources.
+Natural Earth Countries (1:110m) is built from the [Natural Earth 110m Admin 0 Countries (zipped Shapefile)](https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip), pinned by checksum and licensed CC0-1.0.
+Natural Earth Populated Places (1:50m) is built from the [Natural Earth 50m Populated Places (zipped Shapefile)](https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip), pinned by checksum and licensed CC0-1.0.
+United States Counties (2023, 1:500k) is built from the [US Census cartographic boundary counties 2023 500k (zipped Shapefile)](https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip), pinned by checksum and licensed CC0-1.0.
 
-- Natural Earth Countries (1:110m), https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip
-- Natural Earth Populated Places (1:50m), https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip
-- United States Counties (2023, 1:500k), https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip
-- Boston Open Space, https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326
-- Netherlands Provinces, https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg
-- San Francisco Addresses (EAS), https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id
-- Sample Raster COG, https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif
-- Eurostat Electricity Prices for Household Consumers, https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false
+Boston Open Space tracks the [City of Boston Open Space (zipped Shapefile export)](https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326), a live endpoint refetched on every build rather than pinned, licensed PDDL-1.0.
+Netherlands Provinces is built from the [PDOK Bestuurlijke Gebieden 2026 (GeoPackage)](https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg), pinned by checksum and licensed CC-BY-4.0.
+San Francisco Addresses (EAS) tracks the [DataSF San Francisco Addresses with Units (GeoJSON, 5k extract)](https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id), a live endpoint refetched on every build rather than pinned, licensed PDDL-1.0.
+
+Sample Raster COG is built from the [rasterio RGB.byte.tif test fixture (GeoTIFF)](https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif), pinned by checksum and licensed CC0-1.0.
+Eurostat Electricity Prices for Household Consumers tracks the [Eurostat nrg_pc_204 electricity prices (SDMX-CSV)](https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false), a live endpoint refetched on every build rather than pinned, licensed CC-BY-4.0.

--- a/examples/catalog/portolan-reference/boundaries/README.md
+++ b/examples/catalog/portolan-reference/boundaries/README.md
@@ -12,11 +12,8 @@ Administrative and open-space boundary Collections from official sources.
 
 ## Where the Data Comes From
 
-Licenses, CC-BY-4.0, CC0-1.0, PDDL-1.0.
-Provenance, 3 mirror Collections.
+All 3 Collections here are mirrors, so this catalog hosts copies of data produced elsewhere.
 
-Upstream sources.
-
-- United States Counties (2023, 1:500k), https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip
-- Boston Open Space, https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326
-- Netherlands Provinces, https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg
+United States Counties (2023, 1:500k) is built from the [US Census cartographic boundary counties 2023 500k (zipped Shapefile)](https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip), pinned by checksum and licensed CC0-1.0.
+Boston Open Space tracks the [City of Boston Open Space (zipped Shapefile export)](https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326), a live endpoint refetched on every build rather than pinned, licensed PDDL-1.0.
+Netherlands Provinces is built from the [PDOK Bestuurlijke Gebieden 2026 (GeoPackage)](https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg), pinned by checksum and licensed CC-BY-4.0.

--- a/examples/catalog/portolan-reference/mirror/README.md
+++ b/examples/catalog/portolan-reference/mirror/README.md
@@ -10,9 +10,6 @@ Cloud-native mirror Collections of data maintained elsewhere.
 
 ## Where the Data Comes From
 
-Licenses, PDDL-1.0.
-Provenance, 1 mirror Collection.
+The Collection here is a mirror, so this catalog hosts a copy of data produced elsewhere.
 
-Upstream sources.
-
-- San Francisco Addresses (EAS), https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id
+San Francisco Addresses (EAS) tracks the [DataSF San Francisco Addresses with Units (GeoJSON, 5k extract)](https://data.sfgov.org/resource/ramy-di5m.geojson?$limit=5000&$order=:id), a live endpoint refetched on every build rather than pinned, licensed PDDL-1.0.

--- a/examples/catalog/portolan-reference/raster/README.md
+++ b/examples/catalog/portolan-reference/raster/README.md
@@ -10,9 +10,6 @@ Cloud Optimized GeoTIFF raster Collections.
 
 ## Where the Data Comes From
 
-Licenses, CC0-1.0.
-Provenance, 1 mirror Collection.
+The Collection here is a mirror, so this catalog hosts a copy of data produced elsewhere.
 
-Upstream sources.
-
-- Sample Raster COG, https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif
+Sample Raster COG is built from the [rasterio RGB.byte.tif test fixture (GeoTIFF)](https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif), pinned by checksum and licensed CC0-1.0.

--- a/examples/catalog/portolan-reference/reference/README.md
+++ b/examples/catalog/portolan-reference/reference/README.md
@@ -11,10 +11,7 @@ Public domain reference basemap layers for general orientation and joins.
 
 ## Where the Data Comes From
 
-Licenses, CC0-1.0.
-Provenance, 2 mirror Collections.
+All 2 Collections here are mirrors, so this catalog hosts copies of data produced elsewhere.
 
-Upstream sources.
-
-- Natural Earth Countries (1:110m), https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip
-- Natural Earth Populated Places (1:50m), https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip
+Natural Earth Countries (1:110m) is built from the [Natural Earth 110m Admin 0 Countries (zipped Shapefile)](https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip), pinned by checksum and licensed CC0-1.0.
+Natural Earth Populated Places (1:50m) is built from the [Natural Earth 50m Populated Places (zipped Shapefile)](https://naciscdn.org/naturalearth/50m/cultural/ne_50m_populated_places.zip), pinned by checksum and licensed CC0-1.0.

--- a/examples/catalog/portolan-reference/tabular/README.md
+++ b/examples/catalog/portolan-reference/tabular/README.md
@@ -10,9 +10,6 @@ Non-geospatial companion tables published as Parquet.
 
 ## Where the Data Comes From
 
-Licenses, CC-BY-4.0.
-Provenance, 1 mirror Collection.
+The Collection here is a mirror, so this catalog hosts a copy of data produced elsewhere.
 
-Upstream sources.
-
-- Eurostat Electricity Prices for Household Consumers, https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false
+Eurostat Electricity Prices for Household Consumers tracks the [Eurostat nrg_pc_204 electricity prices (SDMX-CSV)](https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/nrg_pc_204/?format=SDMX-CSV&compressed=false), a live endpoint refetched on every build rather than pinned, licensed CC-BY-4.0.

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -630,6 +630,7 @@ def build_collection(spec: dict, host: dict, out_root: Path, cache: Path,
 
     return {"id": cid, "seg": seg, "title": spec["title"], "updated": prov.get("updated"),
             "license": spec["license"], "is_mirror": is_mirror, "source": src["url"],
+            "source_title": src["title"], "stable": src.get("stable", True),
             "kind": kind, "geometry": spec.get("geometry"), "n": n,
             "bands": len(bands), "blurb": blurb(spec)}
 
@@ -656,28 +657,57 @@ def collections_table(colls: list[dict], nested: bool) -> list[str]:
     return lines
 
 
+def _provenance_sentence(colls: list[dict]) -> str:
+    """Whether the Collections beneath this node are mirrors, in one sentence."""
+    n = len(colls)
+    mirrors = sum(1 for c in colls if c["is_mirror"])
+    official = n - mirrors
+    if not official:
+        if n == 1:
+            return ("The Collection here is a mirror, so this catalog hosts a "
+                    "copy of data produced elsewhere.")
+        return (f"All {n} Collections here are mirrors, so this catalog hosts "
+                "copies of data produced elsewhere.")
+    if not mirrors:
+        subject = ("The Collection here is published" if n == 1
+                   else f"All {n} Collections here are published")
+        return f"{subject} by the organization that produced the data."
+    return (f"{mirrors} of the {n} Collections here are mirrors of data produced "
+            f"elsewhere, and {official} come straight from the organization that "
+            "produced them.")
+
+
+def _source_sentence(c: dict) -> str:
+    """One Collection and its upstream file, named and linked inside a sentence."""
+    src = f"[{c['source_title']}]({c['source']})"
+    if c["stable"]:
+        return (f"{c['title']} is built from the {src}, pinned by checksum and "
+                f"licensed {c['license']}.")
+    return (f"{c['title']} tracks the {src}, a live endpoint refetched on every "
+            f"build rather than pinned, licensed {c['license']}.")
+
+
 def sources_block(colls: list[dict]) -> list[str]:
-    """License and provenance lines for a catalog-level README.
+    """Licensing and provenance for a catalog-level README, written as prose.
 
     core.md requires every README, on catalogs as well as collections, to carry a
     title, a description, a license, and data provenance. A catalog holds no data
-    of its own, so it states the licenses and the provenance of what it contains."""
-    licenses = sorted({c["license"] for c in colls})
-    mirrors = sum(1 for c in colls if c["is_mirror"])
-    official = len(colls) - mirrors
-    kinds = []
-    if mirrors:
-        kinds.append(f"{mirrors} mirror {'Collection' if mirrors == 1 else 'Collections'}")
-    if official:
-        kinds.append(f"{official} official {'Collection' if official == 1 else 'Collections'}")
-    lines = [
-        f"Licenses, {', '.join(licenses)}.",
-        f"Provenance, {' and '.join(kinds)}.",
-        "",
-        "Upstream sources.",
-        "",
-    ]
-    lines += [f"- {c['title']}, {c['source']}" for c in colls]
+    of its own, so it states the licenses and the provenance of what it contains.
+
+    best-practices/documentation.md asks for every link to be introduced in a
+    flowing sentence rather than collected in a bare reference list at the
+    bottom, so each Collection gets one sentence naming the upstream file it was
+    built from, whether those bytes are pinned, and the license they arrive
+    under. Sentences run three to a paragraph, which keeps a group of one and a
+    catalog of eight both readable. One sentence per source line keeps a diff
+    pointed at the Collection that changed, and markdown reads consecutive lines
+    as one paragraph anyway."""
+    if not colls:
+        return []
+    lines = [_provenance_sentence(colls)]
+    sentences = [_source_sentence(c) for c in colls]
+    for i in range(0, len(sentences), 3):
+        lines += [""] + sentences[i:i + 3]
     return lines
 
 
@@ -705,7 +735,11 @@ def catalog_sidecar_bodies(title: str, description: str, colls: list[dict],
         "## Collections\n\n{{collections}}\n\n"
         "## Where the Data Comes From\n\n{{sources}}")
     readme = render_template(readme_tpl, blocks, f"{where} readme")
-    if "Licenses," not in "\n".join(readme):
+    # core.md wants the license and provenance on every README, so a template
+    # that leaves out {{sources}} gets the block appended anyway. Tested on the
+    # template rather than on the rendered prose, which has no fixed phrase to
+    # match now that the block is written as sentences.
+    if "{{sources}}" not in readme_tpl:
         readme += [""] + sources_block(colls)
     agents_tpl = (templates.get("agents") or "").strip() or (
         f"This catalog groups {len(colls)} Collections. Each carries its own "
@@ -907,6 +941,8 @@ def regen_docs(manifest: dict, out: Path, cache: Path) -> None:
         built.append({"id": spec["id"], "seg": seg, "title": spec["title"],
                       "updated": prov.get("updated"), "license": spec["license"],
                       "is_mirror": is_mirror, "source": spec["source"]["url"],
+                      "source_title": spec["source"]["title"],
+                      "stable": spec["source"].get("stable", True),
                       "kind": spec["kind"], "geometry": spec.get("geometry"),
                       "n": facts["n"], "bands": len(facts["bands"]),
                       "blurb": blurb(spec)})


### PR DESCRIPTION
## What this changes

Rewrites the generated "Where the Data Comes From" block so sources read as prose with links woven in, replacing a bare bullet list of raw URLs. Six READMEs regenerate. The edit is in `examples/tools/stacio.py`, not in the committed output.

Two things a reviewer should look at deliberately, both called out rather than buried.

- The catalog-level licence summary line is **removed**. Each Collection now names its own licence inside its sentence.
- The fallback that detects a template missing `{{sources}}` now tests the template directly instead of grepping rendered output for the literal `"Licenses,"`. Same behaviour today, but it is a second concern in this commit.

## Why

Resolves #137. `specs/best-practices/documentation.md` line 139 asks for links introduced in the prose, "not as a bare reference list at the bottom". Our own golden examples did the one pattern it names as wrong.

Each sentence now also carries two facts the bullet list never had, whether the bytes are pinned by checksum or refetched from a live endpoint, and the per-Collection licence.

## Verification

Data read, `examples/manifests/portolan-reference.yaml` and the built tree at `examples/catalog/portolan-reference/`.

```console
$ uv run examples/tools/build.py --docs-only --catalog portolan-reference
=== manifest portolan-reference.yaml ===
done

$ git status --porcelain examples/catalog/
(no output, so regeneration is stable and the committed output matches the generator)

$ uv run examples/tools/tests/run_all.py
10/10 generator checks passed

$ uv run examples/tools/tests/check_docs.py
docs code blocks, 36 ran, 2 skipped as illustrative, 0 failed
```

Before and after, `boundaries/README.md`.

```
- United States Counties (2023, 1:500k), https://www2.census.gov/geo/tiger/GENZ2023/shp/cb_2023_us_county_500k.zip
- Boston Open Space, https://opendata.arcgis.com/api/v3/datasets/2868d370c55d4d458d4ae2224ef8cddd_7/downloads/data?format=shp&spatialRefId=4326
- Netherlands Provinces, https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/atom/downloads/BestuurlijkeGebieden_2026.gpkg
```

```
All 3 Collections here are mirrors, so this catalog hosts copies of data produced elsewhere.

United States Counties (2023, 1:500k) is built from the [US Census cartographic boundary counties 2023 500k (zipped Shapefile)](...), pinned by checksum and licensed CC0-1.0.
Boston Open Space tracks the [City of Boston Open Space (zipped Shapefile export)](...), a live endpoint refetched on every build rather than pinned, licensed PDDL-1.0.
Netherlands Provinces is built from the [PDOK Bestuurlijke Gebieden 2026 (GeoPackage)](...), pinned by checksum and licensed CC-BY-4.0.
```
