### PR TITLE
fix(ci): refresh the rashid index page before each resolve

### DIFF
--- a/.github/workflows/publish-catalogs.yaml
+++ b/.github/workflows/publish-catalogs.yaml
@@ -177,7 +177,12 @@ jobs:
           # collection dropped from the manifest would otherwise survive there
           # and get published as though it were still current.
           rm -rf "examples/catalog/${CATALOG}"
-          uv run examples/tools/build.py --catalog "$CATALOG"
+          # The rashid pin bump and the rashid release land in the same pull
+          # request. A restored uv cache can hold a PyPI index page from
+          # before that version exists, and the resolve then fails. Refresh
+          # the one package. See #155.
+          uv run --refresh-package rashid \
+            examples/tools/build.py --catalog "$CATALOG"
 
       # Nothing unvalidated reaches a public URL. Errors and warnings both fail,
       # the same gate the weekly catalog-upstream run applies.

--- a/examples/tools/check_catalogs.py
+++ b/examples/tools/check_catalogs.py
@@ -95,7 +95,11 @@ def run_rashid(requirement: str, catalog: Path) -> dict:
     """rashid's JSON report for one catalog tree."""
     completed = subprocess.run(
         [
-            "uv", "run", "--with", requirement,
+            # The rashid pin bump and the rashid release land in the same
+            # pull request. A warm uv cache can hold a PyPI index page from
+            # before that version exists. Refresh the one package. A flag on
+            # the outer uv run does not reach this subprocess. See #155.
+            "uv", "run", "--refresh-package", "rashid", "--with", requirement,
             "rashid", "check", "--schema", "--all", "--json", str(catalog),
         ],
         capture_output=True,

--- a/examples/tools/tests/run_all.py
+++ b/examples/tools/tests/run_all.py
@@ -49,7 +49,14 @@ def main() -> int:
     for script in checks:
         print(f"::group::{script.name}", flush=True)
         started = time.monotonic()
-        completed = subprocess.run(["uv", "run", str(script)], check=False)
+        # check_validate.py pins rashid, and that pin bump lands in the same
+        # pull request as the rashid release. A warm uv cache can hold a PyPI
+        # index page from before that version exists. Refresh the one
+        # package. See #155.
+        completed = subprocess.run(
+            ["uv", "run", "--refresh-package", "rashid", str(script)],
+            check=False,
+        )
         elapsed = time.monotonic() - started
         print("::endgroup::", flush=True)
         results.append((script.name, completed.returncode == 0, elapsed))


### PR DESCRIPTION
## What changed

Three call sites now pass `--refresh-package rashid` to uv:

- The build step in `publish-catalogs.yaml`. It runs `build.py`, which pins rashid in its PEP 723 header.
- The nested `uv run --with` in `check_catalogs.py`.
- The nested `uv run` per check in `run_all.py`. `check_validate.py` pins rashid in its own header.

`catalog-upstream.yaml` calls `check_catalogs.py`, so it takes the fix from there.

## Why

This resolves #155. A release pull request bumps the rashid pin. The new version went to PyPI minutes earlier. `setup-uv` restores an older cache through its prefix restore-keys. That cache holds the PyPI index page for rashid. The page predates the new version. uv then reports the requirement as unsatisfiable. The error names a missing package, so it reads as a broken release.

The issue names one call site and one fix. Both are too narrow. The build step resolves rashid before the validate step runs, so the build fails first. A flag on the outer `uv run check_catalogs.py` also does not reach the subprocess that call spawns.

Three runs failed this way on release branches:

| Run | Date | Step | Path |
| --- | --- | --- | --- |
| 32350227854 | 2026-08-20 | Validate the built catalog | nested `uv run --with` |
| 33167203455 | 2026-08-28 | Build the catalog | PEP 723 header |
| 33167203407 | 2026-08-28 | Run the generator checks | nested `uv run` per check |

Each one passed on a plain re-run minutes later, with no change to the tree.

uv offers no global lever for this. There is no `UV_REFRESH_PACKAGE` variable, and `refresh-package` is not a `uv.toml` key.

## Verification

I reproduced the failure against a local PEP 503 index. The index serves `Cache-Control: max-age=600`, the header PyPI sends on simple pages. I warmed the uv cache while only `0.1.5` existed, published `0.1.6`, then resolved again.

```console
$ uv run --no-project --with "stalepkg>=0.1.6" python -c "import stalepkg"
  × No solution found when resolving `--with` dependencies:
  ╰─▶ Because only stalepkg==0.1.5 is available and you require
      stalepkg>=0.1.6, we can conclude that your requirements are
      unsatisfiable.

$ uv run --no-project --refresh-package stalepkg \
    --with "stalepkg>=0.1.6" python -c "import stalepkg; print(stalepkg.__version__)"
Installed 1 package in 2ms
0.1.6
```

The same stale cache fails the PEP 723 script path and the nested subprocess path. The flag on the outer call does not reach the nested one.

```console
$ uv run --no-project --refresh-package stalepkg check_demo.py
  × No solution found when resolving `--with` dependencies:
  ╰─▶ Because only stalepkg==0.1.5 is available and you require
      stalepkg>=0.1.6, we can conclude that your requirements are
      unsatisfiable.
```

The generator checks pass with the patched runner. They read the committed catalogs under `examples/catalog/`.

```console
$ uv run examples/tools/tests/run_all.py
PASS    0.6s  check_cog.py
PASS    7.4s  check_compliance.py
PASS    6.3s  check_docs.py
PASS    0.6s  check_fetch.py
PASS    0.7s  check_styles.py
PASS    0.5s  check_thumb_geoms.py
PASS    0.5s  check_thumbnails.py
PASS    0.3s  check_tiles.py
PASS    0.9s  check_validate.py
PASS    0.8s  check_web_output.py

10/10 generator checks passed
```

The fix refreshes rashid alone. A rashid release that also needs a dependency version published in the same window still fails.
