### PR TITLE
docs(spec): add best practices for git-backed catalogs

### DIFF
--- a/specs/best-practices/README.md
+++ b/specs/best-practices/README.md
@@ -11,6 +11,8 @@ the people who publish them and the agents that consume them.
   what makes a good `README.md`.
 - [`philosophy.md`](philosophy.md) — how to think about scoping, organizing, and
   maintaining a Portolan catalog; pointers to exemplary catalogs.
+- [`git-backed-catalogs.md`](git-backed-catalogs.md) — keeping catalog metadata
+  in a repository, with the data outside it, and validating every change in CI.
 - [`grader.md`](grader.md) — the rubric for rating catalog quality, A+ through F.
 - [`styling.md`](styling.md) — making visualization styles that are clear and
   distinctive across a catalog.

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -76,47 +76,63 @@ A catalog may have a reason to accept a validator finding temporarily, for examp
 
 ## Link a catalog to its repository
 
-Core's [`via`](../portolan/core.md#source-provenance) link relation records where the data came from. It does not identify the repository that maintains the catalog, so a consumer may have no machine-readable way to find the repository or report a correction.
+If a catalog is maintained in Git, publish two links on the root catalog:
 
-Add two links to the root catalog: `vcs` for the repository, and `issues` for its issue tracker. Both hrefs are absolute, because the repository is not part of the published catalog.
+* `vcs` points to the repository.
+* `issues` points to its issue tracker.
+
+Use absolute URLs because the repository is outside the published catalog.
 
 ```json
 { "rel": "vcs",    "href": "https://github.com/example/catalog", "title": "Source repository" },
 { "rel": "issues", "href": "https://github.com/example/catalog/issues", "title": "Issue tracker" }
 ```
 
-This is a convention for catalogs managed this way, not a Core requirement. Core describes every catalog, and most catalogs have no repository behind them. A validator cannot check this either, because nothing in a published catalog says whether one exists.
+This is a best practice, not a Core requirement. Not every catalog is maintained in Git, and a catalog does not say whether it is. A validator therefore cannot require these links.
 
-Fields of the World already publishes both links. The reasoning for preferring them over the two alternatives follows.
+Fields of the World already uses both links. The reasons for this convention are below.
 
-### Why links rather than fields
+### Why use links
 
-Fields of the World also carries `git:repository`, `git:ref`, and `git:provider`, from an extension proposal that has not shipped. Portolan 0.1 does not define these fields, rashid does not interpret them, and `tests/test_git_ext.py` checks them with hardcoded string comparisons.
+Fields of the World also publishes `git:repository`, `git:ref`, and `git:provider` fields from an extension proposal that has not shipped. Portolan does not define these fields, and rashid does not interpret them.
 
-The links carry the same information at lower cost. A repository is a related resource, which is what link relations are for, and the extra fields are derivable or rare: the provider follows from the host name, the branch defaults to the repository's default branch, and a path inside the repository matters only for a monorepo. Neither `vcs` nor `issues` is registered with IANA, but a consumer that does not recognize a relation ignores it.
+The links provide what a consumer needs without adding new fields:
 
-### Why not the host provider URL
+* The repository URL identifies the repository and its Git provider.
+* The default branch needs no separate field.
+* A repository path is only needed when the catalog lives inside a monorepo.
+* A repository and its issue tracker are related resources, so link relations are a natural way to reference them.
 
-TriMet and St. Louis set the `url` of their `host` provider to the GitHub repository, on the root catalog and on each collection. This uses existing Core vocabulary and appears at every level of the tree.
+`vcs` and `issues` are not IANA-registered relations, but clients that do not recognize them can ignore them.
 
-It cannot serve as a general mechanism. A provider `url` records where an organization can be reached, so a repository URL there is indistinguishable from a homepage, and it leaves no place for an issue tracker. It also fails for catalogs that use a hosting service: Fields of the World stores its data on Source Cooperative, so its `host` provider correctly identifies Source Cooperative rather than a repository.
+### Why not `providers[host].url`
+
+TriMet and St. Louis put their GitHub repository in the `url` of the `host` provider, both on the root catalog and on collections.
+
+This is ambiguous because `host` identifies where the catalog's data is hosted, not where its metadata is maintained. FTW demonstrates the problem: its data is hosted by Source Cooperative, so its `host` provider correctly points to Source Cooperative rather than its Git repository.
+
+It also provides no separate link to the issue tracker.
 
 ### Why the root catalog only
 
-The repository describes the whole tree, so repeating it on every collection duplicates a fact that can then go stale. Every object carries a `root` link, so a consumer that arrives at a `collection.json` is one step from the answer.
+The repository maintains the catalog as a whole, so repeating the repository links on every collection adds duplication.
 
-### Prose as well
+The root catalog is always reachable through the `root` link. A client that starts at a collection can therefore follow that link to find the repository.
 
-TriMet's published README identifies the catalog repository and directs readers to issues and pull requests. The Fields of the World root description says that its repository manages the metadata and accepts pull requests. Software cannot act on either, but people find them, so write the invitation in prose as well as in the links.
+### Include the links in prose too
+
+The machine-readable links are the reliable way for software to find the repository and issue tracker. A README or catalog description can also tell people where to contribute.
+
+TriMet's README and the Fields of the World description both do this. This is useful for human contributors but does not replace the links.
 
 ## Catalogs worth studying
 
