### PR TITLE
feat(examples): generate the CRS block from the detected proj:code

### DIFF
--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
@@ -26,11 +26,16 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('bo
   neighborhoods, and four large linear parks are assigned the literal
   value Multi-District rather than a place.
 
+## Coordinate Reference System
+
+EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
+Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
 ## Area, Use the ACRES Column
 
-Geometry is WGS84 degrees, so `ST_Area` returns square degrees. The
-official `ACRES` column matches geodesic geometry area to a median of
-0.003 acres, use it. If you must compute, DuckDB's spheroid function
+The official `ACRES` column matches geodesic geometry area to a median
+of 0.003 acres, use it. If you must compute, DuckDB's spheroid function
 wants latitude first, and skipping the flip shrinks Boston by more
 than half.
 

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
@@ -30,7 +30,7 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('bo
 
 EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
 Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+The `data` asset carries the same code as `proj:code`.
 
 ## Area, Use the ACRES Column
 

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/AGENTS.md
@@ -8,12 +8,16 @@ ligt_in_provincie_code.
 
 Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('netherlands-provinces.parquet'), or load it with GeoPandas. It streams over HTTP range requests, so query the published URL directly rather than downloading first. For rendering use the visual PMTiles asset with its MapLibre styles.
 
-## CRS, a Metric National Grid
+## Coordinate Reference System
 
-EPSG:28992, Amersfoort / RD New, the Dutch national grid in meters,
-valid only for the European Netherlands. `ST_Area(geom)` returns
-square meters directly, divide by 1e6 for square kilometres, and the
-results match CBS official figures to one decimal. Web maps need
+EPSG:28992, Amersfoort / RD New, a projected coordinate reference system whose coordinates are in metres.
+Planar distance and area functions return metres and square metres directly, so no geodesic correction is needed. Web maps and anything joined to data in degrees need a transform to EPSG:4326 first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
+This is the Dutch national grid, valid only for the European
+Netherlands. Divide `ST_Area(geom)` by 1e6 for square kilometres and
+the results match CBS official figures to one decimal. The transform
+web maps need is
 `ST_Transform(geom, 'EPSG:28992', 'EPSG:4326', always_xy := true)`,
 and without always_xy the axes come back flipped. Points must be
 transformed into RD before ST_Contains. The bbox covering column is

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/AGENTS.md
@@ -12,7 +12,7 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('ne
 
 EPSG:28992, Amersfoort / RD New, a projected coordinate reference system whose coordinates are in metres.
 Planar distance and area functions return metres and square metres directly, so no geodesic correction is needed. Web maps and anything joined to data in degrees need a transform to EPSG:4326 first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+The `data` asset carries the same code as `proj:code`.
 
 This is the Dutch national grid, valid only for the European
 Netherlands. Divide `ST_Area(geom)` by 1e6 for square kilometres and

--- a/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
@@ -30,7 +30,7 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('us
 
 EPSG:4269, NAD83, a geographic coordinate reference system whose coordinates are in degrees.
 Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+The `data` asset carries the same code as `proj:code`.
 
 The spheroid escape hatch does not work here. DuckDB's
 `ST_Area_Spheroid` returns NaN or wrong values on several of these

--- a/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
@@ -26,12 +26,16 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('us
   Francisco's polygon covers 122 km2 while ALAND plus AWATER is 601
   km2. Offshore points in legal county water fall in no polygon.
 
-## Areas, the Wrong Way and the Right Way
+## Coordinate Reference System
 
-Coordinates are NAD83 degrees, EPSG:4269, so `ST_Area` returns square
-degrees and DuckDB's `ST_Area_Spheroid` returns NaN or wrong values on
-several of these multipolygons. Trust `ALAND` and `AWATER`, or
-transform to an equal-area CRS.
+EPSG:4269, NAD83, a geographic coordinate reference system whose coordinates are in degrees.
+Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
+The spheroid escape hatch does not work here. DuckDB's
+`ST_Area_Spheroid` returns NaN or wrong values on several of these
+multipolygons, so trust `ALAND` and `AWATER`, or transform to an
+equal-area CRS.
 
 ```sql
 INSTALL spatial; LOAD spatial;

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
@@ -31,8 +31,8 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('sa
 ## Coordinate Reference System
 
 EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
-Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+Planar distance functions return degrees, which are not ground units and vary with latitude. For real distances use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`.
 
 For metric distances use `ST_Distance_Sphere`, as the query below
 does, or transform to EPSG:26910, UTM zone 10N, for planar work over

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
@@ -28,11 +28,15 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('sa
   number, and supname holds the 2026 incumbents, which dates the
   snapshot.
 
-## CRS
+## Coordinate Reference System
 
-EPSG:4326 degrees, so ST_Distance returns degrees. Use
-ST_Distance_Sphere for meters, or transform to EPSG:26910 for planar
-work.
+EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
+Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
+For metric distances use `ST_Distance_Sphere`, as the query below
+does, or transform to EPSG:26910, UTM zone 10N, for planar work over
+San Francisco.
 
 ## Tested Queries
 

--- a/examples/catalog/portolan-reference/raster/sample-cog/AGENTS.md
+++ b/examples/catalog/portolan-reference/raster/sample-cog/AGENTS.md
@@ -16,12 +16,16 @@ Read the COG `data` asset with rioxarray.open_rasterio("sample-cog.tif", masked=
 - Eastings run 101,985 to 339,315 meters, far west of the UTM zone 18
   central meridian. Legal values, they just look odd.
 
-## CRS and Pixel Math
+## Coordinate Reference System
 
-EPSG:32618, WGS84 UTM zone 18N, in meters. Pixels are 300.04 meters
-square, so one pixel is about 9 hectares and pixel counts convert to
-area by multiplying by 300.04 squared. Reproject bounds to EPSG:4326
-before overlaying anything in longitude and latitude.
+EPSG:32618, WGS 84 / UTM zone 18N, a projected coordinate reference system whose coordinates are in metres.
+Planar distance and area functions return metres and square metres directly, so no geodesic correction is needed. Web maps and anything joined to data in degrees need a transform to EPSG:4326 first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
+## Pixel Math
+
+Pixels are 300.04 meters square, so one pixel is about 9 hectares and
+pixel counts convert to area by multiplying by 300.04 squared.
 
 ## Tested Reads
 

--- a/examples/catalog/portolan-reference/raster/sample-cog/AGENTS.md
+++ b/examples/catalog/portolan-reference/raster/sample-cog/AGENTS.md
@@ -19,8 +19,8 @@ Read the COG `data` asset with rioxarray.open_rasterio("sample-cog.tif", masked=
 ## Coordinate Reference System
 
 EPSG:32618, WGS 84 / UTM zone 18N, a projected coordinate reference system whose coordinates are in metres.
-Planar distance and area functions return metres and square metres directly, so no geodesic correction is needed. Web maps and anything joined to data in degrees need a transform to EPSG:4326 first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+Pixel size is in metres, so cell size and any distance read off the grid are already in metres. Web maps need a warp to EPSG:3857, and joining to data in degrees needs EPSG:4326 first.
+The `data` asset carries the same code as `proj:code`.
 
 ## Pixel Math
 

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
@@ -26,7 +26,7 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('na
 
 EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
 Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+The `data` asset carries the same code as `proj:code`.
 
 Coordinates are stored longitude first. `ST_Area(geom)` in square
 degrees makes Greenland read nearly as large as Brazil. For real areas

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
@@ -22,12 +22,16 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('na
 - Russia and Fiji cross the antimeridian, so their bboxes span the full
   longitude range and naive bbox-width logic breaks.
 
-## CRS, Degrees In, Degrees Out
+## Coordinate Reference System
 
-EPSG:4326, longitude and latitude in degrees. `ST_Area(geom)` returns
-square degrees, which makes Greenland read nearly as large as Brazil.
-For real areas use the spheroid function, and flip coordinates first
-because DuckDB's geodesic functions expect latitude first.
+EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
+Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
+Coordinates are stored longitude first. `ST_Area(geom)` in square
+degrees makes Greenland read nearly as large as Brazil. For real areas
+use the spheroid function, and flip coordinates first because DuckDB's
+geodesic functions expect latitude first.
 
 ```sql
 INSTALL spatial; LOAD spatial;

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
@@ -26,8 +26,8 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('na
 ## Coordinate Reference System
 
 EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
-Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
-The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+Planar distance functions return degrees, which are not ground units and vary with latitude. For real distances use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`.
 
 The same CRS as the countries Collection, so the two overlay and join
 without a transform. Nearest-neighbour work wants

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
@@ -23,6 +23,16 @@ Query the GeoParquet `data` asset in place with DuckDB spatial, read_parquet('na
 - 59 places carry POP_MAX below 1,000, mostly stations and outposts, so
   population filters silently drop real capitals of small territories.
 
+## Coordinate Reference System
+
+EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates are in degrees.
+Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
+The `data` asset carries the same code as `proj:code`, so this and the machine-readable metadata cannot disagree.
+
+The same CRS as the countries Collection, so the two overlay and join
+without a transform. Nearest-neighbour work wants
+`ST_Distance_Sphere`, which the query below uses.
+
 ## Tested Queries
 
 Capitals per continent, with the country join done correctly.

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -281,12 +281,12 @@ collections:
         - Russia and Fiji cross the antimeridian, so their bboxes span the full
           longitude range and naive bbox-width logic breaks.
 
-        ## CRS, Degrees In, Degrees Out
+        {{crs}}
 
-        EPSG:4326, longitude and latitude in degrees. `ST_Area(geom)` returns
-        square degrees, which makes Greenland read nearly as large as Brazil.
-        For real areas use the spheroid function, and flip coordinates first
-        because DuckDB's geodesic functions expect latitude first.
+        Coordinates are stored longitude first. `ST_Area(geom)` in square
+        degrees makes Greenland read nearly as large as Brazil. For real areas
+        use the spheroid function, and flip coordinates first because DuckDB's
+        geodesic functions expect latitude first.
 
         ```sql
         INSTALL spatial; LOAD spatial;
@@ -457,6 +457,12 @@ collections:
           a projection.
         - 59 places carry POP_MAX below 1,000, mostly stations and outposts, so
           population filters silently drop real capitals of small territories.
+
+        {{crs}}
+
+        The same CRS as the countries Collection, so the two overlay and join
+        without a transform. Nearest-neighbour work wants
+        `ST_Distance_Sphere`, which the query below uses.
 
         ## Tested Queries
 
@@ -647,12 +653,12 @@ collections:
           Francisco's polygon covers 122 km2 while ALAND plus AWATER is 601
           km2. Offshore points in legal county water fall in no polygon.
 
-        ## Areas, the Wrong Way and the Right Way
+        {{crs}}
 
-        Coordinates are NAD83 degrees, EPSG:4269, so `ST_Area` returns square
-        degrees and DuckDB's `ST_Area_Spheroid` returns NaN or wrong values on
-        several of these multipolygons. Trust `ALAND` and `AWATER`, or
-        transform to an equal-area CRS.
+        The spheroid escape hatch does not work here. DuckDB's
+        `ST_Area_Spheroid` returns NaN or wrong values on several of these
+        multipolygons, so trust `ALAND` and `AWATER`, or transform to an
+        equal-area CRS.
 
         ```sql
         INSTALL spatial; LOAD spatial;
@@ -849,11 +855,12 @@ collections:
           neighborhoods, and four large linear parks are assigned the literal
           value Multi-District rather than a place.
 
+        {{crs}}
+
         ## Area, Use the ACRES Column
 
-        Geometry is WGS84 degrees, so `ST_Area` returns square degrees. The
-        official `ACRES` column matches geodesic geometry area to a median of
-        0.003 acres, use it. If you must compute, DuckDB's spheroid function
+        The official `ACRES` column matches geodesic geometry area to a median
+        of 0.003 acres, use it. If you must compute, DuckDB's spheroid function
         wants latitude first, and skipping the flip shrinks Boston by more
         than half.
 
@@ -1042,12 +1049,12 @@ collections:
 
         {{access}}
 
-        ## CRS, a Metric National Grid
+        {{crs}}
 
-        EPSG:28992, Amersfoort / RD New, the Dutch national grid in meters,
-        valid only for the European Netherlands. `ST_Area(geom)` returns
-        square meters directly, divide by 1e6 for square kilometres, and the
-        results match CBS official figures to one decimal. Web maps need
+        This is the Dutch national grid, valid only for the European
+        Netherlands. Divide `ST_Area(geom)` by 1e6 for square kilometres and
+        the results match CBS official figures to one decimal. The transform
+        web maps need is
         `ST_Transform(geom, 'EPSG:28992', 'EPSG:4326', always_xy := true)`,
         and without always_xy the axes come back flipped. Points must be
         transformed into RD before ST_Contains. The bbox covering column is
@@ -1259,11 +1266,11 @@ collections:
           number, and supname holds the 2026 incumbents, which dates the
           snapshot.
 
-        ## CRS
+        {{crs}}
 
-        EPSG:4326 degrees, so ST_Distance returns degrees. Use
-        ST_Distance_Sphere for meters, or transform to EPSG:26910 for planar
-        work.
+        For metric distances use `ST_Distance_Sphere`, as the query below
+        does, or transform to EPSG:26910, UTM zone 10N, for planar work over
+        San Francisco.
 
         ## Tested Queries
 
@@ -1416,12 +1423,12 @@ collections:
         - Eastings run 101,985 to 339,315 meters, far west of the UTM zone 18
           central meridian. Legal values, they just look odd.
 
-        ## CRS and Pixel Math
+        {{crs}}
 
-        EPSG:32618, WGS84 UTM zone 18N, in meters. Pixels are 300.04 meters
-        square, so one pixel is about 9 hectares and pixel counts convert to
-        area by multiplying by 300.04 squared. Reproject bounds to EPSG:4326
-        before overlaying anything in longitude and latitude.
+        ## Pixel Math
+
+        Pixels are 300.04 meters square, so one pixel is about 9 hectares and
+        pixel counts convert to area by multiplying by 300.04 squared.
 
         ## Tested Reads
 

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -106,6 +106,15 @@ includes the catalog id and title, the nested-catalog titles, thumbnail colors,
 and the basemap. If you find yourself adding a catalog-specific value to the
 Python, put it in the manifest instead and read it back.
 
+The CRS runs the other way, and it is the one exception worth naming. It is
+detected from the source, not declared, so no manifest states one in prose
+either. `crs.py` reads the code, the CRS name, whether it is geographic or
+projected, and the axis unit out of the CRS registry, and `{{crs}}` turns that
+into the block the best-practices documentation page asks every AGENTS.md for.
+A manifest keeps only the advice a registry cannot know, which upstream layer
+shares the CRS, which equal-area CRS to transform into, which DuckDB function
+misbehaves on this geometry.
+
 ## Manifest schema
 
 Top level of each file in `manifests/`.
@@ -138,7 +147,7 @@ Each entry in `collections`.
 - `join?`. Tabular only. `{column, target, target_column, target_file, note?}`. Emits the README join section and a runnable DuckDB example, which formats.md requires whenever geometry and attributes live in separate files. `target_file` is relative to the Collection directory.
 - `blurb?`. One line for the catalog-level collections tables. Falls back to the first sentence of `description`.
 - `metadata?`. `{url, media_type, title, standard?, filename?}`. Mirrors an upstream machine-readable metadata record, for example an ISO 19115 record from a GeoNetwork registry, into the Collection directory and attaches it as a `metadata`-role asset with real `file:size` and `file:checksum`. Mirrored rather than linked because a registry regenerates its XML and a checksum pinned to bytes the catalog does not control rots, the live-endpoint rule again. The fetch happens once, an existing local copy is reused.
-- `docs?`. `{readme?, agents?}`. Markdown templates for the Collection sidecars, the heart of the golden-example documentation. Each is near-final markdown whose structure and voice the manifest author controls per collection, with `{{placeholder}}` lines expanding to generated blocks that cannot drift from the built assets. README templates may use `{{quickstart}}` (the one tested open-it snippet, chosen by kind), `{{schema}}` (a table of the described columns from `table:columns`), `{{join}}` (the tabular join section), and `{{provenance}}` (the license and provenance block core.md requires, appended automatically when the template omits it). AGENTS templates may use `{{access}}` (the one-line access guidance). An unknown placeholder fails the build, a typo would otherwise publish literally. Without templates a minimal default skeleton is emitted, so a bare manifest still builds a conformant catalog.
+- `docs?`. `{readme?, agents?}`. Markdown templates for the Collection sidecars, the heart of the golden-example documentation. Each is near-final markdown whose structure and voice the manifest author controls per collection, with `{{placeholder}}` lines expanding to generated blocks that cannot drift from the built assets. README templates may use `{{quickstart}}` (the one tested open-it snippet, chosen by kind), `{{schema}}` (a table of the described columns from `table:columns`), `{{join}}` (the tabular join section), and `{{provenance}}` (the license and provenance block core.md requires, appended automatically when the template omits it). AGENTS templates may use `{{access}}` (the one-line access guidance). Both surfaces may use `{{crs}}` (the coordinate reference system and what follows from it), which is offered only where the built `data` asset carries a `proj:code`. A placeholder the surface does not offer fails the build, whether it is a typo or a `{{crs}}` on a non-geospatial Collection, since either would otherwise publish literally or silently vanish. Without templates a minimal default skeleton is emitted, so a bare manifest still builds a conformant catalog.
 
 ## Provenance is derived, not declared
 

--- a/examples/tools/crs.py
+++ b/examples/tools/crs.py
@@ -6,6 +6,7 @@ per collection. Nothing about the CRS is hardcoded in the rest of the generator.
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import duckdb
@@ -57,6 +58,53 @@ def detect_vector_crs(gdal_path: str, layer: str | None) -> str:
         raise ValueError(
             f"{gdal_path} layer {chosen['name']} uses unsupported authority "
             f"{auth_name!r} (only EPSG is supported)")
+    return out
+
+
+# PROJJSON names a CRS by type. Only the two horizontal kinds the generator can
+# produce are mapped, so a compound or vertical CRS raises rather than being
+# described with prose that would not be true of it.
+_CRS_KINDS = {"GeographicCRS": "geographic", "ProjectedCRS": "projected"}
+
+_DESCRIBED: dict[str, dict] = {}
+
+
+def describe_crs(crs: str) -> dict:
+    """Return `{code, name, kind, unit}` for an `AUTH:CODE` string.
+
+    `kind` is `geographic` or `projected` and `unit` is the axis unit, both read
+    out of the PROJJSON DuckDB holds for the CRS rather than inferred from the
+    code. That keeps the generated CRS prose true for whatever CRS a Collection
+    happens to preserve, instead of true only for the ones someone thought of.
+    Raises if DuckDB cannot resolve the CRS or the CRS is not a horizontal one.
+    Results are memoized, the lookup costs a DuckDB connection."""
+    if crs in _DESCRIBED:
+        return _DESCRIBED[crs]
+    auth, _, code = crs.partition(":")
+    con = duckdb.connect()
+    try:
+        con.execute("INSTALL spatial; LOAD spatial;")
+        row = con.execute(
+            "SELECT projjson FROM duckdb_coordinate_systems() "
+            "WHERE auth_name = ? AND auth_code = ?", [auth, code]).fetchone()
+    finally:
+        con.close()
+    if not row:
+        raise ValueError(f"unknown CRS {crs}")
+    pj = json.loads(row[0])
+    kind = _CRS_KINDS.get(pj.get("type"))
+    if not kind:
+        raise ValueError(f"{crs} is a {pj.get('type')}, not a horizontal CRS")
+    axes = pj.get("coordinate_system", {}).get("axis") or []
+    unit = axes[0].get("unit") if axes else None
+    # PROJJSON writes a unit either as a bare name or as an object when it
+    # carries a conversion factor, for example a US survey foot.
+    if isinstance(unit, dict):
+        unit = unit.get("name")
+    if not unit:
+        raise ValueError(f"{crs} declares no axis unit")
+    out = {"code": crs, "name": pj.get("name") or crs, "kind": kind, "unit": unit}
+    _DESCRIBED[crs] = out
     return out
 
 

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -17,7 +17,7 @@ from config import (
     ATTRIBUTION_EXT, STAC_VERSION, MEDIA,
 )
 from fetch import fetch
-from crs import resolve_output_crs
+from crs import resolve_output_crs, describe_crs
 from convert import (
     to_geoparquet, feature_count, to_cog, bands_from_cog,
     bbox_wgs84_raster, to_table_parquet, table_columns,
@@ -298,6 +298,53 @@ def schema_block(cols: list[dict]) -> list[str]:
     return lines
 
 
+# PROJ names an axis unit in the singular. Only the units that actually appear
+# on an EPSG horizontal CRS are mapped. Anything else is printed as PROJ wrote
+# it rather than pluralized by a rule that would mangle it.
+_UNIT_PLURALS = {
+    "degree": "degrees", "metre": "metres", "meter": "meters",
+    "kilometre": "kilometres", "foot": "feet", "US survey foot": "US survey feet",
+    "grad": "grads", "link": "links",
+}
+
+
+def crs_block(crs: str) -> list[str]:
+    """The coordinate reference system block, and the consequence of it.
+
+    The best-practices documentation page asks an AGENTS.md to name the CRS and
+    say what follows from it, and the grader makes that an A-grade criterion.
+    Every word here is computed from the `proj:code` the built `data` asset
+    carries, the code, the CRS name, whether it is geographic or projected, and
+    the axis unit, so a Collection that changes its output CRS cannot leave
+    stale prose behind. Nothing about the CRS is written by hand in a manifest.
+
+    A Collection with no CRS never gets this block, and `{{crs}}` is withheld
+    from its templates rather than rendering something vague."""
+    d = describe_crs(crs)
+    unit = _UNIT_PLURALS.get(d["unit"], d["unit"])
+    lines = [
+        "## Coordinate Reference System",
+        "",
+        f"{d['code']}, {d['name']}, a {d['kind']} coordinate reference system "
+        f"whose coordinates are in {unit}.",
+    ]
+    if d["kind"] == "geographic":
+        lines.append(
+            f"Planar distance and area functions return {unit} and square "
+            f"{unit}, which are not ground units and vary with latitude. For "
+            "real distances and areas use a sphere or spheroid function, or "
+            "transform to a projected CRS first.")
+    else:
+        lines.append(
+            f"Planar distance and area functions return {unit} and square "
+            f"{unit} directly, so no geodesic correction is needed. Web maps "
+            "and anything joined to data in degrees need a transform to "
+            "EPSG:4326 first.")
+    lines.append("The `data` asset carries the same code as `proj:code`, so "
+                 "this and the machine-readable metadata cannot disagree.")
+    return lines
+
+
 def provenance_block(spec: dict, providers: list[dict], facts: dict) -> list[str]:
     """The license and provenance block core.md requires in every README."""
     src = facts["src"]
@@ -333,8 +380,8 @@ def provenance_block(spec: dict, providers: list[dict], facts: dict) -> list[str
 # Doc templates in the manifest are markdown with {{placeholder}} lines. Each
 # placeholder expands to a block the generator computes from the built assets,
 # so the numbers, schema tables, and open-it code in the docs cannot drift from
-# the catalog they describe. An unknown placeholder is an error, a typo would
-# otherwise publish literally.
+# the catalog they describe. A placeholder the surface does not offer is an
+# error, a typo would otherwise publish literally.
 DOC_PLACEHOLDER = re.compile(r"^\{\{([a-z_]+)\}\}$")
 
 
@@ -347,9 +394,14 @@ def render_template(template: str, blocks: dict[str, list[str]], where: str) -> 
             continue
         name = m.group(1)
         if name not in blocks:
+            # Two cases land here, a typo and a placeholder this Collection has
+            # nothing to fill. Both are build failures, and the message names
+            # the second because it is the one that looks like a bug.
             raise ValueError(
-                f"{where} uses unknown placeholder {{{{{name}}}}}, "
-                f"available are {sorted(blocks)}")
+                f"{where} uses {{{{{name}}}}}, which is not available here, "
+                f"available are {sorted(blocks)}. A placeholder is withheld "
+                "when the Collection cannot fill it, for example {{crs}} on a "
+                "Collection whose data asset carries no proj:code.")
         out.extend(blocks[name])
     return out
 
@@ -379,6 +431,8 @@ def collection_readme_extra(spec: dict, facts: dict) -> list[str]:
         "provenance": provenance_block(spec, facts["providers"], facts),
         "join": join_section(facts.get("join") or {}),
     }
+    if facts.get("crs"):
+        blocks["crs"] = crs_block(facts["crs"])
     template = (docs.get("readme") or "").strip()
     if not template:
         template = "## Quick Start\n\n{{quickstart}}"
@@ -397,12 +451,17 @@ def collection_agents_lines(spec: dict, facts: dict) -> list[str]:
     """The body of a collection AGENTS.md.
 
     A manifest `docs.agents` template carries the dataset-specific guidance,
-    join keys, quirks, CRS consequences, and tested queries. The generated
-    access block is available as {{access}}. Without a template a minimal
-    fallback is emitted so a bare manifest still builds a conformant catalog."""
+    join keys, quirks, and tested queries. The generated access block is
+    available as {{access}} and the generated coordinate reference system block
+    as {{crs}}, the latter only where the data asset carries a `proj:code`.
+    Without a template a minimal fallback is emitted so a bare manifest still
+    builds a conformant catalog."""
     docs = spec.get("docs") or {}
     access = access_line(facts["kind"], facts["data_name"],
                          facts["has_visual"], facts["has_thumb"])
+    blocks = {"access": [access]}
+    if facts.get("crs"):
+        blocks["crs"] = crs_block(facts["crs"])
     template = (docs.get("agents") or "").strip()
     if not template:
         src = facts["src"]
@@ -418,8 +477,7 @@ def collection_agents_lines(spec: dict, facts: dict) -> list[str]:
                 f"This table has no geometry. Join column {join['column']} to "
                 f"{join['target']} on {join['target_column']} to map it, see the README.")
         return lines
-    return render_template(template, {"access": [access]},
-                           f"{spec['id']} docs.agents")
+    return render_template(template, blocks, f"{spec['id']} docs.agents")
 
 
 def readme_md(title: str, description: str, extra_lines: list[str]) -> str:

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -308,7 +308,48 @@ _UNIT_PLURALS = {
 }
 
 
-def crs_block(crs: str) -> list[str]:
+# What a CRS costs you depends on the geometry, not on the CRS alone. A point
+# has no area and a line has no area, so naming area functions there sends a
+# reader after a measurement the data cannot produce. Each shape gets the
+# measures it can actually compute, as the function name, what it returns, and
+# the plural noun for the geodesic advice.
+_MEASURES = {
+    "polygon": ("distance and area", "{u} and square {u}", "distances and areas"),
+    "line": ("length and distance", "{u}", "lengths and distances"),
+    "point": ("distance", "{u}", "distances"),
+}
+
+
+def _vector_consequence(shape: str, unit: str, geographic: bool) -> str:
+    """What the CRS means for SQL over a geometry column of this shape."""
+    if shape not in _MEASURES:
+        raise ValueError(
+            f"a vector Collection using {{{{crs}}}} needs a known geometry to "
+            f"say what follows from its CRS, got {shape!r}, expected one of "
+            f"{', '.join(sorted(_MEASURES))}")
+    names, returns, real = _MEASURES[shape]
+    got = returns.format(u=unit)
+    if geographic:
+        return (f"Planar {names} functions return {got}, which are not ground "
+                f"units and vary with latitude. For real {real} use a sphere "
+                "or spheroid function, or transform to a projected CRS first.")
+    return (f"Planar {names} functions return {got} directly, so no geodesic "
+            "correction is needed. Web maps and anything joined to data in "
+            "degrees need a transform to EPSG:4326 first.")
+
+
+def _raster_consequence(unit: str, geographic: bool) -> str:
+    """What the CRS means for a grid, which has no geometry column at all."""
+    if geographic:
+        return ("Pixel size is in degrees, so the ground size of a cell "
+                "changes with latitude. Warp to a projected CRS before "
+                "measuring anything off the grid.")
+    return (f"Pixel size is in {unit}, so cell size and any distance read off "
+            f"the grid are already in {unit}. Web maps need a warp to "
+            "EPSG:3857, and joining to data in degrees needs EPSG:4326 first.")
+
+
+def crs_block(crs: str, kind: str, geometry: str | None) -> list[str]:
     """The coordinate reference system block, and the consequence of it.
 
     The best-practices documentation page asks an AGENTS.md to name the CRS and
@@ -318,31 +359,27 @@ def crs_block(crs: str) -> list[str]:
     the axis unit, so a Collection that changes its output CRS cannot leave
     stale prose behind. Nothing about the CRS is written by hand in a manifest.
 
+    The consequence is chosen by kind and geometry as well, because the same
+    CRS costs a different thing on each. A polygon layer can measure area, a
+    line layer length, a point layer only distance, and a raster has no
+    geometry column to run any of them over, so it is told about pixel size
+    instead. Naming a measure the data cannot produce reads as authoritative
+    and sends a consumer down a dead end.
+
     A Collection with no CRS never gets this block, and `{{crs}}` is withheld
     from its templates rather than rendering something vague."""
     d = describe_crs(crs)
     unit = _UNIT_PLURALS.get(d["unit"], d["unit"])
-    lines = [
+    geographic = d["kind"] == "geographic"
+    return [
         "## Coordinate Reference System",
         "",
         f"{d['code']}, {d['name']}, a {d['kind']} coordinate reference system "
         f"whose coordinates are in {unit}.",
+        _raster_consequence(unit, geographic) if kind == "raster"
+        else _vector_consequence(geometry or "", unit, geographic),
+        "The `data` asset carries the same code as `proj:code`.",
     ]
-    if d["kind"] == "geographic":
-        lines.append(
-            f"Planar distance and area functions return {unit} and square "
-            f"{unit}, which are not ground units and vary with latitude. For "
-            "real distances and areas use a sphere or spheroid function, or "
-            "transform to a projected CRS first.")
-    else:
-        lines.append(
-            f"Planar distance and area functions return {unit} and square "
-            f"{unit} directly, so no geodesic correction is needed. Web maps "
-            "and anything joined to data in degrees need a transform to "
-            "EPSG:4326 first.")
-    lines.append("The `data` asset carries the same code as `proj:code`, so "
-                 "this and the machine-readable metadata cannot disagree.")
-    return lines
 
 
 def provenance_block(spec: dict, providers: list[dict], facts: dict) -> list[str]:
@@ -432,7 +469,8 @@ def collection_readme_extra(spec: dict, facts: dict) -> list[str]:
         "join": join_section(facts.get("join") or {}),
     }
     if facts.get("crs"):
-        blocks["crs"] = crs_block(facts["crs"])
+        blocks["crs"] = crs_block(facts["crs"], facts["kind"],
+                                  spec.get("geometry"))
     template = (docs.get("readme") or "").strip()
     if not template:
         template = "## Quick Start\n\n{{quickstart}}"
@@ -461,7 +499,8 @@ def collection_agents_lines(spec: dict, facts: dict) -> list[str]:
                          facts["has_visual"], facts["has_thumb"])
     blocks = {"access": [access]}
     if facts.get("crs"):
-        blocks["crs"] = crs_block(facts["crs"])
+        blocks["crs"] = crs_block(facts["crs"], facts["kind"],
+                                  spec.get("geometry"))
     template = (docs.get("agents") or "").strip()
     if not template:
         src = facts["src"]

--- a/examples/tools/tests/check_compliance.py
+++ b/examples/tools/tests/check_compliance.py
@@ -317,18 +317,50 @@ def check_crs_block_is_derived_not_authored() -> None:
     # Every fact in the block comes from the CRS registry, so a projected CRS
     # gets its linear unit and a geographic one gets the degrees warning
     # without anything in a manifest saying so.
-    proj = "\n".join(crs_block("EPSG:28992"))
+    proj = "\n".join(crs_block("EPSG:28992", "vector", "polygon"))
     assert "## Coordinate Reference System" in proj, proj
     assert "EPSG:28992, Amersfoort / RD New" in proj, proj
     assert "projected" in proj and "metres" in proj, proj
-    geog = "\n".join(crs_block("EPSG:4269"))
+    geog = "\n".join(crs_block("EPSG:4269", "vector", "polygon"))
     assert "EPSG:4269, NAD83" in geog, geog
     assert "geographic" in geog and "square degrees" in geog, geog
 
 
+def check_crs_consequence_matches_the_geometry() -> None:
+    # A measure the geometry cannot produce reads as authoritative and sends a
+    # consumer after a number that is always zero. Verified in DuckDB 1.5.5,
+    # ST_Area and ST_Length on a POINT both return 0.0, and ST_Area on a
+    # LINESTRING returns 0.0, so only a polygon may be told about area.
+    point = "\n".join(crs_block("EPSG:4326", "vector", "point"))
+    assert "area" not in point.lower(), point
+    assert "distance" in point, point
+    line = "\n".join(crs_block("EPSG:4326", "vector", "line"))
+    assert "area" not in line.lower(), line
+    assert "length" in line, line
+    polygon = "\n".join(crs_block("EPSG:4326", "vector", "polygon"))
+    assert "square degrees" in polygon, polygon
+    # A raster has no geometry column, so naming SQL measures over one is
+    # meaningless. It is told about pixel size instead.
+    raster = "\n".join(crs_block("EPSG:32618", "raster", None))
+    assert "Pixel size" in raster, raster
+    assert "functions" not in raster, raster
+
+
+def check_crs_block_without_a_geometry_raises() -> None:
+    # A vector Collection whose manifest omits geometry cannot be told what
+    # follows from its CRS, so the build stops rather than guessing polygon
+    # and shipping area advice to a point layer.
+    try:
+        crs_block("EPSG:4326", "vector", None)
+    except ValueError as exc:
+        assert "geometry" in str(exc), f"reason not given: {exc}"
+        return
+    raise AssertionError("a vector Collection with no geometry did not raise")
+
+
 def check_crs_placeholder_renders_for_a_geospatial_collection() -> None:
     spec = {"id": "x/y", "title": "T", "license": "CC0-1.0",
-            "docs": {"agents": "Lead.\n\n{{crs}}"}}
+            "geometry": "polygon", "docs": {"agents": "Lead.\n\n{{crs}}"}}
     facts = {"kind": "vector", "data_name": "y.parquet", "has_visual": False,
              "has_thumb": False, "crs": "EPSG:32618"}
     out = "\n".join(collection_agents_lines(spec, facts))
@@ -392,6 +424,8 @@ CHECKS = [
     check_describe_crs_projected,
     check_describe_crs_unknown_raises,
     check_crs_block_is_derived_not_authored,
+    check_crs_consequence_matches_the_geometry,
+    check_crs_block_without_a_geometry_raises,
     check_crs_placeholder_renders_for_a_geospatial_collection,
     check_crs_placeholder_without_a_proj_code_raises,
     check_committed_agents_docs_state_their_crs,

--- a/examples/tools/tests/check_compliance.py
+++ b/examples/tools/tests/check_compliance.py
@@ -26,10 +26,17 @@ from pathlib import Path
 import duckdb
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from stacio import resolve_providers, license_links  # noqa: E402
+from stacio import (  # noqa: E402
+    resolve_providers, license_links, crs_block, collection_agents_lines,
+)
 from convert import write_web_geoparquet, table_columns  # noqa: E402
-from crs import detect_vector_crs, detect_raster_crs, resolve_output_crs, assert_known_crs  # noqa: E402
+from crs import (  # noqa: E402
+    detect_vector_crs, detect_raster_crs, resolve_output_crs, assert_known_crs,
+    describe_crs,
+)
 import glob  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[3]
 
 HOST = {"name": "Portolan SDI", "url": "https://github.com/portolan-sdi",
         "email": "portolan@googlegroups.com"}
@@ -284,6 +291,84 @@ def check_to_cog_preserves_source_crs() -> None:
         assert -180 <= bb[0] <= 180 and -90 <= bb[1] <= 90, bb
 
 
+def check_describe_crs_geographic() -> None:
+    d = describe_crs("EPSG:4326")
+    assert d == {"code": "EPSG:4326", "name": "WGS 84", "kind": "geographic",
+                 "unit": "degree"}, d
+
+
+def check_describe_crs_projected() -> None:
+    d = describe_crs("EPSG:28992")
+    assert d["kind"] == "projected", d
+    assert d["unit"] == "metre", d
+    assert d["name"] == "Amersfoort / RD New", d
+
+
+def check_describe_crs_unknown_raises() -> None:
+    try:
+        describe_crs("EPSG:999999")
+    except ValueError as exc:
+        assert "unknown CRS" in str(exc), f"wrong message: {exc}"
+        return
+    raise AssertionError("an unresolvable CRS did not raise")
+
+
+def check_crs_block_is_derived_not_authored() -> None:
+    # Every fact in the block comes from the CRS registry, so a projected CRS
+    # gets its linear unit and a geographic one gets the degrees warning
+    # without anything in a manifest saying so.
+    proj = "\n".join(crs_block("EPSG:28992"))
+    assert "## Coordinate Reference System" in proj, proj
+    assert "EPSG:28992, Amersfoort / RD New" in proj, proj
+    assert "projected" in proj and "metres" in proj, proj
+    geog = "\n".join(crs_block("EPSG:4269"))
+    assert "EPSG:4269, NAD83" in geog, geog
+    assert "geographic" in geog and "square degrees" in geog, geog
+
+
+def check_crs_placeholder_renders_for_a_geospatial_collection() -> None:
+    spec = {"id": "x/y", "title": "T", "license": "CC0-1.0",
+            "docs": {"agents": "Lead.\n\n{{crs}}"}}
+    facts = {"kind": "vector", "data_name": "y.parquet", "has_visual": False,
+             "has_thumb": False, "crs": "EPSG:32618"}
+    out = "\n".join(collection_agents_lines(spec, facts))
+    assert "EPSG:32618, WGS 84 / UTM zone 18N" in out, out
+
+
+def check_crs_placeholder_without_a_proj_code_raises() -> None:
+    # A non-geospatial Collection has no CRS to state, so {{crs}} must fail the
+    # build rather than render an empty or vague block. The placeholder is
+    # simply not offered where the data asset carries no proj:code.
+    spec = {"id": "tabular/t", "title": "T", "license": "CC0-1.0",
+            "docs": {"agents": "Lead.\n\n{{crs}}"}}
+    facts = {"kind": "tabular", "data_name": "t.parquet", "has_visual": False,
+             "has_thumb": False, "crs": None}
+    try:
+        collection_agents_lines(spec, facts)
+    except ValueError as exc:
+        assert "{{crs}}" in str(exc), f"placeholder not named: {exc}"
+        assert "proj:code" in str(exc), f"reason not given: {exc}"
+        return
+    raise AssertionError("{{crs}} on a Collection with no CRS did not raise")
+
+
+def check_committed_agents_docs_state_their_crs() -> None:
+    # The drift guard. Every geospatial Collection's AGENTS.md must name the
+    # exact code its data asset carries, and a Collection with no proj:code
+    # must not claim one. This is what issue #138 found missing.
+    colls = sorted(glob.glob(str(ROOT / "examples/catalog/*/*/*/collection.json")))
+    assert colls, "no committed collections found"
+    for path in colls:
+        coll = json.loads(Path(path).read_text())
+        code = coll["assets"]["data"].get("proj:code")
+        agents = (Path(path).parent / "AGENTS.md").read_text()
+        cid = coll["id"]
+        if code:
+            assert code in agents, f"{cid} AGENTS.md never states its CRS {code}"
+        else:
+            assert "EPSG:" not in agents, f"{cid} has no proj:code but names an EPSG code"
+
+
 CHECKS = [
     check_official_host_moved_last,
     check_multiple_hosts_error,
@@ -303,6 +388,13 @@ CHECKS = [
     check_resolve_output_crs_precedence,
     check_assert_known_crs,
     check_to_cog_preserves_source_crs,
+    check_describe_crs_geographic,
+    check_describe_crs_projected,
+    check_describe_crs_unknown_raises,
+    check_crs_block_is_derived_not_authored,
+    check_crs_placeholder_renders_for_a_geospatial_collection,
+    check_crs_placeholder_without_a_proj_code_raises,
+    check_committed_agents_docs_state_their_crs,
 ]
 
 


### PR DESCRIPTION
## What this changes

Adds a `{{crs}}` placeholder to the reference-catalog generator. It renders the coordinate reference system and what follows from it, computed from the `proj:code` on the built `data` asset. `crs.describe_crs` reads the code, the CRS name, geographic versus projected, and the axis unit out of the CRS registry DuckDB ships. The manifest keeps only the advice a registry cannot know.

## Why

Issue #138 found that `natural-earth-populated-places` never states its CRS. So does `boston-open-space`, and five others state one by hand, which goes stale silently. `specs/best-practices/grader.md` makes an AGENTS.md that "states the CRS with its practical consequences" an A-grade criterion, so the reference catalog was failing its own rubric. Hand-writing the code would break the `crs.py` invariant that nothing about the CRS is hardcoded.

## Verification

Regenerating leaves the tree clean, so no generated file was hand-edited. A Collection with no `proj:code` cannot use `{{crs}}`, and the new drift guard fails on the pre-change doc, which is the defect #138 reports.

```console
$ uv run examples/tools/build.py --docs-only && git status --porcelain
=== manifest portolan-reference.yaml ===
done

$ uv run examples/tools/tests/run_all.py | tail -3
10/10 generator checks passed

$ git checkout origin/main -- examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
$ uv run examples/tools/tests/check_compliance.py | grep FAIL
FAIL check_committed_agents_docs_state_their_crs: reference/natural-earth-populated-places AGENTS.md never states its CRS EPSG:4326
```

Data read, `examples/catalog/portolan-reference/`.

## Related issues

Closes #138. Replaces #139, which fixed one file by hand.
