### PR TITLE
chore(release): 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
-## Unreleased
+## 0.1.2 - 2026-08-20
+
+A catalog declares this version by carrying
+`https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json` in `stac_extensions`.
+The `v0.1.0` and `v0.1.1` schemas stay published unchanged, so a catalog authored
+against either version keeps validating against it.
+
+Nothing in this release asks more of a catalog that already conforms. The
+fan-out guidance is a SHOULD that rashid reports as a warning, and the
+multilingual rules permit a structure the profile previously left unspecified.
+The schema carries no change beyond its own `$id`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ defined in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
 The specification is versioned with [SemVer](https://semver.org/), starting
 pre-1.0. A catalog declares the version it was authored against through the
 **Portolan STAC profile schema URI** in its `stac_extensions` array, e.g.
-`https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json`. That schema URI
+`https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`. That schema URI
 is the single signal of specification version, and there is no separate version
 file (see
 [Conformance and Versioning](specs/portolan/core.md#conformance-and-versioning)).

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/boundaries/catalog.json
+++ b/examples/catalog/portolan-reference/boundaries/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "boundaries",
   "title": "Administrative Boundaries",

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/catalog.json
+++ b/examples/catalog/portolan-reference/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "portolan-reference",
   "title": "Portolan Reference Catalog",

--- a/examples/catalog/portolan-reference/mirror/catalog.json
+++ b/examples/catalog/portolan-reference/mirror/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "mirror",
   "title": "Mirrored Collections",

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/raster/catalog.json
+++ b/examples/catalog/portolan-reference/raster/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "raster",
   "title": "Raster Data",

--- a/examples/catalog/portolan-reference/raster/sample-cog/collection.json
+++ b/examples/catalog/portolan-reference/raster/sample-cog/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
   ],

--- a/examples/catalog/portolan-reference/reference/catalog.json
+++ b/examples/catalog/portolan-reference/reference/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "reference",
   "title": "Reference Basemaps",

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"

--- a/examples/catalog/portolan-reference/tabular/catalog.json
+++ b/examples/catalog/portolan-reference/tabular/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "tabular",
   "title": "Tabular Data",

--- a/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
+++ b/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/attribution/v0.1.0/schema.json"

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -1,4 +1,4 @@
-# Portolan reference catalog manifest, authored against Portolan spec v0.1.1.
+# Portolan reference catalog manifest, authored against Portolan spec v0.1.2.
 #
 # One manifest file describes one whole catalog. build.py reads every *.yaml in
 # this directory and builds each into its own tree under the output directory,
@@ -48,7 +48,7 @@ description: >-
   specification with real, openly licensed data pulled from its original
   upstream sources, vector polygons and points, raster, tabular, mirror
   provenance, nested catalogs and flat collections.
-schema_uri: https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json
+schema_uri: https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json
 
 host:
   name: Portolan SDI

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -127,7 +127,7 @@ misbehaves on this geometry.
 Top level of each file in `manifests/`.
 
 - `id`, `title`, `description`. Root Catalog identity.
-- `schema_uri`. Must equal the pinned v0.1.1 URI. `load_manifest` asserts this.
+- `schema_uri`. Must equal the pinned v0.1.2 URI. `load_manifest` asserts this.
 - `host`. `{name, url, email}`. Appended as the `host`-role provider on mirror Collections.
 - `catalogs`. Map from the first id segment to `{title, description, readme?, agents?}` for each nested Catalog. The optional `readme` and `agents` are markdown templates like the per-collection `docs` below.
 - `docs?`. `{readme?, agents?}` markdown templates for the root Catalog sidecars. Catalog-level templates may use `{{collections}}` (the table of contents the best-practices page asks for), `{{sources}}` (licenses, provenance, upstream list), and `{{agents_index}}` (per-child pointers to each AGENTS.md). Without a template a default skeleton with those blocks is emitted.
@@ -252,7 +252,7 @@ finding. Warnings and infos print without failing.
 Four passes run. The metadata pass checks the Portolan rules. The structural
 pass checks STAC 1.1.0 core validity and degrades to a warning when its
 schemas are unreachable. The schema pass validates every object against the
-working-copy schema at `../../stac/json-schema/v0.1.1/schema.json`, injected
+working-copy schema at `../../stac/json-schema/v0.1.2/schema.json`, injected
 so the build tests this repo's schema rather than the published one. The data
 pass reads the built assets and checks checksum, size, format, COG internal
 overviews, COG band statistics including valid percent, and GeoParquet ordering,

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -7,7 +7,7 @@
 #   "pyarrow>=25",
 #   "geoparquet-io @ git+https://github.com/yharby/geoparquet-io.git@f27e53108910f19bd74a9ff4be5c7d97b104753c",
 #   "rasterio>=1.5",
-#   "rashid[data]>=0.1.6,<0.2.0",
+#   "rashid[data]>=0.1.7,<0.2.0",
 #   "rio-cogeo>=5.3",
 #   "Pillow>=11",
 # ]

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -67,7 +67,7 @@ def main() -> int:
     ap.add_argument("--cache", default=root / "examples/.cache", type=Path)
     ap.add_argument("--catalog", default=None, help="build only the manifest with this file stem")
     ap.add_argument("--only", default=None, help="build only this collection id")
-    ap.add_argument("--schema", default=root / "stac/json-schema/v0.1.1/schema.json", type=Path)
+    ap.add_argument("--schema", default=root / "stac/json-schema/v0.1.2/schema.json", type=Path)
     ap.add_argument("--no-validate", action="store_true")
     ap.add_argument("--styles-only", action="store_true",
                     help="re-author MapLibre styles and their assets against "

--- a/examples/tools/config.py
+++ b/examples/tools/config.py
@@ -5,7 +5,7 @@ logic, no catalog-specific values.
 """
 from __future__ import annotations
 
-SCHEMA_URI = "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+SCHEMA_URI = "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
 FILE_EXT = "https://stac-extensions.github.io/file/v2.1.0/schema.json"
 WEBMAP_EXT = "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json"
 RASTER_EXT = "https://stac-extensions.github.io/raster/v2.0.0/schema.json"

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -32,7 +32,7 @@ from thumbnails import (
 # --------------------------------------------------------------------- manifest
 def load_manifest(path: Path) -> dict:
     m = yaml.safe_load(path.read_text())
-    assert m["schema_uri"] == SCHEMA_URI, "manifest schema_uri must be the pinned v0.1.1 URI"
+    assert m["schema_uri"] == SCHEMA_URI, "manifest schema_uri must be the pinned v0.1.2 URI"
     logo = m.get("logo")
     if logo:
         # The manifest directory is the only place that knows where a relative

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "jsonschema>=4.26.0",
-#   "rashid[data]>=0.1.6,<0.2.0",
+#   "rashid[data]>=0.1.7,<0.2.0",
 # ]
 # ///
 """Standalone checks for the rashid validation adapter.

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -19,7 +19,7 @@ from validate import _local_schema_validator  # noqa: E402
 from validate import _LocalOnlyReader  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
-SCHEMA = REPO / "stac/json-schema/v0.1.1/schema.json"
+SCHEMA = REPO / "stac/json-schema/v0.1.2/schema.json"
 REFERENCE = REPO / "examples/catalog/portolan-reference"
 
 import shutil  # noqa: E402

--- a/specs/best-practices/multilingual-catalogs.md
+++ b/specs/best-practices/multilingual-catalogs.md
@@ -53,7 +53,7 @@ language:
 ```json
 {
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/language/v1.0.0/schema.json"
   ],
   "language": { "code": "ro", "name": "Română", "alternate": "Romanian" },

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -78,7 +78,7 @@ versioned schema URI carries the specification version the object was authored
 against.
 
 Every catalog and collection MUST declare the versioned Portolan schema URI (e.g.
-`https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json`) in its `stac_extensions`
+`https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`) in its `stac_extensions`
 array. The schema URI is the single signal of specification version; no separate
 version property is defined. Declaration happens at the catalog and collection
 level only, since assets cannot carry `stac_extensions`, and items inherit

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -67,7 +67,7 @@ requirements:
     file: specs/portolan/core.md
     quote: >-
       Every catalog and collection MUST declare the versioned Portolan schema
-      URI (e.g. `https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json`)
+      URI (e.g. `https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`)
       in its `stac_extensions` array.
 
   - id: PORTO-CORE-007

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.2 - 2026-08-20
+
+The schema is published at
+<https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json>. The `v0.1.0` and
+`v0.1.1` schemas stay published unchanged.
+
+### Changed
+
+- The schema is identical to `v0.1.1` apart from its `$id`. The specification
+  release adds `PORTO-CORE-078`, `PORTO-CORE-079`, and `PORTO-CORE-080`, none of
+  which the schema can check: the fan-out rule counts children across the tree,
+  and the multilingual rules govern `alternate` links between separate roots.
+  The version directory exists because the schema URI is the signal of
+  specification version, and a released schema is immutable.
+
 ## 0.1.1 - 2026-08-14
 
 The schema is published at

--- a/stac/README.md
+++ b/stac/README.md
@@ -3,7 +3,7 @@
 > **Work in Progress** — This profile is under active development. Requirement levels and the schema URL may change before the first stable release.
 
 - **Title:** Portolan
-- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json>
+- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json>
 - **Field Name Prefix:** portolan (reserved; no fields defined in v0.1)
 - **Scope:** Catalog, Collection — Items inherit conformance from their collection
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
@@ -42,7 +42,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
-| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
+| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
 | [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | When an asset carries `file:size` or `file:checksum`, both of which are SHOULD-level per asset (checksum as multihash) |
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
   ],
   "id": "andalusia-open-geodata",
   "title": "Andalusia Open Geodata",

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.1/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
     "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",

--- a/stac/json-schema/v0.1.2/schema.json
+++ b/stac/json-schema/v0.1.2/schema.json
@@ -1,0 +1,534 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json#",
+  "title": "Portolan STAC Profile",
+  "description": "The schema-checkable structural requirements of the Portolan specification. The versioned schema URI declared in stac_extensions is the single signal of specification version; no portolan-prefixed fields are defined. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
+  "oneOf": [
+    {
+      "$comment": "STAC Catalogs.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Catalog"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/human_readable"
+        },
+        {
+          "$ref": "#/definitions/links_conformant"
+        },
+        {
+          "$ref": "#/definitions/agents_link"
+        },
+        {
+          "$ref": "#/definitions/readme_link"
+        }
+      ]
+    },
+    {
+      "$comment": "STAC Collections.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/human_readable"
+        },
+        {
+          "$ref": "#/definitions/links_conformant"
+        },
+        {
+          "$ref": "#/definitions/agents_link"
+        },
+        {
+          "$ref": "#/definitions/readme_link"
+        },
+        {
+          "$ref": "#/definitions/assets_typed_and_roled"
+        },
+        {
+          "$ref": "#/definitions/license_not_proprietary"
+        },
+        {
+          "$ref": "#/definitions/providers_conformant"
+        },
+        {
+          "$ref": "#/definitions/partition_conformant"
+        },
+        {
+          "properties": {
+            "extent": {
+              "type": "object",
+              "properties": {
+                "spatial": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/valid_bbox"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "$comment": "STAC Items. Items do not declare the Portolan schema URI — declaration happens at the catalog and collection level only, and items inherit conformance from their collection. This branch is applied to items by the Portolan validator, not via stac_extensions.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            }
+          }
+        },
+        {
+          "properties": {
+            "bbox": {
+              "$ref": "#/definitions/valid_bbox"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/assets_typed_and_roled"
+        },
+        {
+          "$ref": "#/definitions/links_conformant"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+          }
+        }
+      }
+    },
+    "human_readable": {
+      "$comment": "Every Catalog and Collection carries a non-empty title and description. Whether a title is a raw slug is checked by Portolan tooling, not by schema.",
+      "type": "object",
+      "required": ["title", "description"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "links_conformant": {
+      "$comment": "Objects never carry a self link; a catalog is fully portable (pystac SELF_CONTAINED convention). Structural links (root, parent, child, item, collection) are relative and carry the required media type. Every child and item link carries a human-readable title so browsers can render names without fetching every child. A logo link (rel 'icon') declares a media type a browser renders in an img element (spec: Catalog Logo); that its href is relative and that it carries a title are SHOULD-level, so Portolan tooling reports them rather than the schema. Whether every link resolves is a crawling check performed by Portolan tooling.",
+      "type": "object",
+      "properties": {
+        "links": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "self"
+                    }
+                  }
+                },
+                "then": false
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "enum": ["root", "parent", "child", "collection"]
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "const": "application/json"
+                    },
+                    "href": {
+                      "type": "string",
+                      "minLength": 1,
+                      "not": {
+                        "pattern": "://"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "item"
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "const": "application/geo+json"
+                    },
+                    "href": {
+                      "type": "string",
+                      "minLength": 1,
+                      "not": {
+                        "pattern": "://"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "enum": ["child", "item"]
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["title"],
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "icon"
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "image/apng",
+                        "image/avif",
+                        "image/gif",
+                        "image/jpeg",
+                        "image/png",
+                        "image/svg+xml",
+                        "image/webp"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "agents_link": {
+      "$comment": "Every Catalog and Collection links its AGENTS.md with rel 'agents' and type text/markdown. The target's existence is a link-resolution check performed by crawling validators.",
+      "type": "object",
+      "required": ["links"],
+      "properties": {
+        "links": {
+          "type": "array",
+          "contains": {
+            "type": "object",
+            "required": ["rel", "href", "type"],
+            "properties": {
+              "rel": {
+                "const": "agents"
+              },
+              "type": {
+                "const": "text/markdown"
+              }
+            }
+          }
+        }
+      }
+    },
+    "readme_link": {
+      "$comment": "Every Catalog and Collection links its README.md with rel 'describedby' and type text/markdown (spec: README.md). The target's existence is a link-resolution check performed by crawling validators.",
+      "type": "object",
+      "required": ["links"],
+      "properties": {
+        "links": {
+          "type": "array",
+          "contains": {
+            "type": "object",
+            "required": ["rel", "href", "type"],
+            "properties": {
+              "rel": {
+                "const": "describedby"
+              },
+              "type": {
+                "const": "text/markdown"
+              }
+            }
+          }
+        }
+      }
+    },
+    "providers_conformant": {
+      "$comment": "Every collection identifies at least one producer and a host provider reachable through url or email (spec: Providers). That there is exactly one host, listed last, is checked by Portolan tooling, as is deriving official-vs-mirror from producer and host.",
+      "type": "object",
+      "required": ["providers"],
+      "properties": {
+        "providers": {
+          "type": "array",
+          "minItems": 1,
+          "allOf": [
+            {
+              "contains": {
+                "type": "object",
+                "required": ["roles"],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "producer"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "contains": {
+                "type": "object",
+                "required": ["roles"],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "host"
+                    }
+                  }
+                },
+                "anyOf": [
+                  {
+                    "required": ["url"]
+                  },
+                  {
+                    "required": ["email"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "assets_typed_and_roled": {
+      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. file:size and file:checksum are SHOULD-level (spec: Assets), so the schema constrains their shape where present but does not require them; the checksum's multihash encoding and its agreement with the bytes are verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["href", "type", "roles"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "minLength": 1,
+                "anyOf": [
+                  {
+                    "pattern": "^https://"
+                  },
+                  {
+                    "not": {
+                      "pattern": "://"
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "roles": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "file:size": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "file:checksum": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "partition_conformant": {
+      "$comment": "A partitioned collection declares the partition extension and carries its required fields (spec: Partitioned Collections). Any partition:* field without the declared extension, or a declaration missing a required field, fails. Field shapes are validated by the partition extension schema itself, which Portolan validators apply alongside this profile; cross-partition Parquet schema consistency is checked by tooling reading file footers.",
+      "type": "object",
+      "if": {
+        "anyOf": [
+          {
+            "required": ["partition:scheme"]
+          },
+          {
+            "required": ["partition:keys"]
+          },
+          {
+            "required": ["partition:strategy"]
+          },
+          {
+            "required": ["partition:file_count"]
+          },
+          {
+            "required": ["partition:glob"]
+          },
+          {
+            "required": ["stac_extensions"],
+            "properties": {
+              "stac_extensions": {
+                "type": "array",
+                "contains": {
+                  "const": "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "required": ["partition:scheme", "partition:keys", "partition:glob", "stac_extensions"],
+        "properties": {
+          "stac_extensions": {
+            "type": "array",
+            "contains": {
+              "const": "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json"
+            }
+          }
+        }
+      }
+    },
+    "license_not_proprietary": {
+      "$comment": "The deprecated STAC 1.1 value 'proprietary' is banned; use an SPDX identifier, or 'other' plus a rel 'license' link. SPDX validity and the conditional license link are checked by Portolan tooling.",
+      "type": "object",
+      "properties": {
+        "license": {
+          "not": {
+            "const": "proprietary"
+          }
+        }
+      }
+    },
+    "valid_bbox": {
+      "$comment": "WGS84 ranges exclude sentinel 'effectively infinite' values (e.g. ±1.79e308). NaN and Infinity cannot be expressed in JSON, so they fail at the parser. south <= north is checked by Portolan tooling.",
+      "type": "array",
+      "oneOf": [
+        {
+          "minItems": 4,
+          "maxItems": 4,
+          "items": [
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            }
+          ]
+        },
+        {
+          "minItems": 6,
+          "maxItems": 6,
+          "items": [
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/elevation"
+            },
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/elevation"
+            }
+          ]
+        }
+      ]
+    },
+    "longitude": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "latitude": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "elevation": {
+      "type": "number",
+      "minimum": -100000,
+      "maximum": 100000
+    }
+  }
+}

--- a/stac/package.json
+++ b/stac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portolan-stac-profile",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Portolan STAC profile — JSON Schema for the schema-checkable requirements plus a profile over reused STAC extensions",
   "scripts": {
     "pretest": "node scripts/fetch-extension-schemas.js",


### PR DESCRIPTION
Companion-PR: portolan-sdi/rashid#152

## What changed

The Portolan specification releases 0.1.2. A catalog declares it by
carrying `https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`
in `stac_extensions`.

`stac/json-schema/v0.1.2/` is a copy of v0.1.1 with a new `$id`. None of
the three requirements this release adds are schema-checkable: the
fan-out rule counts children across the tree, and the multilingual rules
govern `alternate` links between separate roots. The directory exists
because the schema URI is the signal of specification version, and
`publish-schema.yaml` refuses to build a release without one. The v0.1.0
and v0.1.1 directories are untouched, so a catalog authored against
either keeps validating against it.

Everything else is the version move: the examples, the generator, the
profile README, `stac/package.json`, `core.md`, `requirements.yaml`, and
both changelogs.

The generator's rashid floor rises from 0.1.6 to 0.1.7, the release that
bundles the v0.1.2 schema. rashid#152 has merged and 0.1.7 is published,
so the floor resolves.

Nothing here asks more of a catalog that already conforms, so the bump is
a patch under the pre-1.0 policy.

The release integrates work already verified in its own pull requests:

- #172 multilingual catalogs (`PORTO-CORE-079`, `PORTO-CORE-080`)
- #171, #168 subcatalog fan-out guidance (`PORTO-CORE-078`)
- #165 float predictor qualification
- #158, #156 ops sync and schema immutability

## Why

rashid 0.1.7 ships the v0.1.2 schema and needs the published URI to
resolve. The three requirements added since 0.1.1 are only declarable by
a catalog once a version carries them.

## Verification

The requirements census against the manifest:

```console
$ uv run specs/tools/check_requirements.py
OK: 128 requirements anchored; all keyword occurrences covered.
```

The generator suite, which validates the reference catalog at
`examples/catalog/portolan-reference` through rashid and checks the COG,
the GeoParquet, the styles, and the thumbnails:

```console
$ uv run examples/tools/tests/run_all.py
PASS    0.7s  check_cog.py
PASS    6.7s  check_compliance.py
PASS    6.6s  check_docs.py
PASS    0.6s  check_fetch.py
PASS    0.5s  check_styles.py
PASS    0.5s  check_thumb_geoms.py
PASS    0.5s  check_thumbnails.py
PASS    0.2s  check_tiles.py
PASS    1.2s  check_validate.py
PASS    0.8s  check_web_output.py

10/10 generator checks passed
```

The profile suite, including `check-version.js`, which is what proves no
stale Portolan schema URI survives anywhere it scans:

```console
$ cd stac && npm test
✓ all Portolan schema URI references match https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json
Files: 4
Valid: 4
Invalid: 0
✓ catalog.json
✓ vector-collection.json
✓ vector-partitioned-collection.json
✓ vector-partitioned-item.json
```

Before the pin rose, `publish-catalogs` failed on exactly the gap the
pin closes, which is the clearest evidence that the floor is load-bearing
rather than cosmetic:

```
warning PTL-SCH-000  .: schema validation could not run: no bundled schema
for https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json;
this build carries v0.1.0, v0.1.1
0 error(s), 1 warning(s), 8 info(s) across 14 files.
##[error]examples/catalog/portolan-reference no longer validates.
```

With `rashid[data]>=0.1.7`:

```console
$ python3 examples/tools/check_catalogs.py
rashid requirement: rashid[data]>=0.1.7,<0.2.0
  0 error(s), 0 warning(s), 8 info(s) across 14 files.
1/1 catalogs passed
```

The contacts extension pin at `stac/README.md:57` reads
`contacts/v0.1.1/schema.json` and is deliberately untouched. The version
move matched `portolan/v0.1.1`, not a bare `v0.1.1`.

- [ ] This change does not alter behavior (docs, chore, or CI only).
- [x] This pull request integrates changes already verified in their own pull
      requests (a release or integration branch). List them under "What
      changed".

## Implementation notes

**Merge this with a merge commit, not a squash.** rashid's `SPEC_REF`
pins `ae713a6`, a commit on this branch. A squash would orphan it and the
nightly spec-sync canary would start reporting drift against a commit
that no longer exists. This is how 0.1.1 merged, as `c13e476`.

After merge, publish the release so `publish-schema.yaml` deploys the new
URI:

```bash
gh release create v0.1.2 \
  --title "Portolan specification 0.1.2" \
  --notes "See CHANGELOG.md for details."
```

## Related issues

None beyond the integrated pull requests listed above.
