### PR TITLE
docs: state that a released schema is immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ a new required field, and removing or renaming a field or accepted value are all
 breaking. A change is **non-breaking** when previously-conforming catalogs still
 conform, as with adding a warning, relaxing a constraint, or clarifying wording.
 
+**A released schema is immutable.** Once a version is tagged, the JSON Schema
+served at its URI never changes, so a catalog validates the same way in a year
+as on the day it was published. Editing the schema means adding a new version
+directory under [`stac/json-schema/`](stac/json-schema/), even for a change the
+prose treats as a clarification. The publish workflow rebuilds
+`schemas.portolan-sdi.org` from every tracked version directory on each release,
+so an in-place edit would republish the old URI with new rules.
+
 ## Contributing
 
 The spec is developed in the open, and this repository records the decisions


### PR DESCRIPTION
## What this changes

Adds a paragraph to the README's Versioning section: a released schema is
immutable, and editing one means adding a version directory under
`stac/json-schema/`.

## Why

The 0.1.1 release applied this policy but never wrote it down, so it survives
only as precedent. Issue #152 recorded what goes wrong without it: two edits
landed under the released v0.1.0 URI, and consumers fetching it a month apart
validated against different rules.

## Verification

Documentation only, so the evidence is that the repo's own gates still pass over
the edited README and that the schema URI it now cites matches the published
one.

```console
$ uv run specs/tools/check_requirements.py
OK: 125 requirements anchored; all keyword occurrences covered.

$ cd stac && npm test
README.md: no issues found
✓ all Portolan schema URI references match https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json
```

- [x] This change does not alter behavior (docs, chore, or CI only).
