### PR TITLE
fix(examples): set the DuckDB axis order in every geodesic example

### DIFF
--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/AGENTS.md
@@ -35,16 +35,17 @@ The `data` asset carries the same code as `proj:code`.
 ## Area, Use the ACRES Column
 
 The official `ACRES` column matches geodesic geometry area to a median
-of 0.003 acres, use it. If you must compute, DuckDB's spheroid function
-wants latitude first, and skipping the flip shrinks Boston by more
-than half.
+of 0.003 acres, use it. If you must compute, set `geometry_always_xy`
+first, because DuckDB reads the first coordinate as latitude by
+default and that shrinks Boston by more than half.
 
 ```sql
 INSTALL spatial; LOAD spatial;
-SELECT round(sum(ST_Area_Spheroid(ST_FlipCoordinates(geom))) / 4046.8564) AS acres_flipped,
+SET geometry_always_xy = true;
+SELECT round(sum(ST_Area_Spheroid(geom)) / 4046.8564) AS acres_geodesic,
        round(sum(ACRES)) AS acres_official
 FROM read_parquet('boston-open-space.parquet');
--- 7374 from geometry against 7356 official. Without the flip, 3250.
+-- 7374 from geometry against 7356 official. Without the setting, 3250.
 ```
 
 Eighteen sites disagree with their geometry by more than 10 percent,

--- a/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/AGENTS.md
@@ -32,10 +32,11 @@ EPSG:4269, NAD83, a geographic coordinate reference system whose coordinates are
 Planar distance and area functions return degrees and square degrees, which are not ground units and vary with latitude. For real distances and areas use a sphere or spheroid function, or transform to a projected CRS first.
 The `data` asset carries the same code as `proj:code`.
 
-The spheroid escape hatch does not work here. DuckDB's
-`ST_Area_Spheroid` returns NaN or wrong values on several of these
-multipolygons, so trust `ALAND` and `AWATER`, or transform to an
-equal-area CRS.
+The spheroid function works here once `geometry_always_xy` is set.
+Without it 1,646 of the 3,235 counties return NaN, which reads like a
+geometry problem and is not. Transforming to an equal-area CRS is
+still the better habit, since it leaves you somewhere you can measure,
+and the query below does that.
 
 ```sql
 INSTALL spatial; LOAD spatial;

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/AGENTS.md
@@ -34,9 +34,9 @@ EPSG:4326, WGS 84, a geographic coordinate reference system whose coordinates ar
 Planar distance functions return degrees, which are not ground units and vary with latitude. For real distances use a sphere or spheroid function, or transform to a projected CRS first.
 The `data` asset carries the same code as `proj:code`.
 
-For metric distances use `ST_Distance_Sphere`, as the query below
-does, or transform to EPSG:26910, UTM zone 10N, for planar work over
-San Francisco.
+For metric distances use `ST_Distance_Sphere` with
+`geometry_always_xy` set, as the query below does, or transform to
+EPSG:26910, UTM zone 10N, for planar work over San Francisco.
 
 ## Tested Queries
 
@@ -54,12 +54,13 @@ Addresses within 250 meters of a point, metric distance done right.
 
 ```sql
 INSTALL spatial; LOAD spatial;
+SET geometry_always_xy = true;
 SELECT address,
        round(ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237))) AS meters
 FROM read_parquet('san-francisco-addresses.parquet')
 WHERE ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237)) < 250
 ORDER BY meters LIMIT 5;
--- 512 Van Ness Ave #415 at 104 meters leads.
+-- One row, 512 Van Ness Ave #415 at 136 meters.
 ```
 
 Buildings with the most sampled units.

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/AGENTS.md
@@ -30,16 +30,17 @@ The `data` asset carries the same code as `proj:code`.
 
 Coordinates are stored longitude first. `ST_Area(geom)` in square
 degrees makes Greenland read nearly as large as Brazil. For real areas
-use the spheroid function, and flip coordinates first because DuckDB's
-geodesic functions expect latitude first.
+use the spheroid function, and set `geometry_always_xy` first, because
+DuckDB still reads the first coordinate as latitude by default.
 
 ```sql
 INSTALL spatial; LOAD spatial;
