### PR TITLE
feat(stac): validate declared extension schemas, and pin the Language extension

### DIFF
--- a/specs/best-practices/multilingual-catalogs.md
+++ b/specs/best-practices/multilingual-catalogs.md
@@ -6,7 +6,9 @@ links connect equivalent catalogs and collections across the trees.
 
 Use the STAC [Language](https://github.com/stac-extensions/language) extension on each
 translated catalog and collection. It identifies the document's language and gives
-clients the information they need for a language selector.
+clients the information they need for a language selector. The [profile's extension
+registry](../../stac/README.md#stac-extensions) pins the version to declare; the
+examples below use it.
 
 The examples below use Romanian as the source language, with Russian and English
 translations. Core defines the required structure in [Alternate-Language

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -97,7 +97,10 @@ Declaring the Portolan extension is a claim of conformance, not proof of it. An
 object conforms to this specification only by passing the Portolan validator.
 Validation runs in separable passes:
 
-- **Structural validation** against the STAC 1.1.0 schemas.
+- **Structural validation** against the STAC 1.1.0 schemas, and against the
+  schemas of the STAC extensions each object declares. An object that declares
+  an extension makes a claim about its own shape; this pass checks the claim.
+  The extension registry governs which version's schema applies.
 - **Portolan metadata validation**, covering every requirement checkable from
   metadata alone.
 - **Portolan data validation**, covering requirements that require reading asset

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -291,7 +291,8 @@ Provenance (`via`) links are covered under [Source Provenance](#source-provenanc
 
 A catalog MAY publish one STAC object tree for each language. The root catalog links
 to each translated root with an `alternate` link, as defined by the STAC
-[Language](https://github.com/stac-extensions/language) extension.
+[Language](https://github.com/stac-extensions/language) extension. The profile's
+extension registry pins the version of that extension to declare.
 
 A translated tree represents the same catalog in another language. It is not part of
 the containment tree. A catalog MUST NOT link to a translated root with `child` or

--- a/stac/README.md
+++ b/stac/README.md
@@ -47,6 +47,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |
 | [Raster][] | `https://stac-extensions.github.io/raster/v2.0.0/schema.json`               | **MUST**    | When band-level detail is provided |
+| [Language][] | `https://stac-extensions.github.io/language/v1.0.0/schema.json`             | **MUST**    | When alternate-language trees are published: the `alternate` links, `language`, and `languages` (spec: Alternate-Language Trees) |
 | [Vector][] | `https://stac-extensions.github.io/vector/v0.1.0/schema.json`               | **MUST**    | When layer-level detail is provided |
 | [Partition][] | `https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json`              | **MUST**    | Partitioned collections: `partition:scheme`, `partition:keys`, `partition:glob` (spec: Partitioned Collections) |
 | [Table][] | `https://stac-extensions.github.io/table/v1.2.0/schema.json`                | SHOULD      | Vector and tabular collections: document columns with `table:columns` |
@@ -77,6 +78,7 @@ As the profile grows, per-format requirement sets (vector, raster, tabular) may 
 [Contacts]: https://github.com/stac-extensions/contacts
 [Attribution]: https://github.com/stac-extensions/attribution
 [Themes]: https://github.com/stac-extensions/themes
+[Language]: https://github.com/stac-extensions/language
 
 ## Profile
 


### PR DESCRIPTION
## What changed

Two changes to the profile, both about extensions the spec already relies on.

First, the validation passes list in `specs/portolan/core.md` widens.
Structural validation now covers the STAC 1.1.0 schemas and the schemas of the
STAC extensions each object declares. The extension registry decides which
version's schema applies.

Second, the registry itself gains a row. The STAC Language extension is now
pinned at v1.0.0, as a conditional MUST. A catalog declares it when it
publishes alternate-language trees.

`core.md` and the multilingual best-practices page now point at the registry
for the version. The pin gets one home. The best-practices examples already
used v1.0.0 and are unchanged.

Neither sentence carries an RFC 2119 keyword in a manifest-scanned file, so
`specs/portolan/requirements.yaml` is unchanged.

## Why

The passes list said structural validation runs against the STAC 1.1.0
schemas. It said nothing about the other extensions an object declares.

A validator could therefore check that an extension carried the pinned
version, and never open that version's schema. `rashid` did exactly that. An
object could declare the Projection extension, set `proj:code` to the integer
`4326`, and conform.

The spec already says a claim is not proof. "Declaring the Portolan extension
is a claim of conformance, not proof of it." The same logic covers every other
extension an object declares. This change says so.

The Language row closes a matching gap. Core defines Alternate-Language Trees
and tells a publisher to join translated roots with the Language extension.
The registry never listed it. A publisher had to guess the version, and a
validator had no schema to check the tree against.

The registry clause on the passes list matters too. It stops a validator from
judging older content by a newer schema. A catalog that declares Raster v1.1.0
must not be measured against v2.0.0, which defines fields the older version
never had.

This is the spec half of a pair. The validator half is
portolan-sdi/rashid#159, which resolves portolan-sdi/rashid#155.

Companion-PR: portolan-sdi/rashid#159

## Verification

- [x] This change does not alter behavior.

The change is prose plus one registry row. It adds no requirement ID and no
schema change.

The manifest gate agrees:

```console
$ uv run specs/tools/check_requirements.py
OK: 128 requirements anchored; all keyword occurrences covered.
```

The examples suite stays green:

```console
$ uv run examples/tools/tests/run_all.py
10/10 generator checks passed
```

The paired rashid pull request proves the behavior. It picks up the Language
row through the normal spec sync. No Language-specific code is added there. It
then rejects a catalog that declares the extension without a `language` field.
That run reads the reference catalog in this repo. It also reads the
registered catalog `https://data.source.coop/nlebovits/moldova-geodata/`.