### PR TITLE
feat(spec): recommend a root self link, drop the relative-links rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   so the choice belongs to the publisher rather than the standard (#159). The
   Links section now points to the [STAC best practices on the use of
   links](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-catalog-and-collection.md#use-of-links)
-  for the trade-offs. Relaxing a constraint is non-breaking.
+  for the trade-offs.
 - **Requirements manifest**: 128 requirements, now 88 MUST, 23 SHOULD, and
   17 MAY.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+### Changed
+
+- **A `self` link is no longer forbidden** (`PORTO-CORE-034`,
+  [`specs/portolan/core.md`](specs/portolan/core.md)): the rule now says only
+  that structural links MUST be relative. Portolan takes no position on `self`.
+  STAC treats the presence of one as the difference between a self-contained
+  catalog and a [relative published
+  catalog](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#relative-published-catalog),
+  and both are legitimate: the first is portable, the second records where it is
+  served from. Which one suits a catalog follows from how it is built and
+  published, not from anything Portolan needs, so forbidding the link ruled out
+  a layout STAC recommends for catalogs that live online without buying
+  conformance anything (#159). Relaxing a constraint is non-breaking.
+
+### Added
+
+- **Guidance on `self` links for git-backed catalogs**
+  ([`specs/best-practices/git-backed-catalogs.md`](specs/best-practices/git-backed-catalogs.md)):
+  a new "Keep links relative" section, replacing the normative rule with the
+  reasoning behind it. A git-backed catalog is authored in one place and served
+  from another, so a tracked `self` link is either wrong for two of the three
+  and produces diff and merge noise. The section recommends keeping the tracked
+  tree free of `self` links and letting the publish step write an absolute one
+  onto the root catalog from the `public_base` it already holds.
+
 ## 0.1.1 - 2026-08-14
 
 A catalog declares this version by carrying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
+## Unreleased
+
+### Changed
+
+- **Core takes no position on relative versus absolute links**
+  (`PORTO-CORE-034` retired,
+  [`specs/portolan/core.md`](specs/portolan/core.md)): the rule that all
+  structural links be relative, and that objects carry no `self` link, is gone.
+  Both link styles have sound uses. Relative links keep a catalog portable, and
+  absolute links name a location some hosts and clients handle more reliably,
+  so the choice belongs to the publisher rather than the standard (#159). The
+  Links section now points to the [STAC best practices on the use of
+  links](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-catalog-and-collection.md#use-of-links)
+  for the trade-offs. Relaxing a constraint is non-breaking.
+- **Requirements manifest**: 128 requirements, now 88 MUST, 23 SHOULD, and
+  17 MAY.
+
+### Added
+
+- **A published root catalog SHOULD carry a `self` link** (`PORTO-CORE-081`,
+  [`specs/portolan/core.md`](specs/portolan/core.md)): a catalog served over
+  the internet from a single fixed URL SHOULD carry an absolute `self` link on
+  its root catalog, matching the STAC best practice. The link records the
+  canonical location, so a downloaded copy still says where it came from and a
+  tool can turn relative references into URLs from the metadata alone.
+  Enforcement is `process`: whether a catalog is served from a fixed URL is a
+  publisher fact a validator cannot see in the files.
+- **Guidance on links for git-backed catalogs**
+  ([`specs/best-practices/git-backed-catalogs.md`](specs/best-practices/git-backed-catalogs.md)):
+  a new "Links and the publish step" section. It recommends relative links and
+  no `self` link in the tracked tree, so the same files validate in the
+  repository, in a preview, and in production, and it has the publish step
+  write the absolute `self` link onto the root catalog from the `public_base`
+  it already holds. It also notes where absolute asset hrefs serve clients
+  better, such as the Source Cooperative file listing.
+
 ## 0.1.2 - 2026-08-20
 
 A catalog declares this version by carrying
@@ -34,31 +70,6 @@ The schema carries no change beyond its own `$id`.
   structure, link, translate, and maintain the language trees.
 - **Requirements manifest**: 128 requirements, now 89 MUST, 22 SHOULD, and
   17 MAY.
-
-### Changed
-
-- **A `self` link is no longer forbidden** (`PORTO-CORE-034`,
-  [`specs/portolan/core.md`](specs/portolan/core.md)): the rule now says only
-  that structural links MUST be relative. Portolan takes no position on `self`.
-  STAC treats the presence of one as the difference between a self-contained
-  catalog and a [relative published
-  catalog](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#relative-published-catalog),
-  and both are legitimate: the first is portable, the second records where it is
-  served from. Which one suits a catalog follows from how it is built and
-  published, not from anything Portolan needs, so forbidding the link ruled out
-  a layout STAC recommends for catalogs that live online without buying
-  conformance anything (#159). Relaxing a constraint is non-breaking.
-
-### Added
-
-- **Guidance on `self` links for git-backed catalogs**
-  ([`specs/best-practices/git-backed-catalogs.md`](specs/best-practices/git-backed-catalogs.md)):
-  a new "Keep links relative" section, replacing the normative rule with the
-  reasoning behind it. A git-backed catalog is authored in one place and served
-  from another, so a tracked `self` link is either wrong for two of the three
-  and produces diff and merge noise. The section recommends keeping the tracked
-  tree free of `self` links and letting the publish step write an absolute one
-  onto the root catalog from the `public_base` it already holds.
 
 ## 0.1.1 - 2026-08-14
 

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -37,7 +37,9 @@ def check_self_link_fails() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         dst = Path(tmp) / "portolan-reference"
         shutil.copytree(REFERENCE, dst)
-        # Inject a forbidden self link into one Collection.
+        # Inject a self link into one Collection. The v0.1.2 schema rejects
+        # it. The specification no longer does, so the next schema version
+        # drops this check and this test flips with it.
         col = dst / "boundaries/us-counties/collection.json"
         obj = json.loads(col.read_text())
         obj["links"].append({"rel": "self", "href": "collection.json"})

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -34,19 +34,15 @@ The publication directory does not need to contain the data assets referenced by
 
 A typical repository can use `catalog/` for published metadata, `staging/` or `sources/` for source material, `tools/` or `scripts/` for build code, and `tests/` for tests. A root `catalog.publish.yaml` can define the object-storage target and public base URL, keeping publication settings in one place.
 
-## Keep links relative
+## Links and the publish step
 
-Core requires relative structural links and says nothing about `self` links. For a git-backed catalog the `self` link is worth leaving out of the tracked tree, and the reason is the workflow rather than the standard.
+Core takes no position on relative versus absolute links, and it recommends an absolute `self` link on the root of a catalog served from a single fixed URL. The [STAC best practices on the use of links](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-catalog-and-collection.md#use-of-links) cover the general trade-offs. A git-backed workflow gets the best of both by keeping the tracked tree portable and letting the publish step add what only it knows.
 
-A git-backed catalog is authored in one place and served from another. The same JSON has to be valid in the repository, in whatever preview a pull request builds, and in production. Relative links give all three for free: one tree of bytes, checked by CI on a laptop or a runner, published unchanged. A `self` link names one of those locations, so the copy in git is either wrong for the other two or has to be rewritten on the way out.
+Keep structural links relative in the repository. A git-backed catalog is authored in one place and served from another, and the same JSON has to be valid in the repository, in whatever preview a pull request builds, and in production. Relative links give all three for free: one tree of bytes, checked by CI on a laptop or a runner, published unchanged.
 
-That cost is small in absolute terms, since only the root catalog carries the link. It is annoying in a repository. A tracked file whose correct content depends on where it was deployed produces diff noise, and it conflicts on merge or rebase for reasons that have nothing to do with the change under review. It is also a file that a contributor can get wrong in a pull request without any local check catching it.
+Leave the `self` link out of the tracked tree for the same reason. A tracked file whose correct content depends on where it is deployed produces diff noise, and it conflicts on merge or rebase for reasons unrelated to the change under review. Instead, have the publish step write the absolute `self` link onto the root catalog as it uploads. The tool doing the upload is the only one that knows the destination, and the publish configuration already holds the URL: a `catalog.publish.yaml` with a `public_base` key, as described above, has everything the step needs. The repository stays portable, and the published catalog records its canonical location.
 
-The pull is real in the other direction. A published catalog with no `self` link records nothing about where it lives. A reader holding a copy cannot tell where it came from, and a tool reading the metadata cannot turn a relative asset href into a URL without being handed a base separately. That is the case STAC's relative published catalog answers.
-
-The two goals are compatible if the publish step owns the link. Keep the tracked tree free of `self` links, and let the tool that uploads add an absolute one to the root catalog, since it is the only thing that knows the destination. The publish configuration already holds that URL: a `catalog.publish.yaml` with a `public_base` key, as described above, has everything the step needs. The repository stays portable and the published catalog stays self-describing, which is the split a git-backed workflow wants.
-
-Two practices reinforce the same point. Assets are addressed relative to the collection that declares them, which keeps a collection movable within the tree. Tools that generate documentation from the catalog, such as a README with a file table, need an absolute base to make those paths clickable; give them the publish configuration rather than absolute hrefs in the metadata.
+Asset hrefs deserve their own decision. Absolute asset hrefs work better with some clients, because a client that reads one object in isolation has no base to resolve a relative href against. The Source Cooperative file listing is a concrete case: it renders asset hrefs as download links, and only absolute ones resolve. The publish step can rewrite asset hrefs to absolute from the same `public_base` it uses for the `self` link, or the tracked tree can carry absolute asset hrefs from the start when the data already has a stable home.
 
 ## Keep the tools and inputs
 
@@ -88,7 +84,7 @@ OK: 1 files checked, no findings.
 
 ### Handle validator differences
 
-`stac-check` recommends a `self` link, but Portolan forbids it because a static catalog should not hardcode its own location when it may be mirrored or moved. Treat `stac-check` best-practice recommendations as advisory and use rashid as the Portolan conformance gate, as Fields of the World does in `tests/test_stac_valid.py`.
+`stac-check` recommends a `self` link, which the tracked tree omits on purpose because the publish step adds it. Treat `stac-check` best-practice recommendations as advisory and use rashid as the Portolan conformance gate, as Fields of the World does in `tests/test_stac_valid.py`.
 
 ### Record accepted deviations
 

--- a/specs/best-practices/git-backed-catalogs.md
+++ b/specs/best-practices/git-backed-catalogs.md
@@ -34,6 +34,20 @@ The publication directory does not need to contain the data assets referenced by
 
 A typical repository can use `catalog/` for published metadata, `staging/` or `sources/` for source material, `tools/` or `scripts/` for build code, and `tests/` for tests. A root `catalog.publish.yaml` can define the object-storage target and public base URL, keeping publication settings in one place.
 
+## Keep links relative
+
+Core requires relative structural links and says nothing about `self` links. For a git-backed catalog the `self` link is worth leaving out of the tracked tree, and the reason is the workflow rather than the standard.
+
+A git-backed catalog is authored in one place and served from another. The same JSON has to be valid in the repository, in whatever preview a pull request builds, and in production. Relative links give all three for free: one tree of bytes, checked by CI on a laptop or a runner, published unchanged. A `self` link names one of those locations, so the copy in git is either wrong for the other two or has to be rewritten on the way out.
+
+That cost is small in absolute terms, since only the root catalog carries the link. It is annoying in a repository. A tracked file whose correct content depends on where it was deployed produces diff noise, and it conflicts on merge or rebase for reasons that have nothing to do with the change under review. It is also a file that a contributor can get wrong in a pull request without any local check catching it.
+
+The pull is real in the other direction. A published catalog with no `self` link records nothing about where it lives. A reader holding a copy cannot tell where it came from, and a tool reading the metadata cannot turn a relative asset href into a URL without being handed a base separately. That is the case STAC's relative published catalog answers.
+
+The two goals are compatible if the publish step owns the link. Keep the tracked tree free of `self` links, and let the tool that uploads add an absolute one to the root catalog, since it is the only thing that knows the destination. The publish configuration already holds that URL: a `catalog.publish.yaml` with a `public_base` key, as described above, has everything the step needs. The repository stays portable and the published catalog stays self-describing, which is the split a git-backed workflow wants.
+
+Two practices reinforce the same point. Assets are addressed relative to the collection that declares them, which keeps a collection movable within the tree. Tools that generate documentation from the catalog, such as a README with a file table, need an absolute base to make those paths clickable; give them the publish configuration rather than absolute hrefs in the metadata.
+
 ## Keep the tools and inputs
 
 The repository should contain the scripts, tools, and source inputs used to produce the catalog. This can be custom code or existing tools such as GDAL/OGR, `gpio`, or `portolan-cli`.

--- a/specs/best-practices/grader.md
+++ b/specs/best-practices/grader.md
@@ -62,11 +62,9 @@ dimensions; the A+ sits above them all.
   the root, every sub-catalog, and every collection. Each `AGENTS.md` is
   linked with `rel: "agents"` and each `README.md` with `rel: "describedby"`,
   both typed `text/markdown` and pointing at the raw file. Every catalog and
-  collection declares the Portolan schema URI. Structural links are relative;
-  no object carries a `self` link.
+  collection declares the Portolan schema URI.
 - **B** — All files exist and resolve, with scattered defects: a wrong media
-  type on a `describedby` link, a missing schema URI on some objects, a stray
-  `self` link.
+  type on a `describedby` link, or a missing schema URI on some objects.
 - **D** — A file class is absent across the catalog (every `AGENTS.md` 404s,
   or the links to them are missing), the schema URI appears nowhere, or
   hardcoded `self` links pin every object to one deployment URL.

--- a/specs/best-practices/grader.md
+++ b/specs/best-practices/grader.md
@@ -66,8 +66,7 @@ dimensions; the A+ sits above them all.
 - **B** — All files exist and resolve, with scattered defects: a wrong media
   type on a `describedby` link, or a missing schema URI on some objects.
 - **D** — A file class is absent across the catalog (every `AGENTS.md` 404s,
-  or the links to them are missing), the schema URI appears nowhere, or
-  hardcoded `self` links pin every object to one deployment URL.
+  or the links to them are missing), or the schema URI appears nowhere.
 
 ## 2. Metadata integrity
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -269,20 +269,22 @@ every object it contains; an item MUST include `root`, `parent`, and `collection
 links. Every structural link MUST carry a `type` of `application/json` (or
 `application/geo+json` for links to items).
 
-All structural links MUST be relative. This keeps a catalog portable: it can be
-created, validated, moved between local, staging, and production environments,
-or rehosted at a new URL without rewriting a file.
+Structural links can be relative or absolute; Portolan takes no position.
+Relative links keep a catalog portable, so the same tree of files validates
+locally, in staging, and in production without a rewrite. Absolute links name
+their location outright, which some hosts and clients handle more reliably.
+The [STAC best practices on the use of
+links](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-catalog-and-collection.md#use-of-links)
+walk through the choice, and [Git-Backed
+Catalogs](../best-practices/git-backed-catalogs.md#links-and-the-publish-step)
+covers how it plays out for a catalog maintained in git.
 
-Portolan says nothing about `self` links. STAC treats the presence of one as the
-difference between a self-contained catalog and a published catalog, and both
-are legitimate. A catalog that omits it stays portable in the sense above, and
-one that carries an absolute `self` link on its root records where it is served
-from, which is the [relative published
-catalog](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#relative-published-catalog)
-of the STAC best practices, `RELATIVE_PUBLISHED` in pystac. Which of the two
-suits a catalog depends on how it is built and maintained rather than on
-anything Portolan needs, so it is left to the publisher and discussed under
-[Git-Backed Catalogs](../best-practices/git-backed-catalogs.md#keep-links-relative).
+A catalog served over the internet from a single fixed URL SHOULD carry an
+absolute `self` link on its root catalog. The link records the canonical
+location, so someone holding a downloaded copy can see where it came from, and
+a tool can resolve the catalog's relative references into URLs from the
+metadata alone. STAC requires that a `self` link be
+[absolute](https://github.com/radiantearth/stac-spec/blob/master/commons/links.md#relation-types).
 
 Every link in a catalog MUST resolve. A validator MUST resolve each relative link
 against the catalog's own file tree, whether on a local filesystem or on object

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -267,12 +267,20 @@ every object it contains; an item MUST include `root`, `parent`, and `collection
 links. Every structural link MUST carry a `type` of `application/json` (or
 `application/geo+json` for links to items).
 
-All structural links MUST be relative, and objects MUST NOT include a `self` link.
-This keeps a catalog fully portable: it can be created, validated, moved between
-local, staging, and production environments, or rehosted at a new URL without
-rewriting any file. This choice follows pystac's `SELF_CONTAINED` convention and
-may be revisited in a future version if absolute self links prove necessary for
-published catalogs.
+All structural links MUST be relative. This keeps a catalog portable: it can be
+created, validated, moved between local, staging, and production environments,
+or rehosted at a new URL without rewriting a file.
+
+Portolan says nothing about `self` links. STAC treats the presence of one as the
+difference between a self-contained catalog and a published catalog, and both
+are legitimate. A catalog that omits it stays portable in the sense above, and
+one that carries an absolute `self` link on its root records where it is served
+from, which is the [relative published
+catalog](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#relative-published-catalog)
+of the STAC best practices, `RELATIVE_PUBLISHED` in pystac. Which of the two
+suits a catalog depends on how it is built and maintained rather than on
+anything Portolan needs, so it is left to the publisher and discussed under
+[Git-Backed Catalogs](../best-practices/git-backed-catalogs.md#keep-links-relative).
 
 Every link in a catalog MUST resolve. A validator MUST resolve each relative link
 against the catalog's own file tree, whether on a local filesystem or on object

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -298,8 +298,12 @@ remainder against the file tree, as it does for a relative href.
 
 A catalog that carries absolute structural links without a root `self` link
 gives a validator no base. The validator reports nothing for those links,
-because it cannot place them. The requirement to resolve still holds. A
-publisher who wants the check keeps a root `self` link.
+because it cannot place them. An `href` that does not start with the base gets
+the same treatment. A root catalog that links a child in a different bucket
+therefore gets no check on that link.
+
+The requirement to resolve still holds. A publisher who wants the check keeps a
+root `self` link.
 
 Provenance (`via`) links are covered under [Source Provenance](#source-provenance).
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -292,6 +292,15 @@ storage, and confirm the referenced file is present and is the correct object,
 rather than merely checking that the `href` is present or well-formed. A link that
 fails to resolve, or resolves to the wrong object, is a conformance failure.
 
+A validator resolves an absolute structural link through the base that the root
+`self` link names. It strips that base from the `href`. It then resolves the
+remainder against the file tree, as it does for a relative href.
+
+A catalog that carries absolute structural links without a root `self` link
+gives a validator no base. The validator reports nothing for those links,
+because it cannot place them. The requirement to resolve still holds. A
+publisher who wants the check keeps a root `self` link.
+
 Provenance (`via`) links are covered under [Source Provenance](#source-provenance).
 
 ### Alternate-Language Trees

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -331,12 +331,17 @@ requirements:
       Every structural link MUST carry a `type` of `application/json` (or
       `application/geo+json` for links to items).
 
-  - id: PORTO-CORE-034
-    severity: MUST
-    enforcement: validator
+  # PORTO-CORE-034 (all structural links MUST be relative, and objects MUST NOT
+  # include a self link) is retired. Portolan takes no position on relative
+  # versus absolute links, and PORTO-CORE-081 recommends a root self link on a
+  # published catalog (#159).
+  - id: PORTO-CORE-081
+    severity: SHOULD
+    enforcement: process
     file: specs/portolan/core.md
     quote: >-
-      All structural links MUST be relative.
+      A catalog served over the internet from a single fixed URL SHOULD carry
+      an absolute `self` link on its root catalog.
 
   - id: PORTO-CORE-035
     severity: MUST

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -327,8 +327,7 @@ requirements:
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      All structural links MUST be relative, and objects MUST NOT include a
-      `self` link.
+      All structural links MUST be relative.
 
   - id: PORTO-CORE-035
     severity: MUST

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The `links_conformant` block must stop rejecting a `self` link, on every
-  object rather than only the root, to match `PORTO-CORE-034`. A released
-  schema is immutable, so the edit belongs to the next version directory under
-  `stac/json-schema/` and lands with the release that cuts it (#159).
+- The `links_conformant` block must stop rejecting a `self` link and stop
+  requiring a relative `href` on structural links, following the spec's removal
+  of both rules (#159). A released schema is immutable, so the edits belong to
+  the next version directory under `stac/json-schema/` and land with the
+  release that cuts it. The new recommendation of a root `self` link
+  (`PORTO-CORE-081`) is conditional on how the publisher serves the catalog,
+  so the schema does not check it.
 
 ## 0.1.2 - 2026-08-20
 
@@ -28,7 +31,6 @@ The schema is published at
   and the multilingual rules govern `alternate` links between separate roots.
   The version directory exists because the schema URI is the signal of
   specification version, and a released schema is immutable.
->>>>>>> origin/main
 
 ## 0.1.1 - 2026-08-14
 

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `links_conformant` block must stop rejecting a `self` link, on every
+  object rather than only the root, to match `PORTO-CORE-034`. A released
+  schema is immutable, so the edit belongs to the next version directory under
+  `stac/json-schema/` and lands with the release that cuts it (#159).
+
 ## 0.1.1 - 2026-08-14
 
 The schema is published at

--- a/stac/README.md
+++ b/stac/README.md
@@ -25,7 +25,7 @@ The `portolan:` prefix stays reserved for future use.
 The schema encodes the specification's structural requirements that STAC core leaves optional:
 
 - Every Catalog and Collection has a non-empty `title` and `description`; every `child` and `item` link carries a `title` (spec: Human-Readable Titles).
-- No object carries a `self` link, and structural links (`root`, `parent`, `child`, `item`, `collection`) are relative and carry `type: "application/json"` (`application/geo+json` for links to items), keeping a catalog fully portable (spec: Links).
+- Structural links (`root`, `parent`, `child`, `item`, `collection`) carry `type: "application/json"` (`application/geo+json` for links to items) (spec: Links). The schemas through v0.1.2 also reject a `self` link and require relative structural hrefs; the specification has dropped both rules, and the relaxation lands with the next schema version.
 - Every asset has `href`, a media `type`, and at least one `role` (spec: Assets). `file:size` and `file:checksum` are SHOULD-level, so the schema checks their shape where present without requiring them; the checksum's multihash encoding, and whether either value matches the bytes, are verified by tooling rather than schema.
 - Absolute asset hrefs use `https` — `s3://` and other bucket schemes are rejected; relative hrefs are allowed (spec: Assets).
 - Every Collection declares `providers` with at least one `producer` and a `host` reachable through `url` or `email`; that the host is exactly one and listed last is checked by tooling (spec: Providers).
@@ -82,13 +82,14 @@ As the profile grows, per-format requirement sets (vector, raster, tabular) may 
 
 ### Link relations
 
-Objects MUST NOT include a `self` link, and all structural links MUST be relative (pystac `SELF_CONTAINED` convention), so a catalog can be moved or rehosted without rewriting any file.
+Structural links can be relative or absolute; the specification takes no position, and the [STAC best practices on the use of links](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-catalog-and-collection.md#use-of-links) cover the trade-offs. A catalog served over the internet from a single fixed URL SHOULD carry an absolute `self` link on its root catalog (spec: Links).
 
 | `rel` | Where | Notes |
 | ----- | ----- | ----- |
-| `root`, `parent` | All objects (root catalog has no `parent`) | Relative; `type: "application/json"` |
-| `child` / `item` | Catalogs and collections, one per child | Relative, typed (`application/geo+json` for items); MUST carry a `title` |
-| `collection` | Items | Relative; `type: "application/json"` |
+| `root`, `parent` | All objects (root catalog has no `parent`) | `type: "application/json"` |
+| `child` / `item` | Catalogs and collections, one per child | Typed (`application/geo+json` for items); MUST carry a `title` |
+| `collection` | Items | `type: "application/json"` |
+| `self` | Root catalog | Absolute; SHOULD when the catalog is served from a single fixed URL |
 | `agents` | Catalog, Collection | Points to `AGENTS.md`, `type: "text/markdown"` |
 | `describedby` | Catalog, Collection | Points to `README.md`, `type: "text/markdown"` |
 | `via` | Collection | Mirror only: the original source, `type: "text/html"` |
@@ -147,7 +148,7 @@ Tracked in the specification and deliberately **not** settled by this schema:
 - [Single-file vector collection](examples/vector-collection.json) — GeoParquet + PMTiles + style + thumbnail as collection-level assets
 - [Partitioned vector collection](examples/vector-partitioned-collection.json) and [partition item](examples/vector-partitioned-item.json)
 
-The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository. Per the spec's Links section the examples carry no `self` links and use only relative structural hrefs.
+The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository. The examples carry no `self` links and use relative structural hrefs, the portable layout the [git-backed best practices](../specs/best-practices/git-backed-catalogs.md#links-and-the-publish-step) recommend for a tracked tree.
 
 ## Building and Testing
 

--- a/stac/README.md
+++ b/stac/README.md
@@ -148,7 +148,7 @@ Tracked in the specification and deliberately **not** settled by this schema:
 - [Single-file vector collection](examples/vector-collection.json) — GeoParquet + PMTiles + style + thumbnail as collection-level assets
 - [Partitioned vector collection](examples/vector-partitioned-collection.json) and [partition item](examples/vector-partitioned-item.json)
 
-The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository. The examples carry no `self` links and use relative structural hrefs, the portable layout the [git-backed best practices](../specs/best-practices/git-backed-catalogs.md#links-and-the-publish-step) recommend for a tracked tree.
+The files are stored flat in `examples/` for convenience, but their relative hrefs describe the specification's canonical directory layout (`{collection_id}/collection.json`, `{item_id}/item.json` beneath it) — so href targets such as `../catalog.json`, `AGENTS.md`, and the data files are illustrative and not present in this repository. The examples carry no `self` links and use relative structural hrefs, the portable layout the [git-backed best practices](../specs/best-practices/git-backed-catalogs.md) recommend for a tracked tree.
 
 ## Building and Testing
 


### PR DESCRIPTION
Resolves #159.

Companion-PR: portolan-sdi/rashid#134

## What changed

This pull request retires `PORTO-CORE-034`. That rule required relative
structural links. It also forbade a `self` link. The spec now takes no position on relative versus
absolute links. The Links section points to the [STAC best practices on the
use of links](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-catalog-and-collection.md#use-of-links)
for the trade-offs.

`PORTO-CORE-081` is new. A catalog served from a single fixed URL SHOULD
carry an absolute `self` link on its root catalog, following stac best practice. 
For now its enforcement is done with `process`, but I'm hoping we can improve 
that in the future (issue coming soon)

The git-backed best practices gain a "Links and the publish step" section, with
more nuanced recommendations for that use case. And the grader page and the STAC profile README drop the old rule. 

## Why

STAC allows both link styles and explains when each one fits. Its best
practice is direct.
<!-- ste-ok: GERUND verbatim quote from the STAC best practices -->
<!-- ste-ok: LONG_SENTENCE verbatim quote from the STAC best practices -->
> If you're providing access to your catalog over the internet from a single
> fixed url, it is best practice to include a self link on the root catalog.

The old rule forbade that recommendation, and it was needlessly restrictive. #159 is an example of how the restriction hit us.

A root `self` link also records the canonical location. Someone who downloads
a catalog keeps a reference to where it came from. Portability stays
available. A publisher who wants it keeps links relative in the tracked tree.
The tracked tree also omits the `self` link, and it can be added in the publish step, as explained in git-backed page. 

## Verification

The manifest gate proves the prose and the manifest agree, and that the
changelog census matches.

```
$ uv run specs/tools/check_requirements.py
OK: 128 requirements anchored; all keyword occurrences covered.
```

The STAC profile markdown check passes.

```
$ cd stac && npx remark . --frail
CHANGELOG.md: no issues found
README.md: no issues found
```

The validator side runs against real data in portolan-sdi/rashid#134. The
catalog is the St. Louis open data mirror. Source Cooperative serves it at
<https://data.source.coop/tge-labs/st-louis-open-data-mirror>. Released
rashid 0.1.7 rejects a root `self` link on that tree. The companion branch
accepts it, and it resolves absolute structural links through the base the
`self` link names.