-SELECT NAME, round(ST_Area_Spheroid(ST_FlipCoordinates(geom)) / 1e6) AS km2
+SET geometry_always_xy = true;
+SELECT NAME, round(ST_Area_Spheroid(geom) / 1e6) AS km2
 FROM read_parquet('natural-earth-countries.parquet')
 ORDER BY km2 DESC LIMIT 5;
 -- Russia 17,018,507 then Antarctica, Canada, United States, China.
--- Without the flip, Brazil returns 5.2M km2 instead of 8.5M and 33
+-- Without the setting, Brazil returns 5.2M km2 instead of 8.5M and 33
 -- countries return NaN.
 ```
 

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/AGENTS.md
@@ -31,7 +31,8 @@ The `data` asset carries the same code as `proj:code`.
 
 The same CRS as the countries Collection, so the two overlay and join
 without a transform. Nearest-neighbour work wants
-`ST_Distance_Sphere`, which the query below uses.
+`ST_Distance_Sphere`, which needs `geometry_always_xy` set first, as
+the query below does.
 
 ## Tested Queries
 
@@ -52,11 +53,12 @@ Nearest city to a point, distance in kilometres.
 
 ```sql
 INSTALL spatial; LOAD spatial;
+SET geometry_always_xy = true;
 SELECT NAME, ADM0NAME,
        round(ST_Distance_Sphere(geom, ST_Point(-122.4783, 37.8199)) / 1000, 1) AS km
 FROM read_parquet('natural-earth-populated-places.parquet')
 ORDER BY km LIMIT 3;
--- San Francisco 9.0 km, San Jose 71.7 km, Sacramento 120.4 km.
+-- San Francisco 8.0 km, San Jose 75.2 km, Sacramento 121.7 km.
 ```
 
 ## Related Collections

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -285,16 +285,17 @@ collections:
 
         Coordinates are stored longitude first. `ST_Area(geom)` in square
         degrees makes Greenland read nearly as large as Brazil. For real areas
-        use the spheroid function, and flip coordinates first because DuckDB's
-        geodesic functions expect latitude first.
+        use the spheroid function, and set `geometry_always_xy` first, because
+        DuckDB still reads the first coordinate as latitude by default.
 
         ```sql
         INSTALL spatial; LOAD spatial;
-        SELECT NAME, round(ST_Area_Spheroid(ST_FlipCoordinates(geom)) / 1e6) AS km2
+        SET geometry_always_xy = true;
+        SELECT NAME, round(ST_Area_Spheroid(geom) / 1e6) AS km2
         FROM read_parquet('natural-earth-countries.parquet')
         ORDER BY km2 DESC LIMIT 5;
         -- Russia 17,018,507 then Antarctica, Canada, United States, China.
-        -- Without the flip, Brazil returns 5.2M km2 instead of 8.5M and 33
+        -- Without the setting, Brazil returns 5.2M km2 instead of 8.5M and 33
         -- countries return NaN.
         ```
 
@@ -462,7 +463,8 @@ collections:
 
         The same CRS as the countries Collection, so the two overlay and join
         without a transform. Nearest-neighbour work wants
-        `ST_Distance_Sphere`, which the query below uses.
+        `ST_Distance_Sphere`, which needs `geometry_always_xy` set first, as
+        the query below does.
 
         ## Tested Queries
 
@@ -483,11 +485,12 @@ collections:
 
         ```sql
         INSTALL spatial; LOAD spatial;
