### PR TITLE
docs: ask a catalog with twenty or more children to use subcatalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ## Unreleased
 
+### Added
+
+- `PORTO-CORE-078`: a catalog with twenty or more children SHOULD organize them
+  into subcatalogs, thematic or otherwise. A flat list of dozens of children is
+  hard to browse, and the profile already allows a catalog at every level above
+  a leaf. rashid reports the fan-out as a warning (`PTL-CAT-001`).
+- **Requirements manifest**: 126 requirements, now 88 MUST, 22 SHOULD, and
+  16 MAY.
+
 ## 0.1.1 - 2026-08-14
 
 A catalog declares this version by carrying

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -167,7 +167,9 @@ collection holds an intermediate (thematic) `catalog.json`, a data directory hol
 the leaf `collection.json`, and a subdirectory within a collection may hold a
 `catalog.json` that organizes many items. Deep nesting is allowed, with every
 level above the leaf a catalog; a catalog may also appear below a collection to
-organize its items (for example, a raster collection grouping items by year).
+organize its items (for example, a raster collection grouping items by year). A
+catalog with twenty or more children SHOULD organize them into subcatalogs,
+thematic or otherwise, so users can browse the data.
 
 ```
 environment/

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -185,6 +185,14 @@ requirements:
     quote: >-
       A collection MUST NOT contain a child collection.
 
+  - id: PORTO-CORE-078
+    severity: SHOULD
+    enforcement: validator
+    file: specs/portolan/core.md
+    quote: >-
+      A catalog with twenty or more children SHOULD organize them into
+      subcatalogs, thematic or otherwise, so users can browse the data.
+
   - id: PORTO-CORE-019
     severity: MUST
     enforcement: validator


### PR DESCRIPTION
## What changed

Large catalogs should now group their contents into subcatalogs.

`PORTO-CORE-078` says that a catalog with 20 or more children SHOULD organize them into subcatalogs, whether thematic or otherwise. This gives browsers a usable hierarchy instead of a single long list.

The requirement lives in the **Nested Catalogs, Flat Collections** section of `core.md` and has `enforcement: validator`.

## Why

Resolves #167.

The spec already allowed catalogs at any level above a leaf, but never required publishers to use that hierarchy. A root catalog with hundreds of children was therefore conformant even though browsers had to present it as one unreadable list.

Companion PR: `portolan-sdi/rashid#141`

## Verification

The requirements checker passes with the new requirement:

```text
$ uv run specs/tools/check_requirements.py
OK: 126 requirements anchored; all keyword occurrences covered.
```

The companion rashid rule also catches the problem in a real catalog with 486 root children:

```text
$ uv run rashid check ~/Documents/dev/portolan/idecor-arg --summary
warning  PTL-CAT-001    1x  a catalog with twenty or more ungrouped children should use subcatalogs
    catalog.json: catalog holds 486 children with no subcatalog grouping them; a flat list this long is hard to browse
```

The validator counts ungrouped children. A catalog that already contains subcatalogs can therefore still warn if it leaves 20 or more other children flat beside them.

`CHANGELOG.md` records the new requirement and updates the manifest count to 126.

Companion-PR: portolan-sdi/rashid#141
