### PR TITLE
docs: correct two stac-geoparquet references

### DIFF
--- a/specs/incubating/README.md
+++ b/specs/incubating/README.md
@@ -14,4 +14,4 @@ its incubating doc is removed. Debate happens in GitHub issues and PRs.
 | [`raster-styling.md`](raster-styling.md) | Open — how raster styles are expressed ([#41](https://github.com/portolan-sdi/portolan-spec/issues/41)) |
 | [`point-cloud.md`](point-cloud.md) | Deferred — awaiting a COPC reference implementation |
 | [`geotiff-stats-headers.md`](geotiff-stats-headers.md) | Encoding detail for the (normative) COG statistics requirement |
-| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; STAC-GeoParquet mirrors of collections still open ([#72](https://github.com/portolan-sdi/portolan-spec/issues/72)) |
+| [`stac-geoparquet.md`](stac-geoparquet.md) | Partly graduated — raster item mirrors are normative; STAC-GeoParquet mirrors of collections still open ([#44](https://github.com/portolan-sdi/portolan-spec/issues/44)) |

--- a/stac/README.md
+++ b/stac/README.md
@@ -109,12 +109,12 @@ Whether a catalog is official or a mirror is derived from its providers (produce
 | Thumbnail | `image/png`, `image/jpeg`, or `image/webp` | `thumbnail` |
 | Sidecar metadata | (format-specific) | `metadata`, `iso-19115` |
 | MapLibre style | `application/vnd.mapbox.style+json` | `style` (Portolan-defined role) |
-| STAC-GeoParquet item mirror | `application/vnd.apache.parquet` | `collection-mirror` (Portolan-defined role) |
+| STAC-GeoParquet item mirror | `application/vnd.apache.parquet` | `collection-mirror` (stac-geoparquet role) |
 | Upstream original | (format-specific) | `source` (Portolan-defined role) |
 
 Styles are STAC assets: each style file is a collection-level asset with `roles: ["style"]`, discovered by filtering assets on that role — no separate manifest exists (spec: Visualization Styles).
 
-A `source` asset names the upstream original a cloud-native asset was derived from, so the format requirements do not reach it. A mirror should carry one when the original is a direct download, which means referencing it at the upstream href, not rehosting the file. `collection-mirror` is required on a published item mirror. Neither role is enumerated in the JSON Schema, which accepts any non-empty role string.
+A `source` asset names the upstream original a cloud-native asset was derived from, so the format requirements do not reach it. A mirror should carry one when the original is a direct download, which means referencing it at the upstream href, not rehosting the file. `collection-mirror` comes from the [stac-geoparquet specification](https://radiantearth.github.io/stac-geoparquet-spec/latest/#referencing-a-stac-geoparquet-collections-in-a-stac-collection-json), not from Portolan, and is required on a published item mirror. Neither role is enumerated in the JSON Schema, which accepts any non-empty role string.
 
 ### Formats
 


### PR DESCRIPTION
## What this changes

Two one-line corrections, both about the same upstream specification.

The incubating index credited issue #72 for the open collections-mirror question, and now credits #44. The media types table called `collection-mirror` a Portolan-defined role, and now credits stac-geoparquet.

## Why

Issue #72 closed in July 2026 and covered the item mirror at `items.parquet`, which is already normative. The open tracker for catalog-wide collection search is #44.

`collection-mirror` is defined upstream. Portolan uses the same role string, the same media type, and the same collection-level placement, so claiming the role invites a future divergence that would break interoperability.

## Verification

Both issue states and the upstream definition, read live in August 2026.

```console
$ gh issue view 72 -R portolan-sdi/portolan-spec --json number,state,title
{"number":72,"state":"CLOSED","title":"Decide whether to require stac-geoparquet (items.parquet)"}

$ gh issue view 44 -R portolan-sdi/portolan-spec --json number,state,title
{"number":44,"state":"OPEN","title":"Define a root-level GeoParquet for collection search"}

$ curl -s https://raw.githubusercontent.com/radiantearth/stac-geoparquet-spec/1.1.0/stac-geoparquet-spec.md \
  | grep -n "collection-mirror"
171:`application/vnd.apache.parquet` Media type and `collection-mirror` Role type to
180:| roles       | \[string] | [collection-mirror]\*            |

$ uv run specs/tools/check_requirements.py
OK: 118 requirements anchored; all keyword occurrences covered.
```

- [x] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Relates to #44.