-- [ftw-data-catalog](https://github.com/fieldsoftheworld/ftw-data-catalog) — Metadata for a global machine-learning dataset with hundreds of gigabytes of data on Source Cooperative. Its `CLAUDE.md` documents the publication model and explains why a full recursive bucket listing was too slow.
-- [portolan-catalog-stlouis](https://github.com/cholmes/portolan-catalog-stlouis) — Twenty collections mirrored from a city open-data portal, with the fetch, conversion, assembly, and validation workflow in the repository.
-- [portolan-catalog-trimet](https://github.com/cholmes/portolan-catalog-trimet) — Eight transit datasets, with deterministic regeneration tests and a documented conformance-waiver process.
+* [ftw-data-catalog](https://github.com/fieldsoftheworld/ftw-data-catalog) — Metadata for a global machine-learning dataset with hundreds of gigabytes of data on Source Cooperative. Its `CLAUDE.md` documents the publication model and explains why a full recursive bucket listing was too slow.
+* [portolan-catalog-stlouis](https://github.com/cholmes/portolan-catalog-stlouis) — Twenty collections mirrored from a city open-data portal, with the fetch, conversion, assembly, and validation workflow in the repository.
+* [portolan-catalog-trimet](https://github.com/cholmes/portolan-catalog-trimet) — Eight transit datasets, with deterministic regeneration tests and a documented conformance-waiver process.
 
 ## Status
 
-This page documents practices used by three publishers as of August 2026. That is a small sample, so these practices may change as more git-backed catalogs are published.
+This page documents practices used by three publishers as of August 2026. The `vcs` and `issues` convention is already used by Fields of the World; the other practices are drawn from all three catalogs.
 
-The `vcs` and `issues` links are the newest part and the least tested. One catalog publishes them today. If enough catalogs adopt them, they are a candidate for Core; if a better mechanism appears first, this page changes. If you maintain a git-backed catalog and do something different, open an issue or pull request on the [spec repository](https://github.com/portolan-sdi/portolan-spec).
+This is a best practice rather than a normative requirement. We can revisit it if more Git-backed catalogs reveal a better pattern.

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -1,212 +1,115 @@
 # Best Practices — Git-Backed Catalogs
 
-Core defines what a catalog contains and
-[how it declares conformance](../portolan/core.md#conformance-and-versioning).
-It says nothing about how you get there. This page covers one way of working
-that several publishers arrived at independently: keep the catalog metadata in
-a git repository, keep the data out of it, and let continuous integration
-validate every change before it publishes.
+## Why use git for catalog management?
 
-Nothing here is a requirement. A catalog assembled by hand and uploaded once
-conforms exactly as well as one built this way.
+Git gives publishers a controlled way to manage catalog metadata before and after publication. It provides change history, review, validation, and rollback without making git part of the published catalog itself.
 
-## Version control is what makes a catalog safe to edit
+A catalog may already be public when someone discovers an error. With a git-backed workflow, the publisher can correct the metadata in a pull request, validate the change, and publish the new version. If a published change causes a problem, git also provides the previous version and the changes that led to it.
 
-A published catalog is a single mutable tree in a bucket. Overwrite
-`collection.json` with a broken one and the previous version is gone. There is
-no undo, and the damage is live the moment the upload finishes.
+This workflow is useful when several people or agents maintain a catalog, when contributors need to propose corrections, or when the catalog contains generated metadata. It also makes catalog maintenance more like software maintenance: changes are reviewed, checked, and recorded.
 
-Git supplies the undo. It also supplies three things that matter more as a
-catalog grows:
+Nothing on this page is a requirement. Core defines what a catalog contains and how it declares conformance, but it does not define how publishers manage or publish catalogs. A catalog built and maintained by another method can conform just as well.
 
-- **A gate.** Continuous integration runs the validator on every pull request,
-  so a change proves itself before it reaches the bucket. This matters most
-  when an agent is doing the editing. An agent that can run the check and read
-  the findings converges on a conforming catalog. An agent editing straight
-  into a bucket is guessing.
-- **A contribution path.** Someone who spots a wrong license or a stale
-  description can open a pull request. Without a repository the best they can
-  do is find an email address.
-- **An explanation.** `git log` on a collection says why a description changed
-  and who changed it. A published catalog carries an `updated` timestamp and
-  nothing else.
+## Keep metadata in git, not data
 
-## Metadata goes in git, data does not
+The repository should contain the metadata needed to build and publish the catalog. Large data files should remain outside git and be referenced by URL, because git keeps old versions of committed files in its history.
 
-The repository holds the STAC JSON, the READMEs, the agent guides, the styles,
-and the logo. It does not hold the GeoParquet, the COGs, the PMTiles, or the
-Zarr stores. Those live in object storage next to the published metadata, and
-the repository references them by URL.
+[Fields of the World](https://github.com/fieldsoftheworld/ftw-data-catalog) separates repository files into three groups:
 
-[Fields of the World](https://github.com/fieldsoftheworld/ftw-data-catalog)
-states the split as three categories of file, which is the clearest framing of
-it:
+1. **Tracked and published:** STAC JSON, `README.md`, `AGENTS.md`, `llms.txt`, thumbnails, and logos.
+2. **Tracked but not published:** build scripts, tests, publish configuration, and the repository's own README.
+3. **Not tracked:** data files, credentials, and caches.
 
-1. Tracked in git and published: the STAC JSON, `README.md`, `AGENTS.md`,
-   `llms.txt`, thumbnails, logos.
-2. Tracked in git and never published: the build scripts, the tests, the
-   publish configuration, the repository's own README.
-3. Neither: the data files, credentials, and caches. These are gitignored.
+Committing large data files makes the repository expensive to clone and maintain. Git retains old binary versions even after files are deleted. The [St. Louis catalog](https://github.com/cholmes/portolan-catalog-stlouis) therefore ignores `catalog/**/*.parquet` and `catalog/**/*.pmtiles`.
 
-The failure mode of committing data is not subtle. Git stores every version of
-every binary forever, so a 200 MB Parquet file regenerated weekly becomes tens
-of gigabytes that every clone pays for, and no amount of later deletion
-recovers it. The
-[St. Louis mirror](https://github.com/cholmes/portolan-catalog-stlouis)
-gitignores `catalog/**/*.parquet` and `catalog/**/*.pmtiles` by pattern, which
-keeps the rule from depending on anyone remembering it.
+A fresh clone may not contain the data needed by some checks. St. Louis uses `CI_LIGHT=1` in continuous integration to skip file-backed checks while keeping them available locally.
 
-One consequence is worth planning for. Because the data is absent from a fresh
-clone, any check that reads bytes has nothing to read. St. Louis handles this
-with a `CI_LIGHT=1` environment variable that skips the file-backed gates in
-continuous integration while keeping them available locally, where the data
-exists.
+## Separate published metadata from repository files
 
-## The published directory is the whole contract
+The repository should have a clear directory containing the files that it publishes. The three catalogs studied here use a directory such as `catalog/`, while build scripts, tests, and source material remain elsewhere in the repository.
 
-All three catalogs studied here use the same arrangement: one directory,
-usually `catalog/`, that is synced to object storage exactly as it appears in
-the repository. Everything inside it publishes. Nothing outside it can.
+This makes the publication boundary easy to inspect. The publish tool can sync that directory without maintaining a separate list of files that it is allowed to publish.
 
-This is worth more than a convention about tidiness. It makes "what is live"
-answerable by looking, and it makes publishing a credential or a build script
-structurally impossible rather than merely unlikely. The publish tool needs no
-allowlist because the directory boundary is the allowlist.
+A typical repository can use `catalog/` for published metadata, `staging/` or `sources/` for source material, `tools/` or `scripts/` for build code, and `tests/` for tests. A root `catalog.publish.yaml` can define the object-storage target and public base URL, keeping publication settings in one place.
 
-The rest of the repository then sorts itself out. Sources being prepared sit in
-`staging/` or `sources/`. Build code sits in `tools/` or `scripts/`. Tests sit
-in `tests/`. A `catalog.publish.yaml` at the root names the write target and
-the public base URL, so the mapping between the two lives in one file rather
-than being spread through the code.
+The publication directory does not need to contain the data assets referenced by the catalog. For example, a generated STAC-GeoParquet item index can live directly in object storage and be referenced by a collection.
 
-## Generate the catalog once it outgrows hand-editing
+## Generate large catalogs
 
-A catalog of twenty collections can be edited by hand. An imagery catalog of
-tens of thousands of items cannot, and committing them makes every clone and
-every diff expensive for no gain.
+Small catalogs can be edited by hand. Large item collections should be generated instead of maintained as thousands of individual files, because generated files make reviews, diffs, and clones unnecessarily expensive.
 
-Fields of the World draws this line inside a single catalog, which is the
-clearest illustration of where it falls. Its prediction collections are
-committed. Its Sentinel-2 feature collections are not: roughly 22,700 tiles per
-year across two years is about 45,000 item files, and its
-`scripts/features/README.md` says committing them is impractical. The
-`.gitignore` enforces it with `catalog/features/*/items/`.
+Fields of the World shows this distinction within one catalog. It commits its prediction collections but not its Sentinel-2 feature items, which contain about 22,700 tiles per year across two years, or about 45,000 item files. Its `scripts/features/README.md` explains why committing them is impractical, and `.gitignore` enforces the policy with `catalog/features/*/items/`.
 
-What replaces the items is not nothing. The committed `collection.json` points
-at a STAC-GeoParquet `items.parquet` on object storage as the item index, so a
-client reads one file instead of tens of thousands of links. The generator
-writes the items and the index straight to the bucket, and the publish script
-never sees them because they are outside the published directory.
+The generated items are replaced by a STAC-GeoParquet item index in object storage. The committed `collection.json` points to `items.parquet`, allowing clients to read one index instead of thousands of individual item files.
 
-What you commit instead is the generator and its inputs.
-[TriMet](https://github.com/cholmes/portolan-catalog-trimet) commits a `tools/`
-pipeline and the source listings it reads, with the Shapefiles gitignored and
-re-fetchable. A reviewer reads a diff to `make_styles.py`. Nobody reads a diff
-across sixty-three generated style files.
+The repository should contain the generator and its inputs. [TriMet](https://github.com/cholmes/portolan-catalog-trimet) commits a `tools/` pipeline and its source listings while ignoring source Shapefiles that can be fetched again.
 
-Generating the tree turns hand-editing into a bug, so it needs a check rather
-than a request. TriMet's `tests/test_regen.py` rebuilds and compares against
-the committed catalog, which is what makes "edit the generator, not the output"
-enforceable.
+Generated output should be deterministic. TriMet's `tests/test_regen.py` rebuilds the catalog and compares it with the committed version, which lets the repository enforce the rule that contributors edit the generator rather than generated output.
 
-## Validate every change before it lands
+## Validate changes with continuous integration
 
-The gate is [rashid](https://github.com/portolan-sdi/rashid) for Portolan
-conformance and [stac-check](https://github.com/stac-utils/stac-check) for STAC
-validity and best practices. Both install from PyPI and run offline, so a
-workflow is short:
+Use [rashid](https://github.com/portolan-sdi/rashid) for Portolan conformance and [stac-check](https://github.com/stac-utils/stac-check) for STAC validity and best practices. Both install from PyPI and run offline.
+
+A minimal workflow is:
 
 ```yaml
 - run: python -m pip install stac-check rashid
 - run: rashid check catalog/
 ```
 
-A root catalog with no collections yet passes cleanly, so a repository is green
-from its first commit:
+Run these checks on pull requests and before publication. This catches errors before a change reaches the published catalog and gives agents a clear feedback loop when they edit metadata.
+
+A root catalog with no collections can pass validation, which allows a repository to remain valid from its first commit:
 
 ```console
 $ rashid check catalog/ --schema
 OK: 1 files checked, no findings.
 ```
 
-Two things surprise people wiring this up for the first time.
+### Handle validator differences
 
-**stac-check will recommend a `self` link.** Portolan forbids one, because a
-static catalog that hardcodes its own location cannot be mirrored or moved.
-Treat stac-check's best-practice notes as advisory and let rashid be the gate,
-which is what Fields of the World does in `tests/test_stac_valid.py`.
+`stac-check` recommends a `self` link, but Portolan forbids it because a static catalog should not hardcode its own location when it may be mirrored or moved. Treat `stac-check` best-practice recommendations as advisory and use rashid as the Portolan conformance gate, as Fields of the World does in `tests/test_stac_valid.py`.
 
-**Waivers need somewhere to live.** A catalog sometimes has a good reason to
-carry a finding, such as targeting a spec change that has not shipped. TriMet
-keeps a [`docs/conformance.md`](https://github.com/cholmes/portolan-catalog-trimet/blob/main/docs/conformance.md)
-listing every accepted deviation with its reasoning, and its test fails on any
-finding not on that list. The list cannot grow silently, which is the point.
+### Record accepted deviations
 
-## How a catalog points back at its repository is unsettled
+A catalog may have a reason to accept a validator finding temporarily, for example when it targets a spec change that has not shipped. TriMet records accepted deviations in [`docs/conformance.md`](https://github.com/cholmes/portolan-catalog-trimet/blob/main/docs/conformance.md), and its test fails when a finding is not listed there.
 
-Core's [`via`](../portolan/core.md#source-provenance) records where the data
-came from. Nothing records where the catalog is maintained. A consumer holding
-a published `catalog.json` has no dependable way to reach the repository that
-produced it, which means no way to file the correction the README asked for.
+## Link a catalog to its repository
 
-As of August 2026 three encodings are in use, and every catalog studied here
-uses at least two of them. No two use the same pair.
+Core's [`via`](../portolan/core.md#source-provenance) link relation records where the data came from. It does not identify the repository that maintains the catalog, so a consumer may have no machine-readable way to find the repository or report a correction.
 
-**Dedicated fields.** Fields of the World carries `git:repository`, `git:ref`,
-and `git:provider`, plus `vcs` and `issues` link relations. This is the shape
-of [an extension proposal](https://github.com/portolan-sdi/portolan-spec/issues/145)
-that has not shipped, so nothing writes or reads the fields generically.
-Portolan 0.1 defines no git extension and rashid ignores them, and the guard is
-`tests/test_git_ext.py`, twenty lines of string equality against a literal URL.
-The fields sit on the root catalog only, so a consumer who lands on a
-`collection.json` sees nothing.
+Several catalogs use different approaches today, but no single approach has become standard. The examples below describe the current options without recommending one. The question is tracked in [issue #145](https://github.com/portolan-sdi/portolan-spec/issues/145).
 
-**The host provider's url.** TriMet and St. Louis both set the `url` of their
-`host` provider to the GitHub repository, on the root and on every collection.
-This adds no vocabulary, satisfies core's
-[provider requirements](../portolan/core.md#providers) at the same time, and
-reaches every level of the tree. The cost is ambiguity. A provider `url` means
-"where this organization can be reached", so a repository there is
-indistinguishable from a homepage, and there is nowhere to put the issue
-tracker separately.
+### Dedicated fields
 
-That encoding is also unavailable to some catalogs. Fields of the World hosts
-its data on Source Cooperative, so its `host` provider is Source Cooperative,
-which is the right answer to a different question.
+Fields of the World uses `git:repository`, `git:ref`, and `git:provider`, along with `vcs` and `issues` link relations. These fields follow the shape of an extension proposal that has not shipped, so Portolan 0.1 does not define them and rashid does not interpret them.
 
-**Prose.** TriMet's published README carries a table naming the catalog
-repository and the browser repository, then asks directly for issues and pull
-requests. The Fields of the World root description says the metadata is managed
-in its repository and that pull requests are welcome. A person finds this. No
-tool can act on it.
+Fields of the World checks the fields with `tests/test_git_ext.py`. They appear only on the root catalog, so a consumer opening a `collection.json` does not see them.
 
-Nothing is recommended here. That every catalog reaches for two encodings is
-the signal that none of them is sufficient alone, and the resolution belongs in
-the spec rather than in three independent conventions. Weigh in on
-[issue #145](https://github.com/portolan-sdi/portolan-spec/issues/145) if you
-publish a catalog this affects.
+### Host provider URL
+
+TriMet and St. Louis set the `url` of their `host` provider to the GitHub repository on both the root catalog and each collection. This uses existing Core vocabulary and makes the repository visible at every level of the tree.
+
+The meaning remains ambiguous. A provider `url` identifies where an organization can be reached, so a repository URL is not clearly different from a homepage. The approach also provides no separate place for an issue tracker.
+
+It does not work for every catalog. Fields of the World hosts its data on Source Cooperative, so its `host` provider correctly identifies Source Cooperative instead.
+
+### Prose
+
+TriMet's published README identifies the catalog repository and the browser repository, then directs users to issues and pull requests. The Fields of the World root description says that its repository manages the metadata and accepts pull requests.
+
+People can use this information, but software cannot reliably act on it. Repository discovery therefore remains an open question for the spec.
+
+Publishers affected by this question should contribute to [issue #145](https://github.com/portolan-sdi/portolan-spec/issues/145).
 
 ## Catalogs worth studying
 
-Three git-backed catalogs, readable end to end:
+- [ftw-data-catalog](https://github.com/fieldsoftheworld/ftw-data-catalog) — Metadata for a global machine-learning dataset with hundreds of gigabytes of data on Source Cooperative. Its `CLAUDE.md` documents the publication model and explains why a full recursive bucket listing was too slow.
+- [portolan-catalog-stlouis](https://github.com/cholmes/portolan-catalog-stlouis) — Twenty collections mirrored from a city open-data portal, with the fetch, conversion, assembly, and validation workflow in the repository.
+- [portolan-catalog-trimet](https://github.com/cholmes/portolan-catalog-trimet) — Eight transit datasets, with deterministic regeneration tests and a documented conformance-waiver process.
 
-- [ftw-data-catalog](https://github.com/fieldsoftheworld/ftw-data-catalog) —
-  metadata for a global machine-learning dataset whose data runs to hundreds
-  of gigabytes on Source Cooperative. Its `CLAUDE.md` documents the publish
-  model, including why a full recursive bucket listing was too slow and what
-  replaced it.
-- [portolan-catalog-stlouis](https://github.com/cholmes/portolan-catalog-stlouis)
-  — twenty collections mirrored from a city open-data portal, with the
-  fetch-convert-assemble pipeline and its gates in the repository.
-- [portolan-catalog-trimet](https://github.com/cholmes/portolan-catalog-trimet)
-  — eight transit datasets, notable for regeneration determinism tests and a
-  written conformance-waiver policy.
+## Status
 
-## This is a discussion
+This page documents practices used by three publishers as of August 2026. That is a small sample, so these practices may change as more git-backed catalogs are published.
 
-This page describes what three publishers converged on by August 2026, which
-is a small sample. The layout is consistent enough to write down. The
-discovery question is not settled at all, and parts of this may look wrong
-once more catalogs exist. If you maintain a git-backed catalog that solved
-something differently, open an issue or a pull request on the
-[spec repository](https://github.com/portolan-sdi/portolan-spec).
+The repository-discovery question is still open. If you maintain a git-backed catalog and use a different approach, open an issue or pull request on the [spec repository](https://github.com/portolan-sdi/portolan-spec).

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -78,27 +78,36 @@ A catalog may have a reason to accept a validator finding temporarily, for examp
 
 Core's [`via`](../portolan/core.md#source-provenance) link relation records where the data came from. It does not identify the repository that maintains the catalog, so a consumer may have no machine-readable way to find the repository or report a correction.
 
-Several catalogs use different approaches today, but no single approach has become standard. The examples below describe the current options without recommending one.
+Add two links to the root catalog: `vcs` for the repository, and `issues` for its issue tracker. Both hrefs are absolute, because the repository is not part of the published catalog.
 
-### Dedicated fields
+```json
+{ "rel": "vcs",    "href": "https://github.com/example/catalog", "title": "Source repository" },
+{ "rel": "issues", "href": "https://github.com/example/catalog/issues", "title": "Issue tracker" }
+```
 
-Fields of the World uses `git:repository`, `git:ref`, and `git:provider`, along with `vcs` and `issues` link relations. These fields follow the shape of an extension proposal that has not shipped, so Portolan 0.1 does not define them and rashid does not interpret them.
+This is a convention for catalogs managed this way, not a Core requirement. Core describes every catalog, and most catalogs have no repository behind them. A validator cannot check this either, because nothing in a published catalog says whether one exists.
 
-Fields of the World checks the fields with `tests/test_git_ext.py`. They appear only on the root catalog, so a consumer opening a `collection.json` does not see them.
+Fields of the World already publishes both links. The reasoning for preferring them over the two alternatives follows.
 
-### Host provider URL
+### Why links rather than fields
 
-TriMet and St. Louis set the `url` of their `host` provider to the GitHub repository on both the root catalog and each collection. This uses existing Core vocabulary and makes the repository visible at every level of the tree.
+Fields of the World also carries `git:repository`, `git:ref`, and `git:provider`, from an extension proposal that has not shipped. Portolan 0.1 does not define these fields, rashid does not interpret them, and `tests/test_git_ext.py` checks them with hardcoded string comparisons.
 
-The meaning remains ambiguous. A provider `url` identifies where an organization can be reached, so a repository URL is not clearly different from a homepage. The approach also provides no separate place for an issue tracker.
+The links carry the same information at lower cost. A repository is a related resource, which is what link relations are for, and the extra fields are derivable or rare: the provider follows from the host name, the branch defaults to the repository's default branch, and a path inside the repository matters only for a monorepo. Neither `vcs` nor `issues` is registered with IANA, but a consumer that does not recognize a relation ignores it.
 
-It does not work for every catalog. Fields of the World hosts its data on Source Cooperative, so its `host` provider correctly identifies Source Cooperative instead.
+### Why not the host provider URL
 
-### Prose
+TriMet and St. Louis set the `url` of their `host` provider to the GitHub repository, on the root catalog and on each collection. This uses existing Core vocabulary and appears at every level of the tree.
 
-TriMet's published README identifies the catalog repository and the browser repository, then directs users to issues and pull requests. The Fields of the World root description says that its repository manages the metadata and accepts pull requests.
+It cannot serve as a general mechanism. A provider `url` records where an organization can be reached, so a repository URL there is indistinguishable from a homepage, and it leaves no place for an issue tracker. It also fails for catalogs that use a hosting service: Fields of the World stores its data on Source Cooperative, so its `host` provider correctly identifies Source Cooperative rather than a repository.
 
-People can use this information, but software cannot reliably act on it. Repository discovery therefore remains an open question for the spec. Publishers affected by it should open an issue on the [spec repository](https://github.com/portolan-sdi/portolan-spec).
+### Why the root catalog only
+
+The repository describes the whole tree, so repeating it on every collection duplicates a fact that can then go stale. Every object carries a `root` link, so a consumer that arrives at a `collection.json` is one step from the answer.
+
+### Prose as well
+
+TriMet's published README identifies the catalog repository and directs readers to issues and pull requests. The Fields of the World root description says that its repository manages the metadata and accepts pull requests. Software cannot act on either, but people find them, so write the invitation in prose as well as in the links.
 
 ## Catalogs worth studying
 
@@ -110,4 +119,4 @@ People can use this information, but software cannot reliably act on it. Reposit
 
 This page documents practices used by three publishers as of August 2026. That is a small sample, so these practices may change as more git-backed catalogs are published.
 
-The repository-discovery question is still open. If you maintain a git-backed catalog and use a different approach, open an issue or pull request on the [spec repository](https://github.com/portolan-sdi/portolan-spec).
+The `vcs` and `issues` links are the newest part and the least tested. One catalog publishes them today. If enough catalogs adopt them, they are a candidate for Core; if a better mechanism appears first, this page changes. If you maintain a git-backed catalog and do something different, open an issue or pull request on the [spec repository](https://github.com/portolan-sdi/portolan-spec).

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -2,25 +2,25 @@
 
 ## Why use git for catalog management?
 
-Git gives publishers a controlled way to manage catalog metadata before and after publication. It provides change history, review, validation, and rollback without making git part of the published catalog itself.
+Git gives publishers a controlled way to manage catalog metadata before and after publication. It provides change history, review, validation, and rollback without making Git part of the published catalog itself.
 
-A catalog may already be public when someone discovers an error. With a git-backed workflow, the publisher can correct the metadata in a pull request, validate the change, and publish the new version. If a published change causes a problem, git also provides the previous version and the changes that led to it.
+A catalog may already be public when someone discovers an error. With a git-backed workflow, the publisher can correct the metadata in a pull request, validate the change, and publish the new version. If a published change causes a problem, Git also preserves the previous version and the changes that led to it.
 
-This workflow is useful when several people or agents maintain a catalog, when contributors need to propose corrections, or when the catalog contains generated metadata. It also makes catalog maintenance more like software maintenance: changes are reviewed, checked, and recorded.
+This workflow is useful when several people or agents maintain a catalog, when contributors need to propose corrections, or when the catalog contains generated metadata. It makes catalog maintenance more like software maintenance: changes are reviewed, checked, and recorded.
 
-Nothing on this page is a requirement. Core defines what a catalog contains and how it declares conformance, but it does not define how publishers manage or publish catalogs. A catalog built and maintained by another method can conform just as well.
+Nothing on this page is a requirement. Core defines what a catalog contains and how it declares conformance, but it does not define how publishers manage or publish catalogs. A catalog maintained another way can conform just as well.
 
 ## Keep metadata in git, not data
 
-The repository should contain the metadata needed to build and publish the catalog. Large data files should remain outside git and be referenced by URL, because git keeps old versions of committed files in its history.
+The repository should contain the metadata needed to build and publish the catalog. Large data files should remain outside Git and be referenced by URL, because Git keeps old versions of committed files in its history.
 
-[Fields of the World](https://github.com/fieldsoftheworld/ftw-data-catalog) separates repository files into three groups:
+Fields of the World separates repository files into three groups:
 
 1. **Tracked and published:** STAC JSON, `README.md`, `AGENTS.md`, `llms.txt`, thumbnails, and logos.
 2. **Tracked but not published:** build scripts, tests, publish configuration, and the repository's own README.
 3. **Not tracked:** data files, credentials, and caches.
 
-Committing large data files makes the repository expensive to clone and maintain. Git retains old binary versions even after files are deleted. The [St. Louis catalog](https://github.com/cholmes/portolan-catalog-stlouis) therefore ignores `catalog/**/*.parquet` and `catalog/**/*.pmtiles`.
+Committing large data files makes the repository expensive to clone and maintain. Git retains old binary versions even after files are deleted. The St. Louis catalog therefore ignores `catalog/**/*.parquet` and `catalog/**/*.pmtiles`.
 
 A fresh clone may not contain the data needed by some checks. St. Louis uses `CI_LIGHT=1` in continuous integration to skip file-backed checks while keeping them available locally.
 
@@ -28,11 +28,21 @@ A fresh clone may not contain the data needed by some checks. St. Louis uses `CI
 
 The repository should have a clear directory containing the files that it publishes. The three catalogs studied here use a directory such as `catalog/`, while build scripts, tests, and source material remain elsewhere in the repository.
 
-This makes the publication boundary easy to inspect. The publish tool can sync that directory without maintaining a separate list of files that it is allowed to publish.
+This makes the publication boundary easy to inspect. It also lets tools such as STAC Browser open `catalog/catalog.json` directly from the repository to preview and inspect the catalog.
+
+The publication directory does not need to contain the data assets referenced by the catalog. For example, a generated STAC-GeoParquet item index can live directly in object storage and be referenced by a collection.
 
 A typical repository can use `catalog/` for published metadata, `staging/` or `sources/` for source material, `tools/` or `scripts/` for build code, and `tests/` for tests. A root `catalog.publish.yaml` can define the object-storage target and public base URL, keeping publication settings in one place.
 
-The publication directory does not need to contain the data assets referenced by the catalog. For example, a generated STAC-GeoParquet item index can live directly in object storage and be referenced by a collection.
+## Keep the tools and inputs
+
+The repository should contain the scripts, tools, and source inputs used to produce the catalog. This can be custom code or existing tools such as GDAL/OGR, `gpio`, or `portolan-cli`.
+
+Sharing this pipeline makes the catalog easier to reproduce and maintain. It also gives other publishers concrete examples of different ways to build catalogs and gives tool maintainers real workflows to improve.
+
+TriMet commits its `tools/` pipeline and source listings while ignoring source Shapefiles that can be fetched again.
+
+Generated output should be deterministic. TriMet's `tests/test_regen.py` rebuilds the catalog and compares it with the committed version, which lets the repository enforce the rule that contributors edit the generator rather than generated output.
 
 ## Generate large catalogs
 
@@ -42,17 +52,13 @@ Fields of the World shows this distinction within one catalog. It commits its pr
 
 The generated items are replaced by a STAC-GeoParquet item index in object storage. The committed `collection.json` points to `items.parquet`, allowing clients to read one index instead of thousands of individual item files.
 
-The repository should contain the generator and its inputs. [TriMet](https://github.com/cholmes/portolan-catalog-trimet) commits a `tools/` pipeline and its source listings while ignoring source Shapefiles that can be fetched again.
-
-Generated output should be deterministic. TriMet's `tests/test_regen.py` rebuilds the catalog and compares it with the committed version, which lets the repository enforce the rule that contributors edit the generator rather than generated output.
-
 ## Validate changes with continuous integration
 
-Use [rashid](https://github.com/portolan-sdi/rashid) for Portolan conformance and [stac-check](https://github.com/stac-utils/stac-check) for STAC validity and best practices. Both install from PyPI and run offline.
+Use rashid for Portolan conformance and stac-check for STAC validity and best practices. Both install from PyPI and run offline.
 
 A minimal workflow is:
 
-```yaml
+```yaml id="j49h8x"
 - run: python -m pip install stac-check rashid
 - run: rashid check catalog/
 ```
@@ -61,7 +67,7 @@ Run these checks on pull requests and before publication. This catches errors be
 
 A root catalog with no collections can pass validation, which allows a repository to remain valid from its first commit:
 
-```console
+```console id="0v3l6e"
 $ rashid check catalog/ --schema
 OK: 1 files checked, no findings.
 ```
@@ -72,7 +78,7 @@ OK: 1 files checked, no findings.
 
 ### Record accepted deviations
 
-A catalog may have a reason to accept a validator finding temporarily, for example when it targets a spec change that has not shipped. TriMet records accepted deviations in [`docs/conformance.md`](https://github.com/cholmes/portolan-catalog-trimet/blob/main/docs/conformance.md), and its test fails when a finding is not listed there.
+A catalog may have a reason to accept a validator finding temporarily, for example when it targets a spec change that has not shipped. TriMet records accepted deviations in `docs/conformance.md`, and its test fails when a finding is not listed there.
 
 ## Link a catalog to its repository
 
@@ -83,56 +89,43 @@ If a catalog is maintained in Git, publish two links on the root catalog:
 
 Use absolute URLs because the repository is outside the published catalog.
 
-```json
-{ "rel": "vcs",    "href": "https://github.com/example/catalog", "title": "Source repository" },
-{ "rel": "issues", "href": "https://github.com/example/catalog/issues", "title": "Issue tracker" }
+```json id="5cwv69"
+{
+  "rel": "vcs",
+  "href": "https://github.com/example/catalog",
+  "title": "Source repository"
+},
+{
+  "rel": "issues",
+  "href": "https://github.com/example/catalog/issues",
+  "title": "Issue tracker"
+}
 ```
 
-This is a best practice, not a Core requirement. Not every catalog is maintained in Git, and a catalog does not say whether it is. A validator therefore cannot require these links.
+Fields of the World already publishes both links.
 
-Fields of the World already uses both links. The reasons for this convention are below.
+The [STAC VCS Extension](https://github.com/stac-extensions/vcs) is also being developed to describe version-control information such as the VCS type, branch, commit, and tag. It is currently a proposal and is not part of Portolan. The extension can complement the repository link: `vcs` identifies the repository, while the extension can identify the particular version of the catalog that came from it.
 
-### Why use links
+The `issues` link serves a different purpose. It gives people and tools a direct place to report problems or propose corrections. STAC tooling could use this link to provide issue-reporting features directly from a catalog browser.
 
-Fields of the World also publishes `git:repository`, `git:ref`, and `git:provider` fields from an extension proposal that has not shipped. Portolan does not define these fields, and rashid does not interpret them.
+These links are a best practice, not a Core requirement. Not every catalog is maintained in Git, and a published catalog does not say whether a repository exists. A validator therefore cannot require them.
 
-The links provide what a consumer needs without adding new fields:
+## Include contribution guidance
 
-* The repository URL identifies the repository and its Git provider.
-* The default branch needs no separate field.
-* A repository path is only needed when the catalog lives inside a monorepo.
-* A repository and its issue tracker are related resources, so link relations are a natural way to reference them.
+The repository should explain how contributors can propose changes and report problems. A root `README.md` can point people to the relevant tools, documentation, issues, and pull requests.
 
-`vcs` and `issues` are not IANA-registered relations, but clients that do not recognize them can ignore them.
-
-### Why not `providers[host].url`
-
-TriMet and St. Louis put their GitHub repository in the `url` of the `host` provider, both on the root catalog and on collections.
-
-This is ambiguous because `host` identifies where the catalog's data is hosted, not where its metadata is maintained. FTW demonstrates the problem: its data is hosted by Source Cooperative, so its `host` provider correctly points to Source Cooperative rather than its Git repository.
-
-It also provides no separate link to the issue tracker.
-
-### Why the root catalog only
-
-The repository maintains the catalog as a whole, so repeating the repository links on every collection adds duplication.
-
-The root catalog is always reachable through the `root` link. A client that starts at a collection can therefore follow that link to find the repository.
-
-### Include the links in prose too
-
-The machine-readable links are the reliable way for software to find the repository and issue tracker. A README or catalog description can also tell people where to contribute.
-
-TriMet's README and the Fields of the World description both do this. This is useful for human contributors but does not replace the links.
+The machine-readable `vcs` and `issues` links make the repository and issue tracker discoverable to software. The README and catalog description can provide additional context for human contributors.
 
 ## Catalogs worth studying
 
-* [ftw-data-catalog](https://github.com/fieldsoftheworld/ftw-data-catalog) — Metadata for a global machine-learning dataset with hundreds of gigabytes of data on Source Cooperative. Its `CLAUDE.md` documents the publication model and explains why a full recursive bucket listing was too slow.
-* [portolan-catalog-stlouis](https://github.com/cholmes/portolan-catalog-stlouis) — Twenty collections mirrored from a city open-data portal, with the fetch, conversion, assembly, and validation workflow in the repository.
-* [portolan-catalog-trimet](https://github.com/cholmes/portolan-catalog-trimet) — Eight transit datasets, with deterministic regeneration tests and a documented conformance-waiver process.
+* **ftw-data-catalog** — Metadata for a global machine-learning dataset with hundreds of gigabytes of data on Source Cooperative. Its `CLAUDE.md` documents the publication model and explains why a full recursive bucket listing was too slow.
+* **portolan-catalog-stlouis** — Twenty collections mirrored from a city open-data portal, with the fetch, conversion, assembly, and validation workflow in the repository.
+* **portolan-catalog-trimet** — Eight transit datasets, with deterministic regeneration tests and a documented conformance-waiver process.
 
 ## Status
 
-This page documents practices used by three publishers as of August 2026. The `vcs` and `issues` convention is already used by Fields of the World; the other practices are drawn from all three catalogs.
+This page documents early practices in August 2026. These practices may change as more git-backed catalogs are published.
 
-This is a best practice rather than a normative requirement. We can revisit it if more Git-backed catalogs reveal a better pattern.
+The `vcs` and `issues` links are a recommended convention, not a Portolan requirement. A future spec change could add a `SHOULD` for catalogs maintained in Git; that can be evaluated separately as the STAC VCS Extension and related link relations mature.
+
+If you maintain a git-backed catalog and use a different approach, open an issue or pull request on the Portolan spec repository.

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -78,7 +78,7 @@ A catalog may have a reason to accept a validator finding temporarily, for examp
 
 Core's [`via`](../portolan/core.md#source-provenance) link relation records where the data came from. It does not identify the repository that maintains the catalog, so a consumer may have no machine-readable way to find the repository or report a correction.
 
-Several catalogs use different approaches today, but no single approach has become standard. The examples below describe the current options without recommending one. The question is tracked in [issue #145](https://github.com/portolan-sdi/portolan-spec/issues/145).
+Several catalogs use different approaches today, but no single approach has become standard. The examples below describe the current options without recommending one.
 
 ### Dedicated fields
 
@@ -98,9 +98,7 @@ It does not work for every catalog. Fields of the World hosts its data on Source
 
 TriMet's published README identifies the catalog repository and the browser repository, then directs users to issues and pull requests. The Fields of the World root description says that its repository manages the metadata and accepts pull requests.
 
-People can use this information, but software cannot reliably act on it. Repository discovery therefore remains an open question for the spec.
-
-Publishers affected by this question should contribute to [issue #145](https://github.com/portolan-sdi/portolan-spec/issues/145).
+People can use this information, but software cannot reliably act on it. Repository discovery therefore remains an open question for the spec. Publishers affected by it should open an issue on the [spec repository](https://github.com/portolan-sdi/portolan-spec).
 
 ## Catalogs worth studying
 

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -1,0 +1,212 @@
+# Best Practices — Git-Backed Catalogs
+
+Core defines what a catalog contains and
+[how it declares conformance](../portolan/core.md#conformance-and-versioning).
+It says nothing about how you get there. This page covers one way of working
+that several publishers arrived at independently: keep the catalog metadata in
+a git repository, keep the data out of it, and let continuous integration
+validate every change before it publishes.
+
+Nothing here is a requirement. A catalog assembled by hand and uploaded once
+conforms exactly as well as one built this way.
+
+## Version control is what makes a catalog safe to edit
+
+A published catalog is a single mutable tree in a bucket. Overwrite
+`collection.json` with a broken one and the previous version is gone. There is
+no undo, and the damage is live the moment the upload finishes.
+
+Git supplies the undo. It also supplies three things that matter more as a
+catalog grows:
+
+- **A gate.** Continuous integration runs the validator on every pull request,
+  so a change proves itself before it reaches the bucket. This matters most
+  when an agent is doing the editing. An agent that can run the check and read
+  the findings converges on a conforming catalog. An agent editing straight
+  into a bucket is guessing.
+- **A contribution path.** Someone who spots a wrong license or a stale
+  description can open a pull request. Without a repository the best they can
+  do is find an email address.
+- **An explanation.** `git log` on a collection says why a description changed
+  and who changed it. A published catalog carries an `updated` timestamp and
+  nothing else.
+
+## Metadata goes in git, data does not
+
+The repository holds the STAC JSON, the READMEs, the agent guides, the styles,
+and the logo. It does not hold the GeoParquet, the COGs, the PMTiles, or the
+Zarr stores. Those live in object storage next to the published metadata, and
+the repository references them by URL.
+
+[Fields of the World](https://github.com/fieldsoftheworld/ftw-data-catalog)
+states the split as three categories of file, which is the clearest framing of
+it:
+
+1. Tracked in git and published: the STAC JSON, `README.md`, `AGENTS.md`,
+   `llms.txt`, thumbnails, logos.
+2. Tracked in git and never published: the build scripts, the tests, the
+   publish configuration, the repository's own README.
+3. Neither: the data files, credentials, and caches. These are gitignored.
+
+The failure mode of committing data is not subtle. Git stores every version of
+every binary forever, so a 200 MB Parquet file regenerated weekly becomes tens
+of gigabytes that every clone pays for, and no amount of later deletion
+recovers it. The
+[St. Louis mirror](https://github.com/cholmes/portolan-catalog-stlouis)
+gitignores `catalog/**/*.parquet` and `catalog/**/*.pmtiles` by pattern, which
+keeps the rule from depending on anyone remembering it.
+
+One consequence is worth planning for. Because the data is absent from a fresh
+clone, any check that reads bytes has nothing to read. St. Louis handles this
+with a `CI_LIGHT=1` environment variable that skips the file-backed gates in
+continuous integration while keeping them available locally, where the data
+exists.
+
+## The published directory is the whole contract
+
+All three catalogs studied here use the same arrangement: one directory,
+usually `catalog/`, that is synced to object storage exactly as it appears in
+the repository. Everything inside it publishes. Nothing outside it can.
+
+This is worth more than a convention about tidiness. It makes "what is live"
+answerable by looking, and it makes publishing a credential or a build script
+structurally impossible rather than merely unlikely. The publish tool needs no
+allowlist because the directory boundary is the allowlist.
+
+The rest of the repository then sorts itself out. Sources being prepared sit in
+`staging/` or `sources/`. Build code sits in `tools/` or `scripts/`. Tests sit
+in `tests/`. A `catalog.publish.yaml` at the root names the write target and
+the public base URL, so the mapping between the two lives in one file rather
+than being spread through the code.
+
+## Generate the catalog once it outgrows hand-editing
+
+A catalog of twenty collections can be edited by hand. An imagery catalog of
+tens of thousands of items cannot, and committing them makes every clone and
+every diff expensive for no gain.
+
+Fields of the World draws this line inside a single catalog, which is the
+clearest illustration of where it falls. Its prediction collections are
+committed. Its Sentinel-2 feature collections are not: roughly 22,700 tiles per
+year across two years is about 45,000 item files, and its
+`scripts/features/README.md` says committing them is impractical. The
+`.gitignore` enforces it with `catalog/features/*/items/`.
+
+What replaces the items is not nothing. The committed `collection.json` points
+at a STAC-GeoParquet `items.parquet` on object storage as the item index, so a
+client reads one file instead of tens of thousands of links. The generator
+writes the items and the index straight to the bucket, and the publish script
+never sees them because they are outside the published directory.
+
+What you commit instead is the generator and its inputs.
+[TriMet](https://github.com/cholmes/portolan-catalog-trimet) commits a `tools/`
+pipeline and the source listings it reads, with the Shapefiles gitignored and
+re-fetchable. A reviewer reads a diff to `make_styles.py`. Nobody reads a diff
+across sixty-three generated style files.
+
+Generating the tree turns hand-editing into a bug, so it needs a check rather
+than a request. TriMet's `tests/test_regen.py` rebuilds and compares against
+the committed catalog, which is what makes "edit the generator, not the output"
+enforceable.
+
+## Validate every change before it lands
+
+The gate is [rashid](https://github.com/portolan-sdi/rashid) for Portolan
+conformance and [stac-check](https://github.com/stac-utils/stac-check) for STAC
+validity and best practices. Both install from PyPI and run offline, so a
+workflow is short:
+
+```yaml
+- run: python -m pip install stac-check rashid
+- run: rashid check catalog/
+```
+
+A root catalog with no collections yet passes cleanly, so a repository is green
+from its first commit:
+
+```console
+$ rashid check catalog/ --schema
+OK: 1 files checked, no findings.
+```
+
+Two things surprise people wiring this up for the first time.
+
+**stac-check will recommend a `self` link.** Portolan forbids one, because a
+static catalog that hardcodes its own location cannot be mirrored or moved.
+Treat stac-check's best-practice notes as advisory and let rashid be the gate,
+which is what Fields of the World does in `tests/test_stac_valid.py`.
+
+**Waivers need somewhere to live.** A catalog sometimes has a good reason to
+carry a finding, such as targeting a spec change that has not shipped. TriMet
+keeps a [`docs/conformance.md`](https://github.com/cholmes/portolan-catalog-trimet/blob/main/docs/conformance.md)
+listing every accepted deviation with its reasoning, and its test fails on any
+finding not on that list. The list cannot grow silently, which is the point.
+
+## How a catalog points back at its repository is unsettled
+
+Core's [`via`](../portolan/core.md#source-provenance) records where the data
+came from. Nothing records where the catalog is maintained. A consumer holding
+a published `catalog.json` has no dependable way to reach the repository that
+produced it, which means no way to file the correction the README asked for.
+
+As of August 2026 three encodings are in use, and every catalog studied here
+uses at least two of them. No two use the same pair.
+
+**Dedicated fields.** Fields of the World carries `git:repository`, `git:ref`,
+and `git:provider`, plus `vcs` and `issues` link relations. This is the shape
+of [an extension proposal](https://github.com/portolan-sdi/portolan-spec/issues/145)
+that has not shipped, so nothing writes or reads the fields generically.
+Portolan 0.1 defines no git extension and rashid ignores them, and the guard is
+`tests/test_git_ext.py`, twenty lines of string equality against a literal URL.
+The fields sit on the root catalog only, so a consumer who lands on a
+`collection.json` sees nothing.
+
+**The host provider's url.** TriMet and St. Louis both set the `url` of their
+`host` provider to the GitHub repository, on the root and on every collection.
+This adds no vocabulary, satisfies core's
+[provider requirements](../portolan/core.md#providers) at the same time, and
+reaches every level of the tree. The cost is ambiguity. A provider `url` means
+"where this organization can be reached", so a repository there is
+indistinguishable from a homepage, and there is nowhere to put the issue
+tracker separately.
+
+That encoding is also unavailable to some catalogs. Fields of the World hosts
+its data on Source Cooperative, so its `host` provider is Source Cooperative,
+which is the right answer to a different question.
+
+**Prose.** TriMet's published README carries a table naming the catalog
+repository and the browser repository, then asks directly for issues and pull
+requests. The Fields of the World root description says the metadata is managed
+in its repository and that pull requests are welcome. A person finds this. No
+tool can act on it.
+
+Nothing is recommended here. That every catalog reaches for two encodings is
+the signal that none of them is sufficient alone, and the resolution belongs in
+the spec rather than in three independent conventions. Weigh in on
+[issue #145](https://github.com/portolan-sdi/portolan-spec/issues/145) if you
+publish a catalog this affects.
+
+## Catalogs worth studying
+
+Three git-backed catalogs, readable end to end:
+
+- [ftw-data-catalog](https://github.com/fieldsoftheworld/ftw-data-catalog) —
+  metadata for a global machine-learning dataset whose data runs to hundreds
+  of gigabytes on Source Cooperative. Its `CLAUDE.md` documents the publish
+  model, including why a full recursive bucket listing was too slow and what
+  replaced it.
+- [portolan-catalog-stlouis](https://github.com/cholmes/portolan-catalog-stlouis)
+  — twenty collections mirrored from a city open-data portal, with the
+  fetch-convert-assemble pipeline and its gates in the repository.
+- [portolan-catalog-trimet](https://github.com/cholmes/portolan-catalog-trimet)
+  — eight transit datasets, notable for regeneration determinism tests and a
+  written conformance-waiver policy.
+
+## This is a discussion
+
+This page describes what three publishers converged on by August 2026, which
+is a small sample. The layout is consistent enough to write down. The
+discovery question is not settled at all, and parts of this may look wrong
+once more catalogs exist. If you maintain a git-backed catalog that solved
+something differently, open an issue or a pull request on the
+[spec repository](https://github.com/portolan-sdi/portolan-spec).


### PR DESCRIPTION
## Why

Publishing git-backed catalogs is a recommended approach for Portolan, but we've never documented it. This page gives publishers a concrete set of best practices to follow instead of reverse-engineering other repositories.

## What this changes

Adds `specs/best-practices/git-backed-catalogs.md`, a non-normative guide linked from the best-practices README. It covers repository layout, generated metadata, validation, publication, and how to link a catalog to the repository that maintains it.

@cholmes @m-mohr can you please look at the links section specifically and lmk if it makes sense? Chris' catalogs each used a different approach to representing links--I went with `vcs` and `issues`, but we could also use the `git` STAC extension instead. 

## Verification

Checked against `ftw-data-catalog`, `portolan-catalog-stlouis`, and `portolan-catalog-trimet`. FTW has no `git:*` keys on its collections; the other two repeat the host provider there.

```console id="7h1w2s"
$ uv run specs/tools/check_requirements.py
OK: 122 requirements anchored; all keyword occurrences covered.

$ grep -cE '\b(MUST|SHOULD|MAY|REQUIRED|RECOMMENDED|OPTIONAL)\b' specs/best-practices/git-backed-catalogs.md
0
```
