### PR TITLE
fix(ci): install s5cmd without the GitHub releases API

### DIFF
--- a/.github/actions/setup-s5cmd/action.yml
+++ b/.github/actions/setup-s5cmd/action.yml
@@ -1,0 +1,77 @@
+name: Setup s5cmd
+description: Install a pinned s5cmd on PATH from a checksum-verified release asset.
+
+# Replaces peak/action-setup-s5cmd, which resolves the download URL through the
+# unauthenticated GitHub releases API. That API is rate limited per runner IP,
+# and a shared IP can arrive already spent. The limited response is an error
+# object rather than the release list the action expects, so its `jq` filter
+# indexes a string and the step dies with:
+#
+#   jq: error (at <stdin>:1): Cannot index string with string "tag_name"
+#
+# The failure lands on whichever job draws the exhausted IP, so it reads as a
+# flake and a re-run usually clears it. It is not a flake. Every publish is one
+# unlucky scheduling away from it, and the jobs it breaks are the ones that
+# hold Source Cooperative credentials.
+#
+# Release asset URLs are deterministic, so fetching one directly needs no API
+# call and cannot be rate limited.
+#
+# The version and the checksum are pinned here rather than taken as inputs.
+# They have to move together, and an input that lets a caller raise one without
+# the other is a trap. Both callers want the same s5cmd anyway. To upgrade,
+# change both values below and confirm the new digest against the
+# `s5cmd_checksums.txt` published with that release.
+#
+# Dependabot does not watch a URL in a shell script the way it watches a `uses:`
+# reference, so nothing raises this automatically. See .github/dependabot.yml.
+
+runs:
+  using: composite
+  steps:
+    - name: Install s5cmd
+      shell: bash
+      env:
+        S5CMD_VERSION: 2.3.0
+        S5CMD_SHA256: de0fdbfa3aceae55e069ba81a0fc17b2026567637603734a387b2fca06c299b4
+      run: |
+        set -euo pipefail
+
+        # The pinned digest covers the Linux x86-64 asset alone. A runner that
+        # is neither would need its own digest, and guessing one from the
+        # architecture would defeat the point of pinning it. Fail loudly here
+        # instead of downloading an asset nobody has vouched for.
+        if [ "$RUNNER_OS" != "Linux" ] || [ "$RUNNER_ARCH" != "X64" ]; then
+          echo "::error::setup-s5cmd pins the Linux X64 asset, but this runner" \
+            "is ${RUNNER_OS} ${RUNNER_ARCH}. Add a digest for that platform" \
+            "in .github/actions/setup-s5cmd/action.yml before using it there."
+          exit 1
+        fi
+
+        asset="s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz"
+        url="https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/${asset}"
+
+        work="${RUNNER_TEMP}/s5cmd-install"
+        bin="${RUNNER_TEMP}/s5cmd-bin"
+        mkdir -p "$work" "$bin"
+
+        # --fail keeps an HTML error page from being written into the archive,
+        # so a bad response reports itself as a failed download rather than a
+        # corrupt tarball. The retries cover transient network errors, which
+        # were never the problem this action solves but are cheap to absorb.
+        curl --silent --show-error --location --fail \
+          --retry 3 --retry-all-errors \
+          --output "${work}/${asset}" "$url"
+
+        # The URL says where the bytes came from. The digest says which bytes
+        # arrived. These jobs hold publishing credentials, so both are checked.
+        echo "${S5CMD_SHA256}  ${work}/${asset}" | sha256sum --check --strict -
+
+        tar -xzf "${work}/${asset}" -C "$bin" s5cmd
+
+        echo "$bin" >> "$GITHUB_PATH"
+
+        # publish_catalogs.py looks s5cmd up with shutil.which and exits if it
+        # is missing. Proving it runs here turns a broken install into a clear
+        # failure in this step rather than a confusing one several steps later.
+        "${bin}/s5cmd" version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
 # Keeps the actions in .github/workflows/ current.
 #
 # Several of them are pinned exactly rather than to a floating major, because
-# setup-uv stopped publishing major tags after v7 and peak/action-setup-s5cmd
-# publishes no tags at all, so the jobs holding publishing credentials pin it to
-# a commit. An exact pin is only safe while something raises it. Without this
-# config those versions freeze at whatever was current the day they were
-# written, and the repo quietly ships an action nobody has looked at in a year.
+# setup-uv stopped publishing major tags after v7. An exact pin is only safe
+# while something raises it. Without this config those versions freeze at
+# whatever was current the day they were written, and the repo quietly ships an
+# action nobody has looked at in a year.
+#
+# One pin sits outside that reach. .github/actions/setup-s5cmd downloads a
+# pinned s5cmd release asset by URL, and Dependabot reads `uses:` references
+# rather than URLs in shell, so it will never raise that one. Upgrading s5cmd
+# is a hand edit of the version and the digest together, recorded there.
 #
 # Directory / covers .github/workflows/ for this ecosystem.
 

