### PR TITLE
docs(readme): say specification, not standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ understand the data and query it directly. Publishing works the same way whether
 you are a satellite company releasing a planetary archive or a city publishing
 local cadastral data. There are no servers, no databases, and no accounts.
 
-Under the hood, Portolan is an opinionated standard for cloud-native geospatial
-catalogs, plus the tooling around it. A catalog is a directory of open-format
-data on any S3-compatible bucket, described by structured
+Under the hood, Portolan is an opinionated specification for cloud-native
+geospatial catalogs, plus the tooling around it. A catalog is a directory of
+open-format data on any S3-compatible bucket, described by structured
 [STAC](https://stacspec.org/) metadata and built on
 [COG](https://cogeo.org/), [GeoParquet](https://geoparquet.org/),
 [PMTiles](https://github.com/protomaps/pmtiles), [COPC](https://copc.io/), and
 [GeoZarr](https://geozarr.org/). Each part of the tooling raises the value of the
 others:
 
-- **The standard** defines what a great catalog looks like. It lives here.
+- **The specification** defines what a great catalog looks like. It lives here.
 - **[rashid](https://github.com/portolan-sdi/rashid)**, the validator, proves a
-  catalog meets the standard.
+  catalog meets the specification.
 - **[portolan-cli](https://github.com/portolan-sdi/portolan-cli)** makes catalogs
   easy to build.
 - **[The registry](https://github.com/portolan-sdi/portolan-registry)** connects
@@ -27,9 +27,9 @@ If Portolan disappeared tomorrow, every file in a catalog would still work in th
 tools people already use.
 
 Portolan is not a platform. There is nothing to log into and nothing to depend
-on. It is not a paid product either. The standard and the tools are open source
-under Apache-2.0, and your only costs are storage and egress, paid to your cloud
-provider.
+on. It is not a paid product either. The specification and the tools are open
+source under Apache-2.0, and your only costs are storage and egress, paid to
+your cloud provider.
 
 This repository holds the specification. It is pre-1.0 and under active
 development, and contributions are welcome.
@@ -73,7 +73,7 @@ and documentation, so people and agents can use a catalog directly from storage
 with no server in between. The point is a higher quality bar. Working with any
 Portolan catalog should be a good experience.
 
-The standard is prescriptive where that supports interoperability, and it is
+The specification is prescriptive where that supports interoperability, and it is
 meant to evolve as cloud-native tooling matures. Core standards like STAC and
 GeoParquet were built for long-term stability. Portolan sits on top of them and
 moves faster. Each version states what the community currently believes a great
@@ -84,21 +84,21 @@ Every normative statement carries a stable ID in
 [`requirements.yaml`](specs/portolan/requirements.yaml), and CI proves that
 rashid enforces each one.
 
-Where the current landscape has gaps, Portolan will incubate new standards or
-write down practices that until now have been informal. Usually that means
+Where the current landscape has gaps, Portolan will incubate new specifications
+or write down practices that until now have been informal. Usually that means
 contributing to STAC extensions or adding new ones. It can also mean small,
 independent specifications that capture current practice, which live in
 [`specs/incubating/`](specs/incubating/) until they stabilize.
 
 People and agents are treated as equals throughout. The best practices for
-guiding agents are moving fast, so this part of the standard will keep changing,
-but the aim is constant. A Portolan catalog should be low-friction for a human
-analyst and an automated one alike. Building or mirroring a catalog should be
-easy too, including with AI tools, because lowering the effort to publish is how
-more good data gets published.
+guiding agents are moving fast, so this part of the specification will keep
+changing, but the aim is constant. A Portolan catalog should be low-friction for
+a human analyst and an automated one alike. Building or mirroring a catalog
+should be easy too, including with AI tools, because lowering the effort to
+publish is how more good data gets published.
 
-The standard leaves some judgment calls open, such as what one catalog should
-contain and how to organize it.
+The specification leaves some judgment calls open, such as what one catalog
+should contain and how to organize it.
 [`specs/best-practices/philosophy.md`](specs/best-practices/philosophy.md) covers
 those.
 


### PR DESCRIPTION
## What changed

The README now says "specification" wherever it names Portolan itself. Eight
lines said "standard" before. This resolves #191.

Two lines keep the word "standard":

<!-- ste-ok: GERUND the line quotes the README verbatim -->
- `README.md:69`. "Portolan builds on existing standards rather than reinventing them."
- `README.md:77`. "Core standards like STAC and GeoParquet were built for long-term stability."

Both name an outside standard, so the word is correct there. The paragraphs
that changed keep the 80-column wrap of the file.

## Why

The word "standard" tells a reader that a body like OGC or ISO approved the
document. No standards body owns Portolan. Portolan is an open specification
under active development. The README made a claim about its status that is
wrong today.

## Verification

The command below reads the README in this branch. It prints the two lines
that name outside standards and nothing else.

```
$ grep -n standard README.md
69:Portolan builds on existing standards rather than reinventing them. It is STAC
77:meant to evolve as cloud-native tooling matures. Core standards like STAC and
```

The rest of the repository already used the word correctly. This command reads
every tracked file under `specs/`, `stac/`, and `examples/`.

```
$ git grep -niE 'standard' -- specs stac examples | wc -l
37
```

No line among the 37 names Portolan as a standard. They carry these meanings:

- "standard deviation", a statistic.
<!-- ste-ok: GERUND "purchasing power standard" is a quoted Eurostat term -->
- "the standard STAC role names", "the standard join key", and "purchasing power standard", a name in use.
- "the OGC Cloud Optimized GeoTIFF standard", "there is no official standard",
  and "the standard demands them", an outside standard.
- "the standard library" and "standard FOSS tools", a common software term.
- `metadataStandardName` in the ISO 19115 record, and `standard: iso-19115` in
  the manifest, an identifier.
- "aims to standardize the minimum requirements", a verb.
- "written to the standard in the spec's documentation best practices", a
  quality level.

- [x] This change does not alter behavior (docs, chore, or CI only).

`CHANGELOG.md` keeps two shipped entries that use the word. This branch leaves
them. A changelog records what the release said.

`AGENTS.md:10` says "ground truth for the Portolan standard". That file sits
inside the `ops-sync` block. The fix belongs in portolan-ops. A sync run
overwrites any edit made here.