+        SET geometry_always_xy = true;
         SELECT NAME, ADM0NAME,
                round(ST_Distance_Sphere(geom, ST_Point(-122.4783, 37.8199)) / 1000, 1) AS km
         FROM read_parquet('natural-earth-populated-places.parquet')
         ORDER BY km LIMIT 3;
-        -- San Francisco 9.0 km, San Jose 71.7 km, Sacramento 120.4 km.
+        -- San Francisco 8.0 km, San Jose 75.2 km, Sacramento 121.7 km.
         ```
 
         ## Related Collections
@@ -655,10 +658,11 @@ collections:
 
         {{crs}}
 
-        The spheroid escape hatch does not work here. DuckDB's
-        `ST_Area_Spheroid` returns NaN or wrong values on several of these
-        multipolygons, so trust `ALAND` and `AWATER`, or transform to an
-        equal-area CRS.
+        The spheroid function works here once `geometry_always_xy` is set.
+        Without it 1,646 of the 3,235 counties return NaN, which reads like a
+        geometry problem and is not. Transforming to an equal-area CRS is
+        still the better habit, since it leaves you somewhere you can measure,
+        and the query below does that.
 
         ```sql
         INSTALL spatial; LOAD spatial;
@@ -860,16 +864,17 @@ collections:
         ## Area, Use the ACRES Column
 
         The official `ACRES` column matches geodesic geometry area to a median
-        of 0.003 acres, use it. If you must compute, DuckDB's spheroid function
-        wants latitude first, and skipping the flip shrinks Boston by more
-        than half.
+        of 0.003 acres, use it. If you must compute, set `geometry_always_xy`
+        first, because DuckDB reads the first coordinate as latitude by
+        default and that shrinks Boston by more than half.
 
         ```sql
         INSTALL spatial; LOAD spatial;
-        SELECT round(sum(ST_Area_Spheroid(ST_FlipCoordinates(geom))) / 4046.8564) AS acres_flipped,
+        SET geometry_always_xy = true;
+        SELECT round(sum(ST_Area_Spheroid(geom)) / 4046.8564) AS acres_geodesic,
                round(sum(ACRES)) AS acres_official
         FROM read_parquet('boston-open-space.parquet');
-        -- 7374 from geometry against 7356 official. Without the flip, 3250.
+        -- 7374 from geometry against 7356 official. Without the setting, 3250.
         ```
 
         Eighteen sites disagree with their geometry by more than 10 percent,
@@ -1268,9 +1273,9 @@ collections:
 
         {{crs}}
 
-        For metric distances use `ST_Distance_Sphere`, as the query below
-        does, or transform to EPSG:26910, UTM zone 10N, for planar work over
-        San Francisco.
+        For metric distances use `ST_Distance_Sphere` with
+        `geometry_always_xy` set, as the query below does, or transform to
+        EPSG:26910, UTM zone 10N, for planar work over San Francisco.
 
         ## Tested Queries
 
@@ -1288,12 +1293,13 @@ collections:
 
         ```sql
         INSTALL spatial; LOAD spatial;
+        SET geometry_always_xy = true;
         SELECT address,
                round(ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237))) AS meters
         FROM read_parquet('san-francisco-addresses.parquet')
         WHERE ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237)) < 250
         ORDER BY meters LIMIT 5;
-        -- 512 Van Ness Ave #415 at 104 meters leads.
+        -- One row, 512 Van Ness Ave #415 at 136 meters.
         ```
 
         Buildings with the most sampled units.

