### PR TITLE
chore(release): specification v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 under the pre-1.0 bump policy described in the [README](README.md#versioning).
 
-## Unreleased
+## 0.2.0 - 2026-08-28
+
+A catalog declares this version by carrying
+`https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json` in `stac_extensions`.
+The `v0.1.0`, `v0.1.1`, and `v0.1.2` schemas stay published unchanged, so a
+catalog authored against any of them keeps validating against it.
+
+This release is breaking, and it bumps MINOR under the pre-1.0 policy. Every
+catalog that conformed to `v0.1.2` still conforms. A validator built against
+`v0.1.2` does not. It reports an error for a `self` link and for an absolute
+structural `href`. `v0.2.0` allows both. rashid 0.1.8 is the first
+release that carries the new rules.
 
 ### Changed
 
@@ -23,6 +34,14 @@ under the pre-1.0 bump policy described in the [README](README.md#versioning).
   for the trade-offs.
 - **Requirements manifest**: 128 requirements, now 88 MUST, 23 SHOULD, and
   17 MAY.
+- **The versioning policy defines `misvalidate`** ([`README.md`](README.md#versioning)):
+  the breaking rule tested both catalogs and tools, and the non-breaking rule
+  tested only catalogs, so the two rules were not opposites and a relaxation
+  matched both (#182). A tool now misvalidates when it reports an error against
+  a conforming catalog, or reports no error against a non-conforming one. Under
+  that definition a relaxation is breaking, because a released tool rejects what
+  the new version allows. A table lists the verdict for each kind of change.
+  After `1.0.0`, a relaxation bumps MINOR rather than MAJOR.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -136,19 +136,35 @@ defined in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
 The specification is versioned with [SemVer](https://semver.org/), starting
 pre-1.0. A catalog declares the version it was authored against through the
 **Portolan STAC profile schema URI** in its `stac_extensions` array, e.g.
-`https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`. That schema URI
+`https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json`. That schema URI
 is the single signal of specification version, and there is no separate version
 file (see
 [Conformance and Versioning](specs/portolan/core.md#conformance-and-versioning)).
 
 **Bump policy while pre-1.0:** any breaking change bumps the MINOR version (e.g.
 `0.1.0` → `0.2.0`), and non-breaking changes bump PATCH. Once the spec reaches
-`1.0.0`, normal SemVer applies. A change is **breaking** when a catalog that
-conformed to the previous version may no longer conform, or when a tool built
-against the previous version may misvalidate. Raising a rule's severity, adding
-a new required field, and removing or renaming a field or accepted value are all
-breaking. A change is **non-breaking** when previously-conforming catalogs still
-conform, as with adding a warning, relaxing a constraint, or clarifying wording.
+`1.0.0`, normal SemVer applies, with the carve-out below.
+
+A change is **breaking** when a catalog that conformed to the previous version
+may no longer conform, or when a tool built against the previous version may
+misvalidate. A tool **misvalidates** when it reports an error against a
+conforming catalog, or reports no error against a non-conforming one. A change
+is **non-breaking** when neither test finds anything. Previously-conforming
+catalogs still conform, and a tool built against the previous version returns
+the verdicts it returned before.
+
+| Change | What an old tool does | Verdict |
+| --- | --- | --- |
+| Raise a rule's severity | misses an error that is now due | breaking |
+| Add a required field | misses an error that is now due | breaking |
+| Remove or rename a field or accepted value | misses an error that is now due | breaking |
+| Relax a constraint | reports an error against a catalog that now conforms | breaking |
+| Add a warning | emits no warning, and no error was due | non-breaking |
+| Clarify wording | returns the same verdicts | non-breaking |
+
+**After `1.0.0`, a relaxation bumps MINOR, not MAJOR.** Normal SemVer maps a
+break to MAJOR. A relaxation breaks tools alone, and every catalog that
+conformed still conforms, so MINOR carries the signal at the right cost.
 
 **A released schema is immutable.** Once a version is tagged, the JSON Schema
 served at its URI never changes, so a catalog validates the same way in a year

--- a/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/boston-open-space/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/boundaries/catalog.json
+++ b/examples/catalog/portolan-reference/boundaries/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "boundaries",
   "title": "Administrative Boundaries",

--- a/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/netherlands-provinces/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
+++ b/examples/catalog/portolan-reference/boundaries/us-counties/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/catalog.json
+++ b/examples/catalog/portolan-reference/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "portolan-reference",
   "title": "Portolan Reference Catalog",

--- a/examples/catalog/portolan-reference/mirror/catalog.json
+++ b/examples/catalog/portolan-reference/mirror/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "mirror",
   "title": "Mirrored Collections",

--- a/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
+++ b/examples/catalog/portolan-reference/mirror/san-francisco-addresses/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",

--- a/examples/catalog/portolan-reference/raster/catalog.json
+++ b/examples/catalog/portolan-reference/raster/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "raster",
   "title": "Raster Data",

--- a/examples/catalog/portolan-reference/raster/sample-cog/collection.json
+++ b/examples/catalog/portolan-reference/raster/sample-cog/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
   ],

--- a/examples/catalog/portolan-reference/reference/catalog.json
+++ b/examples/catalog/portolan-reference/reference/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "reference",
   "title": "Reference Basemaps",

--- a/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-countries/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"

--- a/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
+++ b/examples/catalog/portolan-reference/reference/natural-earth-populated-places/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json"

--- a/examples/catalog/portolan-reference/tabular/catalog.json
+++ b/examples/catalog/portolan-reference/tabular/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "tabular",
   "title": "Tabular Data",

--- a/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
+++ b/examples/catalog/portolan-reference/tabular/eurostat-electricity-prices/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "https://stac-extensions.github.io/attribution/v0.1.0/schema.json"

--- a/examples/manifests/portolan-reference.yaml
+++ b/examples/manifests/portolan-reference.yaml
@@ -1,4 +1,4 @@
-# Portolan reference catalog manifest, authored against Portolan spec v0.1.2.
+# Portolan reference catalog manifest, authored against Portolan spec v0.2.0.
 #
 # One manifest file describes one whole catalog. build.py reads every *.yaml in
 # this directory and builds each into its own tree under the output directory,
@@ -48,7 +48,7 @@ description: >-
   specification with real, openly licensed data pulled from its original
   upstream sources, vector polygons and points, raster, tabular, mirror
   provenance, nested catalogs and flat collections.
-schema_uri: https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json
+schema_uri: https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json
 
 host:
   name: Portolan SDI

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -127,7 +127,7 @@ misbehaves on this geometry.
 Top level of each file in `manifests/`.
 
 - `id`, `title`, `description`. Root Catalog identity.
-- `schema_uri`. Must equal the pinned v0.1.2 URI. `load_manifest` asserts this.
+- `schema_uri`. Must equal the pinned v0.2.0 URI. `load_manifest` asserts this.
 - `host`. `{name, url, email}`. Appended as the `host`-role provider on mirror Collections.
 - `catalogs`. Map from the first id segment to `{title, description, readme?, agents?}` for each nested Catalog. The optional `readme` and `agents` are markdown templates like the per-collection `docs` below.
 - `docs?`. `{readme?, agents?}` markdown templates for the root Catalog sidecars. Catalog-level templates may use `{{collections}}` (the table of contents the best-practices page asks for), `{{sources}}` (licenses, provenance, upstream list), and `{{agents_index}}` (per-child pointers to each AGENTS.md). Without a template a default skeleton with those blocks is emitted.
@@ -252,7 +252,7 @@ finding. Warnings and infos print without failing.
 Four passes run. The metadata pass checks the Portolan rules. The structural
 pass checks STAC 1.1.0 core validity and degrades to a warning when its
 schemas are unreachable. The schema pass validates every object against the
-working-copy schema at `../../stac/json-schema/v0.1.2/schema.json`, injected
+working-copy schema at `../../stac/json-schema/v0.2.0/schema.json`, injected
 so the build tests this repo's schema rather than the published one. The data
 pass reads the built assets and checks checksum, size, format, COG internal
 overviews, COG band statistics including valid percent, and GeoParquet ordering,

--- a/examples/tools/CLAUDE.md
+++ b/examples/tools/CLAUDE.md
@@ -264,7 +264,7 @@ proven by running rashid directly, without the adapter. Do that before publishin
 rebuild.
 
 ```bash
-uv run --with "rashid[data]>=0.1.6,<0.2.0" \
+uv run --with "rashid[data]>=0.1.8,<0.2.0" \
   rashid check --schema examples/catalog/portolan-reference
 ```
 
@@ -306,7 +306,7 @@ party servers. The spec scopes those MUSTs to the catalog's own assets as of
 PORTO-CORE-073, so a validator does not probe an upstream host.
 
 rashid comes from PyPI, pinned to a compatible range in `build.py`'s PEP 723
-header, currently `rashid[data]>=0.1.6,<0.2.0`. Bumping the Portolan schema is a
+header, currently `rashid[data]>=0.1.8,<0.2.0`. Bumping the Portolan schema is a
 coordinated change across this repo and rashid, update the local schema,
 regenerate the reference catalog, re-vendor fixtures into rashid, then bump the
 rashid range here.

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -67,7 +67,7 @@ def main() -> int:
     ap.add_argument("--cache", default=root / "examples/.cache", type=Path)
     ap.add_argument("--catalog", default=None, help="build only the manifest with this file stem")
     ap.add_argument("--only", default=None, help="build only this collection id")
-    ap.add_argument("--schema", default=root / "stac/json-schema/v0.1.2/schema.json", type=Path)
+    ap.add_argument("--schema", default=root / "stac/json-schema/v0.2.0/schema.json", type=Path)
     ap.add_argument("--no-validate", action="store_true")
     ap.add_argument("--styles-only", action="store_true",
                     help="re-author MapLibre styles and their assets against "

--- a/examples/tools/build.py
+++ b/examples/tools/build.py
@@ -7,7 +7,7 @@
 #   "pyarrow>=25",
 #   "geoparquet-io @ git+https://github.com/yharby/geoparquet-io.git@f27e53108910f19bd74a9ff4be5c7d97b104753c",
 #   "rasterio>=1.5",
-#   "rashid[data]>=0.1.7,<0.2.0",
+#   "rashid[data]>=0.1.8,<0.2.0",
 #   "rio-cogeo>=5.3",
 #   "Pillow>=11",
 # ]

--- a/examples/tools/config.py
+++ b/examples/tools/config.py
@@ -5,7 +5,7 @@ logic, no catalog-specific values.
 """
 from __future__ import annotations
 
-SCHEMA_URI = "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+SCHEMA_URI = "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
 FILE_EXT = "https://stac-extensions.github.io/file/v2.1.0/schema.json"
 WEBMAP_EXT = "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json"
 RASTER_EXT = "https://stac-extensions.github.io/raster/v2.0.0/schema.json"

--- a/examples/tools/stacio.py
+++ b/examples/tools/stacio.py
@@ -32,7 +32,7 @@ from thumbnails import (
 # --------------------------------------------------------------------- manifest
 def load_manifest(path: Path) -> dict:
     m = yaml.safe_load(path.read_text())
-    assert m["schema_uri"] == SCHEMA_URI, "manifest schema_uri must be the pinned v0.1.2 URI"
+    assert m["schema_uri"] == SCHEMA_URI, "manifest schema_uri must be the pinned v0.2.0 URI"
     logo = m.get("logo")
     if logo:
         # The manifest directory is the only place that knows where a relative

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "jsonschema>=4.26.0",
-#   "rashid[data]>=0.1.7,<0.2.0",
+#   "rashid[data]>=0.1.8,<0.2.0",
 # ]
 # ///
 """Standalone checks for the rashid validation adapter.

--- a/examples/tools/tests/check_validate.py
+++ b/examples/tools/tests/check_validate.py
@@ -19,7 +19,7 @@ from validate import _local_schema_validator  # noqa: E402
 from validate import _LocalOnlyReader  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
-SCHEMA = REPO / "stac/json-schema/v0.1.2/schema.json"
+SCHEMA = REPO / "stac/json-schema/v0.2.0/schema.json"
 REFERENCE = REPO / "examples/catalog/portolan-reference"
 
 import shutil  # noqa: E402
@@ -33,22 +33,37 @@ def check_reference_catalog_passes() -> None:
     validate(REFERENCE, SCHEMA)
 
 
-def check_self_link_fails() -> None:
+def check_self_link_passes() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         dst = Path(tmp) / "portolan-reference"
         shutil.copytree(REFERENCE, dst)
-        # Inject a self link into one Collection. The v0.1.2 schema rejects
-        # it. The specification no longer does, so the next schema version
-        # drops this check and this test flips with it.
+        # Inject a self link into one Collection. The schemas through v0.1.2
+        # reject it. PORTO-CORE-034 is retired, so v0.2.0 accepts it.
         col = dst / "boundaries/us-counties/collection.json"
         obj = json.loads(col.read_text())
-        obj["links"].append({"rel": "self", "href": "collection.json"})
+        obj["links"].append(
+            {
+                "rel": "self",
+                "href": "https://example.org/us-counties/collection.json",
+                "type": "application/json",
+            }
+        )
         col.write_text(json.dumps(obj))
         try:
             validate(dst, SCHEMA)
-        except SystemExit:
-            return
-        raise AssertionError("a self link should fail validation")
+        except SystemExit as exc:
+            raise AssertionError("a self link should pass validation") from exc
+
+
+def check_absolute_structural_href_passes() -> None:
+    # PORTO-CORE-034 also required a relative structural href. v0.2.0 drops
+    # that rule, so an absolute child href passes the schema.
+    obj = json.loads((REFERENCE / "boundaries/catalog.json").read_text())
+    for link in obj["links"]:
+        if link["rel"] == "child":
+            link["href"] = "https://example.org/boundaries/" + link["href"].removeprefix("./")
+    validate_object = _local_schema_validator(SCHEMA)
+    assert validate_object(obj) == [], validate_object(obj)
 
 
 def check_schema_validator_passes_conformant_root() -> None:
@@ -106,7 +121,8 @@ CHECKS = [
     check_local_only_reader_drops_remote,
     check_local_only_reader_keeps_local,
     check_reference_catalog_passes,
-    check_self_link_fails,
+    check_self_link_passes,
+    check_absolute_structural_href_passes,
 ]
 
 

--- a/specs/best-practices/multilingual-catalogs.md
+++ b/specs/best-practices/multilingual-catalogs.md
@@ -53,7 +53,7 @@ language:
 ```json
 {
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/language/v1.0.0/schema.json"
   ],
   "language": { "code": "ro", "name": "Română", "alternate": "Romanian" },

--- a/specs/portolan/core.md
+++ b/specs/portolan/core.md
@@ -78,7 +78,7 @@ versioned schema URI carries the specification version the object was authored
 against.
 
 Every catalog and collection MUST declare the versioned Portolan schema URI (e.g.
-`https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`) in its `stac_extensions`
+`https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json`) in its `stac_extensions`
 array. The schema URI is the single signal of specification version; no separate
 version property is defined. Declaration happens at the catalog and collection
 level only, since assets cannot carry `stac_extensions`, and items inherit

--- a/specs/portolan/requirements.yaml
+++ b/specs/portolan/requirements.yaml
@@ -67,7 +67,7 @@ requirements:
     file: specs/portolan/core.md
     quote: >-
       Every catalog and collection MUST declare the versioned Portolan schema
-      URI (e.g. `https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json`)
+      URI (e.g. `https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json`)
       in its `stac_extensions` array.
 
   - id: PORTO-CORE-007

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -5,17 +5,33 @@ All notable changes to the Portolan STAC profile will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.2.0 - 2026-08-28
+
+The schema is published at
+<https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json>. The `v0.1.0`,
+`v0.1.1`, and `v0.1.2` schemas stay published unchanged.
+
+This is the first schema change since `v0.1.0`. `v0.1.1` and `v0.1.2` each
+carried a new `$id` and nothing else.
 
 ### Changed
 
-- The `links_conformant` block must stop rejecting a `self` link and stop
-  requiring a relative `href` on structural links, following the spec's removal
-  of both rules (#159). A released schema is immutable, so the edits belong to
-  the next version directory under `stac/json-schema/` and land with the
-  release that cuts it. The new recommendation of a root `self` link
-  (`PORTO-CORE-081`) is conditional on how the publisher serves the catalog,
-  so the schema does not check it.
+- The `links_conformant` block accepts a `self` link. The branch that mapped
+  `rel: "self"` to `false` is gone, following the spec's retirement of
+  `PORTO-CORE-034` (#159).
+- The `links_conformant` block accepts an absolute structural `href`. The
+  `"not": {"pattern": "://"}` constraint is gone from the
+  `root`/`parent`/`child`/`collection` branch and from the `item` branch.
+  `PORTO-CORE-034` carried that rule too.
+
+The rest of the block is unchanged. Structural links still carry the required
+media type, `child` and `item` links still carry a title, and an `icon` link
+still declares a renderable media type.
+
+The new recommendation of a root `self` link (`PORTO-CORE-081`) is conditional
+on how the publisher serves the catalog, so the schema does not check it. A
+validator resolves an absolute structural link through the base that the root
+`self` link names, which the schema also cannot check.
 
 ## 0.1.2 - 2026-08-20
 

--- a/stac/README.md
+++ b/stac/README.md
@@ -3,8 +3,8 @@
 > **Work in Progress** — This profile is under active development. Requirement levels and the schema URL may change before the first stable release.
 
 - **Title:** Portolan
-- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json>
-- **Field Name Prefix:** portolan (reserved; no fields defined in v0.1)
+- **Identifier:** <https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json>
+- **Field Name Prefix:** portolan (reserved; no fields defined yet)
 - **Scope:** Catalog, Collection — Items inherit conformance from their collection
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions#extension-maturity):** Proposal
 
@@ -25,7 +25,7 @@ The `portolan:` prefix stays reserved for future use.
 The schema encodes the specification's structural requirements that STAC core leaves optional:
 
 - Every Catalog and Collection has a non-empty `title` and `description`; every `child` and `item` link carries a `title` (spec: Human-Readable Titles).
-- Structural links (`root`, `parent`, `child`, `item`, `collection`) carry `type: "application/json"` (`application/geo+json` for links to items) (spec: Links). The schemas through v0.1.2 also reject a `self` link and require relative structural hrefs; the specification has dropped both rules, and the relaxation lands with the next schema version.
+- Structural links (`root`, `parent`, `child`, `item`, `collection`) carry `type: "application/json"` (`application/geo+json` for links to items) (spec: Links). The schema takes no position on relative versus absolute hrefs, and it accepts a `self` link. The schemas through v0.1.2 reject a `self` link and require a relative structural href. v0.2.0 drops both rules, following the specification.
 - Every asset has `href`, a media `type`, and at least one `role` (spec: Assets). `file:size` and `file:checksum` are SHOULD-level, so the schema checks their shape where present without requiring them; the checksum's multihash encoding, and whether either value matches the bytes, are verified by tooling rather than schema.
 - Absolute asset hrefs use `https` — `s3://` and other bucket schemes are rejected; relative hrefs are allowed (spec: Assets).
 - Every Collection declares `providers` with at least one `producer` and a `host` reachable through `url` or `email`; that the host is exactly one and listed last is checked by tooling (spec: Providers).
@@ -42,7 +42,7 @@ Requirement keywords per BCP 14; a conditional MUST applies only when its condit
 
 | Name                | Schema URI for `stac_extensions`                                            | Requirement | When / Usage |
 | ------------------- | --------------------------------------------------------------------------- | ----------- | ------------ |
-| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
+| [Portolan][] | `https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json` | **MUST**    | Always — every catalog and collection; items inherit conformance |
 | [File Info][] | `https://stac-extensions.github.io/file/v2.1.0/schema.json`                 | **MUST**    | When an asset carries `file:size` or `file:checksum`, both of which are SHOULD-level per asset (checksum as multihash) |
 | [Web Map Links][] | `https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json`        | **MUST**    | When PMTiles are provided: the `rel: "pmtiles"` link |
 | [Version][] | `https://stac-extensions.github.io/version/v1.2.0/schema.json`              | **MUST**    | When dataset versioning is used (never `portolan:` fields) |

--- a/stac/examples/catalog.json
+++ b/stac/examples/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json"
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
   ],
   "id": "andalusia-open-geodata",
   "title": "Andalusia Open Geodata",

--- a/stac/examples/vector-collection.json
+++ b/stac/examples/vector-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"

--- a/stac/examples/vector-partitioned-collection.json
+++ b/stac/examples/vector-partitioned-collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://schemas.portolan-sdi.org/portolan/v0.1.2/schema.json",
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json",
     "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.3.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",

--- a/stac/json-schema/v0.2.0/schema.json
+++ b/stac/json-schema/v0.2.0/schema.json
@@ -1,0 +1,517 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json#",
+  "title": "Portolan STAC Profile",
+  "description": "The schema-checkable structural requirements of the Portolan specification. The versioned schema URI declared in stac_extensions is the single signal of specification version; no portolan-prefixed fields are defined. Requirements that need link crawling, reading asset bytes, or probing the hosting server are defined in the Portolan specification and validated by Portolan tooling.",
+  "oneOf": [
+    {
+      "$comment": "STAC Catalogs.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Catalog"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/human_readable"
+        },
+        {
+          "$ref": "#/definitions/links_conformant"
+        },
+        {
+          "$ref": "#/definitions/agents_link"
+        },
+        {
+          "$ref": "#/definitions/readme_link"
+        }
+      ]
+    },
+    {
+      "$comment": "STAC Collections.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/human_readable"
+        },
+        {
+          "$ref": "#/definitions/links_conformant"
+        },
+        {
+          "$ref": "#/definitions/agents_link"
+        },
+        {
+          "$ref": "#/definitions/readme_link"
+        },
+        {
+          "$ref": "#/definitions/assets_typed_and_roled"
+        },
+        {
+          "$ref": "#/definitions/license_not_proprietary"
+        },
+        {
+          "$ref": "#/definitions/providers_conformant"
+        },
+        {
+          "$ref": "#/definitions/partition_conformant"
+        },
+        {
+          "properties": {
+            "extent": {
+              "type": "object",
+              "properties": {
+                "spatial": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/valid_bbox"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "$comment": "STAC Items. Items do not declare the Portolan schema URI — declaration happens at the catalog and collection level only, and items inherit conformance from their collection. This branch is applied to items by the Portolan validator, not via stac_extensions.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            }
+          }
+        },
+        {
+          "properties": {
+            "bbox": {
+              "$ref": "#/definitions/valid_bbox"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/assets_typed_and_roled"
+        },
+        {
+          "$ref": "#/definitions/links_conformant"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
+          }
+        }
+      }
+    },
+    "human_readable": {
+      "$comment": "Every Catalog and Collection carries a non-empty title and description. Whether a title is a raw slug is checked by Portolan tooling, not by schema.",
+      "type": "object",
+      "required": ["title", "description"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "links_conformant": {
+      "$comment": "Structural links (root, parent, child, item, collection) carry the required media type. Portolan takes no position on relative versus absolute hrefs, and an object may carry a self link (spec: Links). Every child and item link carries a human-readable title so browsers can render names without fetching every child. A logo link (rel 'icon') declares a media type a browser renders in an img element (spec: Catalog Logo); that its href is relative and that it carries a title are SHOULD-level, so Portolan tooling reports them rather than the schema. Whether every link resolves is a crawling check performed by Portolan tooling.",
+      "type": "object",
+      "properties": {
+        "links": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "enum": ["root", "parent", "child", "collection"]
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "const": "application/json"
+                    },
+                    "href": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "item"
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "const": "application/geo+json"
+                    },
+                    "href": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "enum": ["child", "item"]
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["title"],
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["rel"],
+                  "properties": {
+                    "rel": {
+                      "const": "icon"
+                    }
+                  }
+                },
+                "then": {
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "image/apng",
+                        "image/avif",
+                        "image/gif",
+                        "image/jpeg",
+                        "image/png",
+                        "image/svg+xml",
+                        "image/webp"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "agents_link": {
+      "$comment": "Every Catalog and Collection links its AGENTS.md with rel 'agents' and type text/markdown. The target's existence is a link-resolution check performed by crawling validators.",
+      "type": "object",
+      "required": ["links"],
+      "properties": {
+        "links": {
+          "type": "array",
+          "contains": {
+            "type": "object",
+            "required": ["rel", "href", "type"],
+            "properties": {
+              "rel": {
+                "const": "agents"
+              },
+              "type": {
+                "const": "text/markdown"
+              }
+            }
+          }
+        }
+      }
+    },
+    "readme_link": {
+      "$comment": "Every Catalog and Collection links its README.md with rel 'describedby' and type text/markdown (spec: README.md). The target's existence is a link-resolution check performed by crawling validators.",
+      "type": "object",
+      "required": ["links"],
+      "properties": {
+        "links": {
+          "type": "array",
+          "contains": {
+            "type": "object",
+            "required": ["rel", "href", "type"],
+            "properties": {
+              "rel": {
+                "const": "describedby"
+              },
+              "type": {
+                "const": "text/markdown"
+              }
+            }
+          }
+        }
+      }
+    },
+    "providers_conformant": {
+      "$comment": "Every collection identifies at least one producer and a host provider reachable through url or email (spec: Providers). That there is exactly one host, listed last, is checked by Portolan tooling, as is deriving official-vs-mirror from producer and host.",
+      "type": "object",
+      "required": ["providers"],
+      "properties": {
+        "providers": {
+          "type": "array",
+          "minItems": 1,
+          "allOf": [
+            {
+              "contains": {
+                "type": "object",
+                "required": ["roles"],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "producer"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "contains": {
+                "type": "object",
+                "required": ["roles"],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "host"
+                    }
+                  }
+                },
+                "anyOf": [
+                  {
+                    "required": ["url"]
+                  },
+                  {
+                    "required": ["email"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "assets_typed_and_roled": {
+      "$comment": "STAC leaves media type and roles optional on assets; Portolan requires both so validators and browsers can dispatch on them. file:size and file:checksum are SHOULD-level (spec: Assets), so the schema constrains their shape where present but does not require them; the checksum's multihash encoding and its agreement with the bytes are verified by Portolan tooling, not by schema. Absolute hrefs MUST use https, never s3 or other bucket schemes; relative hrefs are allowed.",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["href", "type", "roles"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "minLength": 1,
+                "anyOf": [
+                  {
+                    "pattern": "^https://"
+                  },
+                  {
+                    "not": {
+                      "pattern": "://"
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "roles": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "file:size": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "file:checksum": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "partition_conformant": {
+      "$comment": "A partitioned collection declares the partition extension and carries its required fields (spec: Partitioned Collections). Any partition:* field without the declared extension, or a declaration missing a required field, fails. Field shapes are validated by the partition extension schema itself, which Portolan validators apply alongside this profile; cross-partition Parquet schema consistency is checked by tooling reading file footers.",
+      "type": "object",
+      "if": {
+        "anyOf": [
+          {
+            "required": ["partition:scheme"]
+          },
+          {
+            "required": ["partition:keys"]
+          },
+          {
+            "required": ["partition:strategy"]
+          },
+          {
+            "required": ["partition:file_count"]
+          },
+          {
+            "required": ["partition:glob"]
+          },
+          {
+            "required": ["stac_extensions"],
+            "properties": {
+              "stac_extensions": {
+                "type": "array",
+                "contains": {
+                  "const": "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "required": ["partition:scheme", "partition:keys", "partition:glob", "stac_extensions"],
+        "properties": {
+          "stac_extensions": {
+            "type": "array",
+            "contains": {
+              "const": "https://schemas.portolan-sdi.org/incubating/partition/v1.0.0/schema.json"
+            }
+          }
+        }
+      }
+    },
+    "license_not_proprietary": {
+      "$comment": "The deprecated STAC 1.1 value 'proprietary' is banned; use an SPDX identifier, or 'other' plus a rel 'license' link. SPDX validity and the conditional license link are checked by Portolan tooling.",
+      "type": "object",
+      "properties": {
+        "license": {
+          "not": {
+            "const": "proprietary"
+          }
+        }
+      }
+    },
+    "valid_bbox": {
+      "$comment": "WGS84 ranges exclude sentinel 'effectively infinite' values (e.g. ±1.79e308). NaN and Infinity cannot be expressed in JSON, so they fail at the parser. south <= north is checked by Portolan tooling.",
+      "type": "array",
+      "oneOf": [
+        {
+          "minItems": 4,
+          "maxItems": 4,
+          "items": [
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            }
+          ]
+        },
+        {
+          "minItems": 6,
+          "maxItems": 6,
+          "items": [
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/elevation"
+            },
+            {
+              "$ref": "#/definitions/longitude"
+            },
+            {
+              "$ref": "#/definitions/latitude"
+            },
+            {
+              "$ref": "#/definitions/elevation"
+            }
+          ]
+        }
+      ]
+    },
+    "longitude": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "latitude": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "elevation": {
+      "type": "number",
+      "minimum": -100000,
+      "maximum": 100000
+    }
+  }
+}

--- a/stac/package.json
+++ b/stac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portolan-stac-profile",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Portolan STAC profile — JSON Schema for the schema-checkable requirements plus a profile over reused STAC extensions",
   "scripts": {
     "pretest": "node scripts/fetch-extension-schemas.js",


### PR DESCRIPTION
Resolves #182. Ships #160, which resolves #159.

Companion-PR: portolan-sdi/rashid#170

## What changed

This pull request cuts specification version 0.2.0.

`stac/json-schema/v0.2.0/schema.json` is new. Its `links_conformant` block
drops the branch that mapped `rel: "self"` to `false`. It also drops one
constraint from two branches. That constraint is `"not": {"pattern": "://"}`.
It sat on the structural-link branch and on the item branch.
`PORTO-CORE-034` carried both rules, and #160 retired it. A structural
comparison against v0.1.2 confirms that every other branch matches. The
v0.1.0, v0.1.1, and v0.1.2 directories keep their tagged bytes.

This is the first schema change since v0.1.0. v0.1.1 and v0.1.2 each carried
a new `$id` and nothing else.

The versioning policy in `README.md` now defines `misvalidate`. A tool
misvalidates when it reports an error against a catalog that conforms. It
also misvalidates when it reports no error against a catalog that does not.
A table gives the verdict for each kind of change. Under that definition a
relaxation breaks tools, so the release bumps MINOR. A further sentence
keeps a relaxation on MINOR after 1.0.0.

Every Portolan schema URI and schema path in the tree moves to v0.2.0. The
file `stac/package.json` moves to 0.2.0. `stac/scripts/check-version.js`
treats that value as the source of truth.

`examples/tools/tests/check_validate.py` replaces `check_self_link_fails`
with `check_self_link_passes`. It also adds
`check_absolute_structural_href_passes`. Both PEP 723 headers under
`examples/tools/` move to `rashid[data]>=0.1.8,<0.2.0`.

Both changelogs gain a 0.2.0 entry. The requirements census already read
128 requirements at 88 MUST, 23 SHOULD, and 17 MAY.

## Why

Issue #182 shows that the bump policy gave two answers for a relaxation. One
rule tested catalogs and tools. The other rule tested only catalogs. A
relaxation matched both rules.

Issue #182 also proves which answer is right. Released rashid 0.1.7 reports
`PTL-LNK-005` against a catalog that #160 permits. That report is a
misvalidation, so the relaxation breaks tools. The release is 0.2.0 rather
than 0.1.3.

A released schema never changes. The relaxation therefore needs a directory
of its own. The file `stac/CHANGELOG.md` recorded that requirement under
`Unreleased`, and this pull request meets it.

## Verification

The requirements manifest and the prose agree.

```
$ uv run specs/tools/check_requirements.py
OK: 128 requirements anchored; all keyword occurrences covered.
```

The STAC profile suite passes. The version gate runs inside it.

```
$ cd stac && npm test
✓ all Portolan schema URI references match https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json
Files: 4
Valid: 4
Invalid: 0
✓ catalog.json
✓ vector-collection.json
✓ vector-partitioned-collection.json
✓ vector-partitioned-item.json
```

The real-data proof reads the reference catalog at
`examples/catalog/portolan-reference/catalog.json`. That catalog now declares
the v0.2.0 schema URI. The validator rashid 0.1.8 reports no error and no
warning.

```
$ uv run --no-project --with "rashid[data]>=0.1.8,<0.2.0"     rashid check examples/catalog/portolan-reference --no-data
0 error(s), 0 warning(s), 8 info(s) across 14 files.
```

The eight info findings are `PTL-PRO-002`. They report a mirror collection
with no `canonical` link, and they predate this pull request.

The generator suite runs the flipped self-link check against the same
catalog.

```
$ uv run examples/tools/tests/run_all.py
PASS    0.8s  check_validate.py
10/10 generator checks passed
```