--- a/.github/workflows/publish-catalogs.yaml
+++ b/.github/workflows/publish-catalogs.yaml
@@ -143,14 +143,14 @@ jobs:
           sudo apt-get install -y --no-install-recommends tippecanoe
           tippecanoe --version
 
-      # peak/action-setup-s5cmd publishes no tags, so this is pinned to a commit
-      # rather than tracking main. The job holds publishing credentials, and a
-      # mutable third-party ref in it is a supply-chain hole. Reads as `@main`
-      # in peak's own README.
+      # A local action rather than peak/action-setup-s5cmd. That one resolves
+      # the download through the unauthenticated GitHub releases API, which is
+      # rate limited per runner IP and takes the publish down with it when the
+      # IP arrives spent. The local one fetches a pinned release asset by URL
+      # and checks its digest, so this job depends on no API and on no mutable
+      # third-party ref while holding publishing credentials.
       - name: Install s5cmd
-        uses: peak/action-setup-s5cmd@bde462e7399c68b4a9b05549d90b0e7d5c95e60f
-        with:
-          version: v2.3.0
+        uses: ./.github/actions/setup-s5cmd
 
       - uses: astral-sh/setup-uv@v9.0.0
         with:

--- a/.github/workflows/teardown-previews.yaml
+++ b/.github/workflows/teardown-previews.yaml
@@ -40,11 +40,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # Same commit pin as publish-catalogs.yaml, this repo publishes no tags.
+      # The same local action publish-catalogs.yaml installs s5cmd with, so the
+      # delete and the publish run the same pinned binary.
       - name: Install s5cmd
-        uses: peak/action-setup-s5cmd@bde462e7399c68b4a9b05549d90b0e7d5c95e60f
-        with:
-          version: v2.3.0
+        uses: ./.github/actions/setup-s5cmd
 
       - uses: astral-sh/setup-uv@v9.0.0
 


### PR DESCRIPTION
## What this changes

Replaces `peak/action-setup-s5cmd` with a local composite action in both jobs
that install s5cmd. It fetches the pinned release asset by its deterministic
URL, verifies the SHA-256, and puts the binary on PATH. `dependabot.yml` records
that this pin needs a hand edit, since Dependabot reads `uses:` references, not
URLs in shell.

## Why

Resolves #146. The old action asked the unauthenticated releases API for the
download URL. Once rate limited, that API returns an error object instead of the
release array, so its `jq` indexes a string and exits 5. Publish Catalogs died
there on main. A direct URL needs no API call, so no runner's spent budget can
fail a credentialed publish.

## Verification

Ran the action's script with the variables a runner supplies. It read the s5cmd
v2.3.0 Linux x86-64 asset from
https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-64bit.tar.gz
and its expected digest from `s5cmd_checksums.txt` in the same release. The
install succeeds, `shutil.which` finds the binary `publish_catalogs.py` needs,
and both guards reject bad input. The last block reproduces the old failure.

```console
$ RUNNER_OS=Linux RUNNER_ARCH=X64 RUNNER_TEMP=$T GITHUB_PATH=$GP \
  S5CMD_VERSION=2.3.0 \
  S5CMD_SHA256=de0fdbfa3aceae55e069ba81a0fc17b2026567637603734a387b2fca06c299b4 \
  bash step.sh
/tmp/.../s5cmd-install/s5cmd_2.3.0_Linux-64bit.tar.gz: OK
v2.3.0-991c9fb
$ echo $?
0
$ PATH="$(cat $GP):$PATH" python3 -c "import shutil; print(shutil.which('s5cmd'))"
/tmp/.../s5cmd-bin/s5cmd
```

```console
$ S5CMD_SHA256=0000...0000 bash step.sh
/tmp/.../s5cmd_2.3.0_Linux-64bit.tar.gz: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
$ echo $?
1

$ RUNNER_OS=macOS RUNNER_ARCH=ARM64 bash step.sh
::error::setup-s5cmd pins the Linux X64 asset, but this runner is macOS ARM64. Add a digest for that platform in .github/actions/setup-s5cmd/action.yml before using it there.
$ echo $?
1
```

```console
$ python3 -c "
import yaml
for f in ['.github/actions/setup-s5cmd/action.yml',
          '.github/workflows/publish-catalogs.yaml',
          '.github/workflows/teardown-previews.yaml',
          '.github/dependabot.yml']:
    yaml.safe_load(open(f)); print('ok', f)"
ok .github/actions/setup-s5cmd/action.yml
ok .github/workflows/publish-catalogs.yaml
ok .github/workflows/teardown-previews.yaml
ok .github/dependabot.yml
```

```console
$ echo '{"message":"API rate limit exceeded for 20.1.2.3.","documentation_url":"https://docs.github.com/rest"}' \
  | jq --arg tag "v2.3.0" --arg asset_name "s5cmd_2.3.0_Linux-64bit.tar.gz" \
    '.[]| select(.tag_name==$tag) | .assets[].browser_download_url | select(. | test(".+" + $asset_name + "$"))'
jq: error (at <stdin>:1): Cannot index string with string "tag_name"
$ echo $?
5
```
