### PR TITLE
chore(release): 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+## 0.1.1 - 2026-08-14
+
+A catalog declares this version by carrying
+`https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json` in `stac_extensions`.
+The `v0.1.0` schema stays published unchanged, so a catalog authored against that
+version keeps validating against it.
+
+Two changes ask something new of a catalog that already conforms. A collection
+with more than one style now MUST mark exactly one style asset with the `default`
+role (`PORTO-CORE-070`, raised from SHOULD), and a root catalog that publishes an
+`icon` link MUST give it a `type` (`PORTO-CORE-075`).
+
 ### Added
 
 - `PORTO-FMT-046` and `PORTO-FMT-047`: a vector collection SHOULD document its
@@ -49,6 +61,23 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   GeoParquet was never intended. The role records provenance, not hosting;
   which servers the Data Storage requirements reach is settled by
   PORTO-CORE-073 (#90).
+- **Catalog Logo** (PORTO-CORE-074 through PORTO-CORE-077): the root catalog MAY
+  publish a logo as a link with `rel: "icon"`. A registry lists many catalogs
+  side by side, and a logo makes each one recognizable before the reader has read
+  a word. STAC defines no `logo` relation, `icon` is registered with IANA, and
+  stac-js and STAC Browser already read it. An `icon` link MUST declare a `type`
+  drawn from the seven image media types a browser renders in an `<img>` element,
+  since a client drops an icon whose media type it does not recognize. The link
+  SHOULD carry a `title`, which a page renders as the image's accessible label,
+  and its `href` SHOULD be relative, which keeps the catalog portable. The
+  reference catalog publishes the Portolan logo from `_assets/` (#136).
+- **Git-backed catalogs**: a new best-practices page,
+  [`specs/best-practices/git-backed-catalogs.md`](specs/best-practices/git-backed-catalogs.md),
+  covers publishing a catalog whose source of truth is a Git repository. It
+  recommends `vcs` and `issues` links on the root catalog so software can find
+  the repository and its issue tracker. Both relations are registered with IANA.
+  This is a recommended convention, not a Portolan requirement, and the page says
+  so (#145).
 
 ### Changed
 
@@ -108,8 +137,8 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   enforcement moves from `process` to `validator`, since a data pass can check it.
 - **Assets** (PORTO-CORE-029): reworded to govern a `file:checksum` where one is
   present. Multihash encoding is still required, unchanged in force.
-- **Requirements manifest**: 121 requirements, now 87 MUST, 19 SHOULD, and
-  15 MAY.
+- **Requirements manifest**: 125 requirements, now 88 MUST, 21 SHOULD, and
+  16 MAY.
 - **Default style is identified by a `default` role**
   ([`specs/portolan/core.md`](specs/portolan/core.md)): a collection with more than
   one style now MUST mark exactly one style asset with `roles: ["style", "default"]`,

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ defined in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
 The specification is versioned with [SemVer](https://semver.org/), starting
 pre-1.0. A catalog declares the version it was authored against through the
 **Portolan STAC profile schema URI** in its `stac_extensions` array, e.g.
-`https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json`. That schema URI
+`https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json`. That schema URI
 is the single signal of specification version, and there is no separate version
 file (see
 [Conformance and Versioning](specs/portolan/core.md#conformance-and-versioning)).

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/boundaries/catalog.json
+++ b/examples/catalog/portolan-reference/boundaries/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "boundaries",
   "title": "Administrative Boundaries",

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/catalog.json
+++ b/examples/catalog/portolan-reference/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "portolan-reference",
   "title": "Portolan Reference Catalog",

--- a/examples/catalog/portolan-reference/mirror/catalog.json
+++ b/examples/catalog/portolan-reference/mirror/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "mirror",
   "title": "Mirrored Collections",

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/raster/catalog.json
+++ b/examples/catalog/portolan-reference/raster/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "raster",
   "title": "Raster Data",

--- a/examples/catalog/portolan-reference/raster/sample-cog/collection.json
+++ b/examples/catalog/portolan-reference/raster/sample-cog/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
   ],

--- a/examples/catalog/portolan-reference/reference/catalog.json
+++ b/examples/catalog/portolan-reference/reference/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "reference",
   "title": "Reference Basemaps",

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"

--- a/examples/catalog/portolan-reference/tabular/catalog.json
+++ b/examples/catalog/portolan-reference/tabular/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "tabular",
   "title": "Tabular Data",

--- a/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
+++ b/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/attribution/v0.1.0/schema.json"

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -1,4 +1,4 @@
-# Portolan reference catalog manifest, authored against Portolan spec v0.1.0.
+# Portolan reference catalog manifest, authored against Portolan spec v0.1.1.
 #
 # One manifest file describes one whole catalog. build.py reads every *.yaml in
 # this directory and builds each into its own tree under the output directory,
@@ -48,7 +48,7 @@ description: >-
   specification with real, openly licensed data pulled from its original
   upstream sources, vector polygons and points, raster, tabular, mirror
   provenance, nested catalogs and flat collections.
-schema_uri: https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json
+schema_uri: https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json
 
 host:
   name: Portolan SDI

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -127,7 +127,7 @@ misbehaves on this geometry.
 Top level of each file in `manifests/`.
 
 - `id`, `title`, `description`. Root Catalog identity.
-- `schema_uri`. Must equal the pinned v0.1.0 URI. `load_manifest` asserts this.
+- `schema_uri`. Must equal the pinned v0.1.1 URI. `load_manifest` asserts this.
 - `host`. `{name, url, email}`. Appended as the `host`-role provider on mirror Collections.
 - `catalogs`. Map from the first id segment to `{title, description, readme?, agents?}` for each nested Catalog. The optional `readme` and `agents` are markdown templates like the per-collection `docs` below.
 - `docs?`. `{readme?, agents?}` markdown templates for the root Catalog sidecars. Catalog-level templates may use `{{collections}}` (the table of contents the best-practices page asks for), `{{sources}}` (licenses, provenance, upstream list), and `{{agents_index}}` (per-child pointers to each AGENTS.md). Without a template a default skeleton with those blocks is emitted.
@@ -252,7 +252,7 @@ finding. Warnings and infos print without failing.
 Four passes run. The metadata pass checks the Portolan rules. The structural
 pass checks STAC 1.1.0 core validity and degrades to a warning when its
 schemas are unreachable. The schema pass validates every object against the
-working-copy schema at `../../stac/json-schema/v0.1.0/schema.json`, injected
+working-copy schema at `../../stac/json-schema/v0.1.1/schema.json`, injected
 so the build tests this repo's schema rather than the published one. The data
 pass reads the built assets and checks checksum, size, format, COG internal
 overviews, COG band statistics including valid percent, and GeoParquet ordering,

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -264,7 +264,7 @@ proven by running rashid directly, without the adapter. Do that before publishin
 rebuild.
 
 ```bash
-uv run --with "rashid[data]>=0.1.3,<0.2.0" \
+uv run --with "rashid[data]>=0.1.6,<0.2.0" \
   rashid check --schema examples/catalog/portolan-reference
 ```
 
@@ -302,10 +302,11 @@ section says "Servers MUST support range requests" and requires CORS with
 servers. Measured against the eight upstream sources, two ignore `Range`
 entirely, four send no CORS header, and none sends
 `Access-Control-Expose-Headers`. Nothing the generator can fix, those are third
-party servers. The spec should scope those MUSTs to assets the publisher hosts.
+party servers. The spec scopes those MUSTs to the catalog's own assets as of
+PORTO-CORE-073, so a validator does not probe an upstream host.
 
 rashid comes from PyPI, pinned to a compatible range in `build.py`'s PEP 723
-header, currently `rashid[data]>=0.1.3,<0.2.0`. Bumping the Portolan schema is a
+header, currently `rashid[data]>=0.1.6,<0.2.0`. Bumping the Portolan schema is a
 coordinated change across this repo and rashid, update the local schema,
 regenerate the reference catalog, re-vendor fixtures into rashid, then bump the
 rashid range here.

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -67,7 +67,7 @@ def main() -> int:
     ap.add_argument("--cache", default=root / "examples/.cache", type=Path)
     ap.add_argument("--catalog", default=None, help="build only the manifest with this file stem")
     ap.add_argument("--only", default=None, help="build only this collection id")
-    ap.add_argument("--schema", default=root / "stac/json-schema/v0.1.0/schema.json", type=Path)
+    ap.add_argument("--schema", default=root / "stac/json-schema/v0.1.1/schema.json", type=Path)
     ap.add_argument("--no-validate", action="store_true")
     ap.add_argument("--styles-only", action="store_true",
                     help="re-author MapLibre styles and their assets against "

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -7,7 +7,7 @@
 #   "pyarrow>=25",
 #   "geoparquet-io @ git+https://github.com/yharby/geoparquet-io.git@f27e53108910f19bd74a9ff4be5c7d97b104753c",
 #   "rasterio>=1.5",
-#   "rashid[data]>=0.1.3,<0.2.0",
+#   "rashid[data]>=0.1.6,<0.2.0",
 #   "rio-cogeo>=5.3",
 #   "Pillow>=11",
 # ]

--- a/examples/tools/config.py
+++ b/examples/tools/config.py
@@ -5,7 +5,7 @@ logic, no catalog-specific values.
 """
 from __future__ import annotations
 
-SCHEMA_URI = "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+SCHEMA_URI = "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
 FILE_EXT = "https://stac-extensions.github.io/file/v2.1.0/schema.json"
 WEBMAP_EXT = "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json"
 RASTER_EXT = "https://stac-extensions.github.io/raster/v2.0.0/schema.json"

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -32,7 +32,7 @@ from thumbnails import (
 # --------------------------------------------------------------------- manifest
 def load_manifest(path: Path) -> dict:
     m = yaml.safe_load(path.read_text())
-    assert m["schema_uri"] == SCHEMA_URI, "manifest schema_uri must be the pinned v0.1.0 URI"
+    assert m["schema_uri"] == SCHEMA_URI, "manifest schema_uri must be the pinned v0.1.1 URI"
     logo = m.get("logo")
     if logo:
         # The manifest directory is the only place that knows where a relative

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "jsonschema>=4.26.0",
-#   "rashid[data]>=0.1.3,<0.2.0",
+#   "rashid[data]>=0.1.6,<0.2.0",
 # ]
 # ///
 """Standalone checks for the rashid validation adapter.

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -19,7 +19,7 @@ from validate import _local_schema_validator  # noqa: E402
 from validate import _LocalOnlyReader  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
-SCHEMA = REPO / "stac/json-schema/v0.1.0/schema.json"
+SCHEMA = REPO / "stac/json-schema/v0.1.1/schema.json"
 REFERENCE = REPO / "examples/catalog/portolan-reference"
 
 import shutil  # noqa: E402

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -78,7 +78,7 @@ versioned schema URI carries the specification version the object was authored
 against.
 
 Every catalog and collection MUST declare the versioned Portolan schema URI (e.g.
-`https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json`) in its `stac_extensions`
+`https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json`) in its `stac_extensions`
 array. The schema URI is the single signal of specification version; no separate
 version property is defined. Declaration happens at the catalog and collection
 level only, since assets cannot carry `stac_extensions`, and items inherit

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -67,7 +67,7 @@ requirements:
     file: specs/portolan/core.md
     quote: >-
       Every catalog and collection MUST declare the versioned Portolan schema
-      URI (e.g. `https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json`)
+      URI (e.g. `https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json`)
       in its `stac_extensions` array.
 
   - id: PORTO-CORE-007

--- a/specs/tools/check_requirements.py
+++ b/specs/tools/check_requirements.py
@@ -16,6 +16,12 @@ sentence it governs, so the check needs no markup inside the markdown:
    inside the span of some matched quote or exclusion. Adding a normative
    sentence without a manifest entry fails here.
 
+3. The newest requirements census in CHANGELOG.md must match the manifest.
+   The census is the "**Requirements manifest**: N requirements, now A MUST,
+   B SHOULD, and C MAY." line a release writes. Nothing else reads the
+   changelog, so before this check the census drifted every time a
+   requirement landed without a release (#150).
+
 Exclusions cover uppercase keyword mentions that are not requirements (for
 example, prose explaining the RFC 2119 conventions themselves).
 
@@ -29,6 +35,7 @@ Usage::
 
 from __future__ import annotations
 
+import collections
 import re
 import sys
 from pathlib import Path
@@ -38,6 +45,14 @@ import yaml
 # specs/tools/check_requirements.py -> repo root is three levels up
 ROOT = Path(__file__).resolve().parent.parent.parent
 MANIFEST = ROOT / "specs" / "portolan" / "requirements.yaml"
+CHANGELOG = ROOT / "CHANGELOG.md"
+
+# The census line a release writes, matched against whitespace-normalized text
+# because the changelog wraps it across two lines.
+CENSUS = re.compile(
+    r"\*\*Requirements manifest\*\*: (\d+) requirements, now (\d+) MUST, "
+    r"(\d+) SHOULD, and (\d+) MAY\."
+)
 
 KEYWORD = re.compile(
     r"\b(MUST NOT|MUST|SHOULD NOT|SHOULD|MAY|REQUIRED|RECOMMENDED|OPTIONAL)\b"
@@ -59,9 +74,37 @@ def spans_of(needle: str, haystack: str) -> list[tuple[int, int]]:
     return spans
 
 
+def census_errors(manifest: dict) -> list[str]:
+    """Compare the newest CHANGELOG.md census against the manifest.
+
+    The topmost census line is the newest one, so a release that changes the
+    requirement set and forgets to write a fresh census fails here rather than
+    shipping a stale number. A changelog with no census line at all has nothing
+    to drift.
+    """
+    matches = list(CENSUS.finditer(normalize(CHANGELOG.read_text())))
+    if not matches:
+        return []
+    claimed = tuple(int(group) for group in matches[0].groups())
+    counts = collections.Counter(e["severity"] for e in manifest["requirements"])
+    actual = (
+        len(manifest["requirements"]),
+        counts["MUST"],
+        counts["SHOULD"],
+        counts["MAY"],
+    )
+    if claimed == actual:
+        return []
+    return [
+        "CHANGELOG.md census reads {} requirements, {} MUST, {} SHOULD, {} MAY; "
+        "the manifest holds {}, {}, {}, {}".format(*claimed, *actual)
+    ]
+
+
 def main() -> int:
     errors: list[str] = []
     manifest = yaml.safe_load(MANIFEST.read_text())
+    errors.extend(census_errors(manifest))
 
     seen_ids: set[str] = set()
     per_file_spans: dict[str, list[tuple[int, int]]] = {}

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.1 - 2026-08-14
+
+The schema is published at
+<https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json>. The `v0.1.0`
+schema stays published unchanged.
+
 ### Changed
 
 - The extension registry now records the table extension as SHOULD for vector
@@ -24,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asset carries either field rather than on every object with assets.
 - `PORTO-CORE-026`: `image/webp` is now a valid thumbnail media type alongside
   `image/png` and `image/jpeg`. No existing catalog breaks.
+- A link with `rel: "icon"` now MUST carry a `type`, and the schema restricts it
+  to `image/apng`, `image/avif`, `image/gif`, `image/jpeg`, `image/png`,
+  `image/svg+xml`, and `image/webp`, matching core.md's Catalog Logo section. The
+  section's other two rules, a relative `href` and a `title`, are SHOULD-level,
+  so Portolan tooling reports them and the schema does not. A catalog that
+  carries an icon link without a media type conformed before and does not now.
 - The media types and roles table lists the `source` and `collection-mirror`
   roles, which catalogs already carry. The schema is unchanged: `roles` stays a
   non-empty array of non-empty strings with no enumeration, so no previously

--- a/stac/README.md
+++ b/stac/README.md
@@ -3,7 +3,7 @@
 > **Work in Progress** — This profile is under active development. Requirement levels and the schema URL may change before the first stable release.
 
 - **Title:** Portolan
-- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json>
+- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json>
 - **Field Name Prefix:** portolan (reserved; no fields defined in v0.1)
 - **Scope:** Catalog, Collection — Items inherit conformance from their collection
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
@@ -42,7 +42,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
-| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
+| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
 | [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | When an asset carries `file:size` or `file:checksum`, both of which are SHOULD-level per asset (checksum as multihash) |
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
   ],
   "id": "andalusia-open-geodata",
   "title": "Andalusia Open Geodata",

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
     "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",

--- a/stac/json-schema/v0.1.1/schema.json
+++ b/stac/json-schema/v0.1.1/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json#",
+  "$id": "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json#",
   "title": "Portolan STAC Profile",
   "description": "The schema-checkable structural requirements of the Portolan specification. The versioned schema URI declared in stac_extensions is the single signal of specification version; no portolan-prefixed fields are defined. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
   "oneOf": [
@@ -130,7 +130,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://schemas.portolan-sdi.org/portolan/v0.1.0/schema.json"
+            "const": "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
           }
         }
       }
@@ -151,7 +151,7 @@
       }
     },
     "links_conformant": {
-      "$comment": "Objects never carry a self link; a catalog is fully portable (pystac SELF_CONTAINED convention). Structural links (root, parent, child, item, collection) are relative and carry the required media type. Every child and item link carries a human-readable title so browsers can render names without fetching every child. Whether every link resolves is a crawling check performed by Portolan tooling.",
+      "$comment": "Objects never carry a self link; a catalog is fully portable (pystac SELF_CONTAINED convention). Structural links (root, parent, child, item, collection) are relative and carry the required media type. Every child and item link carries a human-readable title so browsers can render names without fetching every child. A logo link (rel 'icon') declares a media type a browser renders in an img element (spec: Catalog Logo); that its href is relative and that it carries a title are SHOULD-level, so Portolan tooling reports them rather than the schema. Whether every link resolves is a crawling check performed by Portolan tooling.",
       "type": "object",
       "properties": {
         "links": {
@@ -234,6 +234,32 @@
                     "title": {
                       "type": "string",
                       "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "icon"
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "image/apng",
+                        "image/avif",
+                        "image/gif",
+                        "image/jpeg",
+                        "image/png",
+                        "image/svg+xml",
+                        "image/webp"
+                      ]
                     }
                   }
                 }
@@ -337,14 +363,14 @@
       }
     },
     "assets_typed_and_roled": {
-      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. Every asset also carries file:size and file:checksum (spec: Assets); the checksum's multihash encoding is verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
+      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. file:size and file:checksum are SHOULD-level (spec: Assets), so the schema constrains their shape where present but does not require them; the checksum's multihash encoding and its agreement with the bytes are verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
       "type": "object",
       "properties": {
         "assets": {
           "type": "object",
           "additionalProperties": {
             "type": "object",
-            "required": ["href", "type", "roles", "file:size", "file:checksum"],
+            "required": ["href", "type", "roles"],
             "properties": {
               "href": {
                 "type": "string",

--- a/stac/package.json
+++ b/stac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portolan-stac-profile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Portolan STAC profile — JSON Schema for the schema-checkable requirements plus a profile over reused STAC extensions",
   "scripts": {
     "pretest": "node scripts/fetch-extension-schemas.js",


### PR DESCRIPTION
## What this changes

Cuts specification release 0.1.1. Freezes `stac/json-schema/v0.1.0/schema.json`
back to its tagged bytes and moves the post-tag edits into a new `v0.1.1`
directory, which is Option A from #152. Bumps the profile URI everywhere, adds the
catalog logo and git-backed-catalogs entries the changelog missed, corrects the
requirements census to 125, and gates the census so it cannot drift again (#150).

## Why

Two schema edits landed under the released `v0.1.0` URI, so a consumer who fetched
it in July 2026 and one who fetches it in August 2026 validate against different
rules (#152). The publish workflow rebuilds the site from every tracked version
directory, so tagging from `main` without the freeze would have republished the
changed file under that URI. The census went stale twice because nothing reads
`CHANGELOG.md` (#150).

## Verification

Ran the three offline gates. The generator checks read the reference catalog at
`examples/catalog/portolan-reference`, which now declares the v0.1.1 URI, and the
profile suite reads `stac/examples`. Breaking the census on purpose fails the new
gate, which is how it was proven.

```console
$ uv run specs/tools/check_requirements.py
OK: 125 requirements anchored; all keyword occurrences covered.

$ uv run examples/tools/tests/run_all.py
PASS    0.5s  check_cog.py
PASS    5.4s  check_compliance.py
PASS    5.3s  check_docs.py
PASS    0.6s  check_fetch.py
PASS    0.8s  check_styles.py
PASS    0.5s  check_thumb_geoms.py
PASS    0.5s  check_thumbnails.py
PASS    0.2s  check_tiles.py
PASS    0.9s  check_validate.py
PASS    0.8s  check_web_output.py

10/10 generator checks passed

$ npm test --prefix stac
✓ incubating/partition v1.0.0 (cached)
CHANGELOG.md: no issues found
README.md: no issues found
✓ all Portolan schema URI references match https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json
Files: 4
Valid: 4
Invalid: 0
✓ catalog.json
✓ vector-collection.json
✓ vector-partitioned-collection.json
✓ vector-partitioned-item.json
```

Companion-PR: portolan-sdi/rashid#124