--- a/examples/tools/tests/check_compliance.py
+++ b/examples/tools/tests/check_compliance.py
@@ -19,6 +19,7 @@ conformance rules the JSON schema delegates to tooling. Run:
     uv run examples/tools/tests/check_compliance.py
 """
 import json
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -401,6 +402,30 @@ def check_committed_agents_docs_state_their_crs() -> None:
             assert "EPSG:" not in agents, f"{cid} has no proj:code but names an EPSG code"
 
 
+def check_geodesic_examples_set_the_axis_order() -> None:
+    # DuckDB's geodesic functions read the first coordinate as latitude unless
+    # geometry_always_xy is set, and this catalog stores longitude first, so a
+    # block that calls one without the setting publishes a wrong number that
+    # still looks plausible. check_docs.py cannot catch it, because it proves a
+    # block runs rather than that its answer is right. Each block gets a fresh
+    # connection, so each one needs its own SET.
+    axis_sensitive = ("ST_Distance_Sphere", "ST_Area_Spheroid",
+                      "ST_Length_Spheroid", "ST_Perimeter_Spheroid")
+    docs = sorted(glob.glob(str(ROOT / "examples/catalog/**/*.md"), recursive=True))
+    assert docs, "no committed docs found"
+    checked = 0
+    for path in docs:
+        for block in re.findall(r"```sql\n(.*?)```", Path(path).read_text(), re.S):
+            if not any(fn in block for fn in axis_sensitive):
+                continue
+            checked += 1
+            rel = Path(path).relative_to(ROOT)
+            assert "SET geometry_always_xy = true;" in block, (
+                f"{rel} runs a geodesic function without setting the axis "
+                f"order, so its answer is wrong\n{block}")
+    assert checked, "no geodesic examples found, the guard is checking nothing"
+
+
 CHECKS = [
     check_official_host_moved_last,
     check_multiple_hosts_error,
@@ -429,6 +454,7 @@ CHECKS = [
     check_crs_placeholder_renders_for_a_geospatial_collection,
     check_crs_placeholder_without_a_proj_code_raises,
     check_committed_agents_docs_state_their_crs,
+    check_geodesic_examples_set_the_axis_order,
 ]
 
 


### PR DESCRIPTION
## What this changes

- Sets `geometry_always_xy` in every geodesic SQL example.
- Corrects two published queries that returned wrong numbers.
- Replaces two `ST_FlipCoordinates` workarounds with the same setting.
- Corrects a false claim that county geometry made `ST_Area_Spheroid` return NaN.
- Adds a test that requires the setting wherever a geodesic function appears.

## Why

DuckDB reads the first coordinate as latitude by default, and this catalog
stores longitude first, so geodesic functions return wrong numbers that still
look plausible. `check_docs.py` cannot catch this, because it checks that a
block runs and not that its answer is correct. The flip workarounds are
correct today, but DuckDB warns its default will change to longitude first,
which would invert them silently. The setting survives that change.

## Verification

The catalog documents five addresses within 250 metres, led by one at 104
metres. Only one address is within 250 metres, at 136 metres. The new test
fails on the file the catalog ships today.

```console
$ cd examples/catalog/portolan-reference/mirror/san-francisco-addresses
$ duckdb -c "INSTALL spatial; LOAD spatial;
  SELECT address, round(ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237))) m
  FROM read_parquet('san-francisco-addresses.parquet')
  WHERE ST_Distance_Sphere(geom, ST_Point(-122.419331, 37.779237)) < 250
  ORDER BY m LIMIT 5;"
512 VAN NESS AVE #415  104     (and 4 more rows)

$ duckdb -c "INSTALL spatial; LOAD spatial; SET geometry_always_xy = true; ...same query"
512 VAN NESS AVE #415  136     (the only row)

$ git checkout origin/main -- .../san-francisco-addresses/AGENTS.md
$ uv run examples/tools/tests/check_compliance.py | grep FAIL
FAIL check_geodesic_examples_set_the_axis_order: mirror/san-francisco-addresses/AGENTS.md
runs a geodesic function without setting the axis order, so its answer is wrong

$ uv run examples/tools/build.py --docs-only && git status --porcelain
$ uv run examples/tools/tests/run_all.py | tail -1
10/10 generator checks passed
```

Data read, `examples/catalog/portolan-reference/`.

## Related issues

Follows #138, which added the CRS block these examples sit under.
