### PR TITLE
docs: apply the subcatalog guidance to collections as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
 ### Added
 
-- `PORTO-CORE-078`: a catalog with twenty or more children SHOULD organize them
-  into subcatalogs, thematic or otherwise. A flat list of dozens of children is
-  hard to browse, and the profile already allows a catalog at every level above
-  a leaf. rashid reports the fan-out as a warning (`PTL-CAT-001`).
+- `PORTO-CORE-078`: a catalog or collection with twenty or more children SHOULD
+  organize them into subcatalogs, thematic or otherwise. A flat list of dozens
+  of children is hard to browse, and the profile already allows a catalog at
+  every level above a leaf, including below a collection. rashid reports the
+  fan-out as a warning (`PTL-CAT-001`).
 - **Requirements manifest**: 126 requirements, now 88 MUST, 22 SHOULD, and
   16 MAY.
 

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -168,8 +168,8 @@ the leaf `collection.json`, and a subdirectory within a collection may hold a
 `catalog.json` that organizes many items. Deep nesting is allowed, with every
 level above the leaf a catalog; a catalog may also appear below a collection to
 organize its items (for example, a raster collection grouping items by year). A
-catalog with twenty or more children SHOULD organize them into subcatalogs,
-thematic or otherwise, so users can browse the data.
+catalog or collection with twenty or more children SHOULD organize them into
+subcatalogs, thematic or otherwise, so users can browse the data.
 
 ```
 environment/

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -190,8 +190,9 @@ requirements:
     enforcement: validator
     file: specs/portolan/core.md
     quote: >-
-      A catalog with twenty or more children SHOULD organize them into
-      subcatalogs, thematic or otherwise, so users can browse the data.
+      A catalog or collection with twenty or more children SHOULD organize
+      them into subcatalogs, thematic or otherwise, so users can browse the
+      data.
 
   - id: PORTO-CORE-019
     severity: MUST


### PR DESCRIPTION
## What changed

`PORTO-CORE-078` now names both object types. The sentence in `core.md`, Nested Catalogs, Flat Collections, reads:

> A catalog or collection with twenty or more children SHOULD organize them into subcatalogs, thematic or otherwise, so users can browse the data.

The ID and the SHOULD severity stay. The census stays at 126 requirements.

## Why

Resolves #169. @m-mohr read the merged sentence and asked why it named only a catalog. A collection links its items, and a flat list of hundreds is as hard to browse as a flat list of child collections. `core.md` already permits the repair, because a catalog may sit below a collection to organize its items, and the same section gives a raster collection grouped by year as the example.

Companion-PR: portolan-sdi/rashid#144

## Verification

The requirements checker anchors the new quote:

```
$ uv run specs/tools/check_requirements.py
OK: 126 requirements anchored; all keyword occurrences covered.
```

rashid, with the companion rule, now reports the collection case on real data. The catalog at `~/Documents/dev/portolan/moldova-geodata/catalog` holds three collections with more than twenty items each, and reported nothing before:

```
$ uv run rashid check ~/Documents/dev/portolan/moldova-geodata/catalog --summary --no-data
warning  PTL-CAT-001    3x  a catalog or collection with twenty or more ungrouped children should use subcatalogs
    wms/maps/collection.json: collection holds 26 children with no subcatalog grouping them; a flat list this long is hard to browse
    wms/midr/collection.json: collection holds 43 children with no subcatalog grouping them; a flat list this long is hard to browse
    wms/orthophoto/collection.json: collection holds 53 children with no subcatalog grouping them; a flat list this long is hard to browse
```

## Implementation notes

The requirement counts children. For a catalog those are its collections and items; for a collection they are its items. rashid counts the ungrouped ones, so an object that already holds subcatalogs still reports a flat tail of twenty or more children beside them.

`CHANGELOG.md` carries the reworded Unreleased entry, since `PORTO-CORE-078` has not shipped in a release yet.

## Related issues

- portolan-sdi/rashid#143
